### PR TITLE
Latest demo

### DIFF
--- a/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
+++ b/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
@@ -168,18 +168,10 @@ Function Log
 
 <#
 .Synopsis
-   Deploy DSC modules and Configurations to the pullserver.
+   Deploy DSC modules to the pullserver.
 .DESCRIPTION
-   If you have one or more DSC module that you need to publish to DSC-Pullserver. There are few steps that you need to do
-        1) Find out the module(s) location. 
-        2) Create a zip  file which contains the content of the module and name it as <ModuleName>_<Version>.zip
-        3) Create a checksum of the module
-        4) Copy module and its checksum to the pullserver module repository.
-   This module will automate steps 1-4. It will auto-detect the location of the module 
-   and figure out the right naming of the zip file and deploy your module and its checksum 
-   to the pullserver. 
-
-   This is available in ps gallary under xPSDesiredStateConfiguration module. 
+   Publish DSC module using Module Info object as an input. 
+   The cmdlet will figure out the location of the module repository using web.config of the pullserver.
 .EXAMPLE
    Get-Module <ModuleName> | Publish-ModuleToPullServer
 #>
@@ -252,7 +244,14 @@ function Publish-ModuleToPullServer
     }
 } 
 
-# Copy a mof file and its checksum to the pullserver configuration repository.
+<#
+.Synopsis
+   Deploy DSC Configuration document to the pullserver.
+.DESCRIPTION
+   Publish Mof file to the pullserver. It takes File Info object as pipeline input. It also auto detects the location of the configuration repository using the web.config of the pullserver.
+.EXAMPLE
+   Dir <path>\*.mof | Publish-MOFToPullServer
+#>
 function Publish-MOFToPullServer
 {
     [CmdletBinding()]
@@ -300,4 +299,4 @@ function Publish-MOFToPullServer
     }
 }
 
-Export-ModuleMember -Function Publish-DSCModuleAndMof
+Export-ModuleMember -Function Publish-*

--- a/README.md
+++ b/README.md
@@ -159,9 +159,21 @@ Note: _the xWindowsOptionalFeature is only supported on Windows client or Window
    - Suported values: ErrorsOnly, ErrorsAndWarning, ErrorsAndWarningAndInformation.
    - Default value: ErrorsOnly.
 
+## Functions
+
+### Publish-ModuleToPullServer
+    Publishes a 'ModuleInfo' object(s) to the pullserver module repository or user provided path. It accepts its input from a pipeline so it can be used in conjunction with Get-Module as Get-Module <ModuleName> | Publish-Module
+
+### Publish-MOFToPullServer
+    Publishes a 'FileInfo' object(s) to the pullserver configuration repository. Its accepts FileInfo input from a pipeline so it can be used in conjunction with Get-ChildItem .*.mof | Publish-MOFToPullServer
+
 ## Versions
 
 ### Unreleased
+
+* **Publish-ModuleToPullServer**
+* **Publish-MOFToPullServer**
+
 ### 4.0.0.0
 
 * Replaced New-NetFirewallRule cmdlets with netsh as this cmdlet is not available by default on some downlevel OS such as Windows 2012 R2 Core.


### PR DESCRIPTION
Added two cmdlets to publish module and configuration from a pipeline ModuleInfo and FileInfo object. The cmdlets will also figure out the location of the module and configuration repositories of the pull server from web.config.

-  Publishing module(s) :-  Get-Module 'xWebAdministration' -ListAvailable | pmp
- Publishing a configuration(s) :-  Dir c:\*mof  | pcp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/102)
<!-- Reviewable:end -->