### PR TITLE
Culture and database fix

### DIFF
--- a/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
+++ b/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
@@ -111,10 +111,12 @@ function Set-TargetResource
     $eseprovider = "ESENT";
     $esedatabase = "$env:PROGRAMFILES\WindowsPowerShell\DscService\Devices.edb";
 
-    #$culture = Get-Culture
-    #$language = $culture.TwoLetterISOLanguageName
+    $culture = Get-Culture
+    $language = $culture.TwoLetterISOLanguageName
     # the two letter iso languagename is not actually implemented in the source path, it's always 'en'
-    $language = 'en'
+    if (-not (Test-Path $pathPullServer\$language\Microsoft.Powershell.DesiredStateConfiguration.Service.Resources.dll)) {
+        $language = 'en'
+    }
 
     $os = [System.Environment]::OSVersion.Version
     $IsBlue = $false;

--- a/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
+++ b/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
@@ -111,8 +111,10 @@ function Set-TargetResource
     $eseprovider = "ESENT";
     $esedatabase = "$env:PROGRAMFILES\WindowsPowerShell\DscService\Devices.edb";
 
-    $culture = Get-Culture
-    $language = $culture.TwoLetterISOLanguageName
+    #$culture = Get-Culture
+    #$language = $culture.TwoLetterISOLanguageName
+    # the two letter iso languagename is not actually implemented in the source path, it's always 'en'
+    $language = 'en'
 
     $os = [System.Environment]::OSVersion.Version
     $IsBlue = $false;
@@ -161,8 +163,11 @@ function Set-TargetResource
     if ($IsBlue)
     {
         Write-Verbose "Set values into the web.config that define the repository for BLUE OS"
-        PSWSIISEndpoint\Set-AppSettingsInWebconfig -path $PhysicalPath -key "dbprovider" -value $eseprovider
-        PSWSIISEndpoint\Set-AppSettingsInWebconfig -path $PhysicalPath -key "dbconnectionstr"-value $esedatabase
+        #PSWSIISEndpoint\Set-AppSettingsInWebconfig -path $PhysicalPath -key "dbprovider" -value $eseprovider
+        #PSWSIISEndpoint\Set-AppSettingsInWebconfig -path $PhysicalPath -key "dbconnectionstr"-value $esedatabase
+        #ESE database is not present in current build
+        PSWSIISEndpoint\Set-AppSettingsInWebconfig -path $PhysicalPath -key "dbprovider" -value $jet4provider
+        PSWSIISEndpoint\Set-AppSettingsInWebconfig -path $PhysicalPath -key "dbconnectionstr" -value $jet4database
         Set-BindingRedirectSettingInWebConfig -path $PhysicalPath
     }
     else


### PR DESCRIPTION
Changed MSFT_xDSCWebService.psm1
* Implemented test-path for Microsoft.Powershell.DesiredStateConfiguration.Service.Resources.dll using culture. If the path does not exist, the language is defaulted to "en". In my experience, there are no other paths then the 'en' path and therefore the resource always fails implementing on a non english system.
* Changed database for blue to jet4 mdb as well as non blue. The edb file is not present anymore on current installatons.