### PR TITLE
Added MatchSource parameter to xRemoteFile. Fixes #45

### DIFF
--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.schema.mof
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.schema.mof
@@ -7,6 +7,7 @@ class MSFT_xRemoteFile : OMI_BaseResource
     [Write, Description("User agent for the web request.")] String UserAgent;
     [Write, EmbeddedInstance("MSFT_KeyValuePair"), Description("Headers of the web request.")] String Headers[];
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Specifies a user account that has permission to send the request.")] String Credential;
+    [Write, Description("A boolean value to indicate if the destination contents have to be always kept in sync with remote file specified in the source path.\n")] Boolean MatchSource;
       [Read, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}, Description("Says whether DestinationPath exists on the machine")] String Ensure;
 };
 

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.schema.mof
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.schema.mof
@@ -7,7 +7,7 @@ class MSFT_xRemoteFile : OMI_BaseResource
     [Write, Description("User agent for the web request.")] String UserAgent;
     [Write, EmbeddedInstance("MSFT_KeyValuePair"), Description("Headers of the web request.")] String Headers[];
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Specifies a user account that has permission to send the request.")] String Credential;
-    [Write, Description("A boolean value to indicate if the destination contents have to be always kept in sync with remote file specified in the source path.\n")] Boolean MatchSource;
+    [Write, Description("A boolean value to indicate whether the remote file should be re-downloaded if file in the DestinationPath was modified locally.")] Boolean MatchSource;
       [Read, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}, Description("Says whether DestinationPath exists on the machine")] String Ensure;
 };
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Domain members may be specified using domain\name or Universal Principal Name (U
 ### Unreleased
 
 * Added CreateCheckRegValue parameter to xPackage resource
+* Added MatchSource parameter to xRemoteFile resource
 
 ### 3.5.0.0
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For a complete list of properties, please use Get-DscResource
 * **UserAgent**: User agent for the web request.
 * **Headers**: Headers of the web request.
 * **Credential**: Specifies credential of a user which has permissions to send the request.
+* **MatchSource**: Determines whether the remote file should be re-downloaded if file in the DestinationPath was modified locally.
 * **Ensure**: Says whether DestinationPath exists on the machine. It's a read only property.
 
 ### xPackage


### PR DESCRIPTION
Note it defaults to $true - I was not sure whether it should default to $true (to keep the original behavior for backward compatibility) or $false (to keep consistency with File / xArchive). 
Please let me know if you think it should default to $false.