### PR TITLE
xService: Bugfix on 'Dependencies' property that caused a crash when set

### DIFF
--- a/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
+++ b/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
@@ -282,7 +282,7 @@ function Set-TargetResource
                     }
                     if($PSBoundParameters.ContainsKey("Dependencies"))
                     {
-                        $argumentsToNewService.Add("Dependencies", $Dependencies)
+                        $argumentsToNewService.Add("DependsOn", $Dependencies)
                     }
                     try
                     {

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ Domain members may be specified using domain\name or Universal Principal Name (U
 ## Versions
 
 ### Unreleased
-
+* xService:
+    - Fixed a bug where 'Dependencies' property was not picked up and caused exception when set.
+ 
 ### 3.6.0.0
 * Added CreateCheckRegValue parameter to xPackage resource
 * Added MatchSource parameter to xRemoteFile resource


### PR DESCRIPTION
Fixed a bug where the New-Service command was called with "Dependencies" instead of "DependsOn" as stated in the Documentation: https://technet.microsoft.com/en-us/library/hh849830.aspx. This caused the DSC Configuration to crash as soon as "Dependencies" was not null.
Updated Readme.md under section "Unreleased"
