### PR TITLE
Issue #16 Fix Get-CacheEntry hash calculation

### DIFF
--- a/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
+++ b/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
@@ -75,7 +75,7 @@ Function Get-CacheEntry
 Function Set-CacheEntry
 {
     param([object] $InputObject)
-    $key = [string]::Join($args).GetHashCode().ToString()
+    $key = [string]::Join(';', $args).GetHashCode().ToString()
     Trace-Message "Using $tmp ($key) to save hash value"
     $path = Join-Path $CacheLocation $key
     Trace-Message "About to cache value $InputObject"

--- a/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
+++ b/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
@@ -56,7 +56,7 @@ $CacheLocation = "$env:systemroot\system32\Configuration\BuiltinProvCache\MSFT_A
 
 Function Get-CacheEntry
 {
-    $key = [string]::Join($args).GetHashCode().ToString()
+    $key = [string]::Join(';', $args).GetHashCode().ToString()
     Trace-Message "Using ($key) to retrieve hash value"
     $path = Join-Path $CacheLocation $key
     if(-not (Test-Path $path))


### PR DESCRIPTION
Update string Join to include the separator, so the GetHashCode is properly calculated based on the actual arguments.