### PR TITLE
Added size comparison

### DIFF
--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -253,13 +253,7 @@ function Test-TargetResource
                 }
             } else {
                 Write-Debug "MatchSource is false. No need for downloading file."
-                [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
-                $wc.OpenRead($URI)
-                [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
-                if($bytes_total -eq (Get-Item $DestinationPath).Length)
-                {
-                    $fileExists = $true
-                }
+                $fileExists = $true 
             }
         }
 

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -252,17 +252,14 @@ function Test-TargetResource
                     Write-Debug "Cache is empty or it doesn't reflect current state. File will be downloaded."
                 }
             } else {
+                Write-Debug "Destination file size is not the same as source file. File will be downloaded."
                 [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
                 $wc.OpenRead($URI)
                 [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
                 if($bytes_total -eq (Get-Item $DestinationPath).Length)
                 {
-                    Write-Debug "Destination and source file are the same size. No need for downloading file."
+                    Write-Debug "MatchSource is false. No need for downloading file."
                     $fileExists = $true
-                }
-                else
-                {
-                    Write-Debug "Destination file size is not the same as source file. File will be downloaded."
                 }
             }
         }

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -253,7 +253,13 @@ function Test-TargetResource
                 }
             } else {
                 Write-Debug "MatchSource is false. No need for downloading file."
-                $fileExists = $true 
+                [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
+                $wc.OpenRead($URI)
+                [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
+                if($bytes_total -eq (Get-Item $DestinationPath).Length)
+                {
+                    $fileExists = $true
+                }
             }
         }
 

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -252,12 +252,13 @@ function Test-TargetResource
                     Write-Debug "Cache is empty or it doesn't reflect current state. File will be downloaded."
                 }
             } else {
-                Write-Debug "MatchSource is false. No need for downloading file."
+                Write-Debug "Destination file size is not the same as source file. File will be downloaded."
                 [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
                 $wc.OpenRead($URI)
                 [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
                 if($bytes_total -eq (Get-Item $DestinationPath).Length)
                 {
+                    Write-Debug "MatchSource is false. No need for downloading file."
                     $fileExists = $true
                 }
             }

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -252,13 +252,12 @@ function Test-TargetResource
                     Write-Debug "Cache is empty or it doesn't reflect current state. File will be downloaded."
                 }
             } else {
-                Write-Debug "Destination file size is not the same as source file. File will be downloaded."
+                Write-Debug "MatchSource is false. No need for downloading file."
                 [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
                 $wc.OpenRead($URI)
                 [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
                 if($bytes_total -eq (Get-Item $DestinationPath).Length)
                 {
-                    Write-Debug "MatchSource is false. No need for downloading file."
                     $fileExists = $true
                 }
             }

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -252,14 +252,17 @@ function Test-TargetResource
                     Write-Debug "Cache is empty or it doesn't reflect current state. File will be downloaded."
                 }
             } else {
-                Write-Debug "Destination file size is not the same as source file. File will be downloaded."
                 [System.Net.WebClient]$wc = [System.Net.WebClient]::New()
                 $wc.OpenRead($URI)
                 [Long]$bytes_total = $wc.ResponseHeaders["Content-Length"]
                 if($bytes_total -eq (Get-Item $DestinationPath).Length)
                 {
-                    Write-Debug "MatchSource is false. No need for downloading file."
+                    Write-Debug "Destination and source file are the same size. No need for downloading file."
                     $fileExists = $true
+                }
+                else
+                {
+                    Write-Debug "Destination file size is not the same as source file. File will be downloaded."
                 }
             }
         }

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -191,8 +191,10 @@ function Set-TargetResource
     {
         $downloadedFile = Get-Item $DestinationPath
         $lastWriteTime = $downloadedFile.LastWriteTimeUtc
+        $filesize = $downloadedFile.Length
         $inputObject = @{}
         $inputObject["LastWriteTime"] = $lastWriteTime
+        $inputObject["FileSize"] = $filesize
         Update-Cache -DestinationPath $DestinationPath -Uri $Uri -InputObject $inputObject
     }     
 }
@@ -242,7 +244,7 @@ function Test-TargetResource
                 # Getting cache. It's cleared every time user runs Start-DscConfiguration
                 $cache = Get-Cache -DestinationPath $DestinationPath -Uri $Uri
 
-                if ($cache -ne $null -and ($cache.LastWriteTime -eq $file.LastWriteTimeUtc))
+                if ($cache -ne $null -and ($cache.LastWriteTime -eq $file.LastWriteTimeUtc) -and ($cache.FileSize -eq $file.Length))
                 {
                     Write-Debug "Cache reflects current state. No need for downloading file."
                     $fileExists = $true


### PR DESCRIPTION
When MatchSource is $False and Test-Path is $True added a webclient
content-length check to compare the size in bytes of the target and
destination files.

This will ensure that the file is re-downloaded if the file sizes are
not the same (i.e. target file has been updated, download was
interrupted previously, local file was corrupted, etc.)