### PR TITLE
Issue #14 - xService throws error when service already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Domain members may be specified using domain\name or Universal Principal Name (U
 
 ### Unreleased
 
+* xService idempotence - no longer throws an error when Ensure = 'Present' and service already exists
+
 ### 3.4.0.0
 
 * Added logging inner exception messages in xArchive and xPackage resources


### PR DESCRIPTION
Made two changes:
* Write-Verbose instead of throw when Ensure='Present' and service exists (in Test-TargetResource and Set-TargetResource)
* 'else' removed from Test-TargetResource - we want to ensure service properties are correct both when Ensure = $null or Ensure = 'Present' (and Ensure = 'Absent' always returns earlier).

Nothing else has been changed - diff is showing lot of lines due to decreased indent after 'else' removal.
