### PR TITLE
Logging inner exception messages in xArchive and xPackage. Closes #31

### DIFF
--- a/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
+++ b/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
@@ -108,7 +108,7 @@ Function Throw-TerminatingError
     )
     
     $exception = new-object "System.InvalidOperationException" $Message,$ErrorRecord.Exception
-    $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception,"MachineStateIncorrect","InvalidOperation",$null
+    $errorRecord = New-Object System.Management.Automation.ErrorRecord ($exception.ToString()),"MachineStateIncorrect","InvalidOperation",$null
     throw $errorRecord
 }
 

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -85,7 +85,7 @@ Function Throw-TerminatingError
     )
 
     $exception = new-object "System.InvalidOperationException" $Message,$ErrorRecord.Exception
-    $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception,"MachineStateIncorrect","InvalidOperation",$null
+    $errorRecord = New-Object System.Management.Automation.ErrorRecord ($exception.ToString()),"MachineStateIncorrect","InvalidOperation",$null
     throw $errorRecord
 }
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Domain members may be specified using domain\name or Universal Principal Name (U
 
 ## Versions
 
+### Unreleased
+
+* Added logging inner exception messages in xArchive and xPackage resources
+
 ### 3.3.0.0
 
 * Add support to xPackage resource for checking different registry hives


### PR DESCRIPTION
Setting exception message to `$exception.ToString()` instead of `$exception` in `Throw-TerminatingError` function. This will make inner exception messages (when available) appear in the console / event log for better user experience (as described in issue #31).

Before:
```
VERBOSE: [X]: LCM:  [ End    Set      ]  [[xPackage]TestPackage]  in 0.2970 seconds.
PowerShell DSC resource MSFT_xPackageResource  failed to execute Set-TargetResource functionality with error message: The process c:\invalid.bat could not be 
started 
    + CategoryInfo          : InvalidOperation: (:) [], CimException
    + FullyQualifiedErrorId : ProviderOperationExecutionFailure
    + PSComputerName        : localhost
 
VERBOSE: [X]: LCM:  [ End    Set      ]
The SendConfigurationApply function did not succeed.
    + CategoryInfo          : NotSpecified: (root/Microsoft/...gurationManager:String) [], CimException
    + FullyQualifiedErrorId : MI RESULT 1
    + PSComputerName        : localhost
 
VERBOSE: Operation 'Invoke CimMethod' complete.
```

After:
```
VERBOSE: [X]: LCM:  [ End    Set      ]  [[xPackage]TestPackage]  in 0.3730 seconds.
PowerShell DSC resource MSFT_xPackageResource  failed to execute Set-TargetResource functionality with error message: System.InvalidOperationException: The 
process c:\invalid.bat could not be started ---> System.Management.Automation.MethodInvocationException: Exception calling "Start" with "0" argument(s): "The 
specified executable is not a valid application for this OS platform." ---> System.ComponentModel.Win32Exception: The specified executable is not a valid 
application for this OS platform.
   at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
   at CallSite.Target(Closure , CallSite , Object )
   --- End of inner exception stack trace ---
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   --- End of inner exception stack trace --- 
    + CategoryInfo          : InvalidOperation: (:) [], CimException
    + FullyQualifiedErrorId : ProviderOperationExecutionFailure
    + PSComputerName        : localhost
 
VERBOSE: [X]: LCM:  [ End    Set      ]
The SendConfigurationApply function did not succeed.
    + CategoryInfo          : NotSpecified: (root/Microsoft/...gurationManager:String) [], CimException
    + FullyQualifiedErrorId : MI RESULT 1
    + PSComputerName        : localhost
 
VERBOSE: Operation 'Invoke CimMethod' complete.
```