### PR TITLE
Renamed namespace of MsiTools class

### DIFF
--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -509,7 +509,7 @@ Function Get-MsiTools
         return GetPackageProperty(msi, "ProductName");
     }
 '@
-    $script:MsiTools = Add-Type -PassThru -Namespace Microsoft.Windows.DesiredStateConfiguration.PackageResource `
+    $script:MsiTools = Add-Type -PassThru -Namespace Microsoft.Windows.DesiredStateConfiguration.xPackageResource `
         -Name MsiTools -Using System.Text -MemberDefinition $sig
     return $script:MsiTools
 }

--- a/DSCResources/MSFT_xPackageResource/Tests/MSFT_xPackageResource.Tests.ps1
+++ b/DSCResources/MSFT_xPackageResource/Tests/MSFT_xPackageResource.Tests.ps1
@@ -1,0 +1,16 @@
+#requires -Version 4.0
+
+Remove-Module MSFT_xPackageResource -ErrorAction Ignore
+$module = Import-Module $PSScriptRoot\..\MSFT_xPackageResource.psm1 -Force -PassThru -ErrorAction Stop
+
+Describe 'Get-MsiTools' {
+    It 'Uses Add-Type with a name that does not conflict with the original Package resource' {
+        InModuleScope MSFT_xPackageResource {
+            $hash = @{ Namespace = 'Mock not called' }
+            Mock Add-Type { $hash['Namespace'] = $Namespace }
+            $null = Get-MsiTools
+
+            $hash['Namespace'] | Should Be 'Microsoft.Windows.DesiredStateConfiguration.xPackageResource'
+        }
+    }
+}


### PR DESCRIPTION
The original Package resource and xPackage were using the same namespace / class names for MsiTools, but the text isn't identical.  This was causing errors in Add-Type if a configuration happened to be using both Package and xPackage, when the second resource to run would try to add a class with the same name.