### PR TITLE
Added size comparison to xRemoteFile

### DIFF
--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -253,7 +253,13 @@ function Test-TargetResource
                 }
             } else {
                 Write-Debug "MatchSource is false. No need for downloading file."
-                $fileExists = $true 
+                [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
+                $wc.OpenRead($URI)
+                [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
+                if($bytes_total -eq (Get-Item $DestinationPath).Length)
+                {
+                    $fileExists = $true
+                }
             }
         }
 

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -252,12 +252,13 @@ function Test-TargetResource
                     Write-Debug "Cache is empty or it doesn't reflect current state. File will be downloaded."
                 }
             } else {
-                Write-Debug "MatchSource is false. No need for downloading file."
+                Write-Debug "Destination file size is not the same as source file. File will be downloaded."
                 [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
                 $wc.OpenRead($URI)
                 [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
                 if($bytes_total -eq (Get-Item $DestinationPath).Length)
                 {
+                    Write-Debug "MatchSource is false. No need for downloading file."
                     $fileExists = $true
                 }
             }


### PR DESCRIPTION
When MatchSource is $False and Test-Path is $True added a webclient
content-length check to compare the size in bytes of the target and
destination files.

This will ensure that the file is re-downloaded if the file sizes are
not the same (i.e. target file has been updated, download was
interrupted previously, local file was corrupted, etc.)