### PR TITLE
Replaced New-NetFirewallRule with netsh as this cmdlet is not availab…

### DIFF
--- a/DSCResources/MSFT_xDSCWebService/PSWSIISEndpoint.psm1
+++ b/DSCResources/MSFT_xDSCWebService/PSWSIISEndpoint.psm1
@@ -357,15 +357,10 @@ function New-FirewallRule
     param ($firewallPort)
     
     Write-Verbose "Disable Inbound Firewall Notification"
-    Set-NetFirewallProfile -Profile Domain,Public,Private –NotifyOnListen False
-
-    $ruleDisplayName = ($($FireWallRuleDisplayName) -f $firewallPort)
-
-    # remove all existing rules with that displayName
-    Get-NetFirewallRule | Where-Object DisplayName -eq $ruleDisplayName | Remove-NetFirewallRule
+    & $script:netsh advfirewall set currentprofile settings inboundusernotification disable
     
-    Write-Verbose "Add Firewall Rule for port $firewallPort"    
-    $null = New-NetFirewallRule -DisplayName $ruleDisplayName -Description ($($FireWallRuleDescription) -f $firewallPort) -Direction Inbound -LocalPort $firewallPort -Protocol TCP -Action Allow
+    Write-Verbose "Add Firewall Rule for port $firewallPort"
+    & $script:netsh advfirewall firewall add rule name=PSWS_IIS_Port dir=in action=allow protocol=TCP localport=$firewallPort   
 }
 
 # Enable & Clear PSWS Operational/Analytic/Debug ETW Channels

--- a/DSCResources/MSFT_xDSCWebService/PSWSIISEndpoint.psm1
+++ b/DSCResources/MSFT_xDSCWebService/PSWSIISEndpoint.psm1
@@ -358,9 +358,12 @@ function New-FirewallRule
     
     Write-Verbose "Disable Inbound Firewall Notification"
     & $script:netsh advfirewall set currentprofile settings inboundusernotification disable
-    
+
+    # remove all existing rules with that displayName
+    & $script:netsh advfirewall firewall delete rule name=DSCPullServer_IIS_Port protocol=tcp localport=$firewallPort > $null
+        
     Write-Verbose "Add Firewall Rule for port $firewallPort"
-    & $script:netsh advfirewall firewall add rule name=PSWS_IIS_Port dir=in action=allow protocol=TCP localport=$firewallPort   
+    & $script:netsh advfirewall firewall add rule name=DSCPullServer_IIS_Port dir=in action=allow protocol=TCP localport=$firewallPort   
 }
 
 # Enable & Clear PSWS Operational/Analytic/Debug ETW Channels


### PR DESCRIPTION
Replaced New-NetFirewallRule with netsh cmdline tool as powershell security cmdlets are not available by default on some downlevel OS like 2012 R2 Core

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/101)
<!-- Reviewable:end -->