### PR TITLE
xService: Fixing StartupType Bug in Test-TargetResource (Fixes #163)

### DIFF
--- a/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
+++ b/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
@@ -425,6 +425,13 @@ function Test-StartupType
     }
 }
 
+<#
+    .SYNOPSIS
+        Converts the StartupType string to the correct StartMode string returned in the Win32 service object.
+
+    .PARAMETER StartupType
+        The StartupType to convert.
+#>
 function ConvertTo-StartModeString
 {
     [OutputType([String])]

--- a/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
+++ b/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
@@ -190,7 +190,7 @@ function Test-TargetResource
             return $false
         }
 
-        if ($PSBoundParameters.ContainsKey("StartupType") -and $SvcWmi.StartMode -ine $StartupType)
+        if ($PSBoundParameters.ContainsKey("StartupType") -and $SvcWmi.StartMode -ine (ConvertTo-StartModeString -StartupType $StartupType))
         {
             Write-Verbose -Message ($LocalizedData.TestStartupTypeMismatch -f $svcWmi.Name,$svcWmi.StartMode,$StartupType)
             return $false
@@ -422,6 +422,27 @@ function Test-StartupType
             # State = Running conflicts with Disabled
             ThrowInvalidArgumentError -ErrorId "CannotStartAndDisable" -ErrorMessage ($LocalizedData.CannotStartAndDisable -f $Name)
         }
+    }
+}
+
+function ConvertTo-StartModeString
+{
+    [OutputType([String])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Automatic', 'Manual', 'Disabled')]
+        [String] $StartupType
+    )
+
+    if ($StartupType -eq 'Automatic')
+    {
+        return 'Auto'
+    }
+    else
+    {
+        return $StartupType
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ These parameters will be the same for each Windows optional feature in the set. 
 * Fixed $script:netsh parameter initialization in xWebService resource that was causing CIM exception when EnableFirewall flag was specified.
 * xService:
     - Fixed a bug where, despite no state specified in the config, the resource test returns false if the service is not running
+    - Fixed bug in which Automatice StartupType did not match the 'Auto' StartMode in Test-TargetResource.
 * xPackage: Fixes bug where CreateCheckRegValue was not being removed when uninstalling packages
 * Replaced New-NetFirewallRule cmdlets with netsh as this cmdlet is not available by default on some downlevel OS such as Windows 2012 R2 Core.
 * Added the xEnvironment resource

--- a/Tests/Unit/MSFT_xServiceResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xServiceResource.Tests.ps1
@@ -1,6 +1,8 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 param ()
 
+Import-Module "$PSScriptRoot\..\..\DSCResource.Tests\TestHelper.psm1" -Force
+
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName 'xPSDesiredStateConfiguration' `
     -DSCResourceName 'MSFT_xServiceResource' `
@@ -303,6 +305,24 @@ InModuleScope 'MSFT_xServiceResource' {
                 $testTargetResourceResult | Should Be $false
 
                 $testTargetResourceResult = Test-TargetResource -Name $script:testServiceName -State 'Stopped'
+                $testTargetResourceResult | Should Be $true
+            }
+
+            It 'Should return true with the Automatic StartupType' {
+                Set-TargetResource -Name $script:testServiceName -StartupType 'Automatic'
+                $testTargetResourceResult = Test-TargetResource -Name $script:testServiceName -StartupType 'Automatic'
+                $testTargetResourceResult | Should Be $true
+            }
+
+            It 'Should return true with the Manual StartupType' {
+                Set-TargetResource -Name $script:testServiceName -StartupType 'Manual'
+                $testTargetResourceResult = Test-TargetResource -Name $script:testServiceName -StartupType 'Manual'
+                $testTargetResourceResult | Should Be $true
+            }
+
+            It 'Should return true with the Disabled StartupType' {
+                Set-TargetResource -Name $script:testServiceName -State 'Stopped' -StartupType 'Disabled'
+                $testTargetResourceResult = Test-TargetResource -Name $script:testServiceName -State 'Stopped' -StartupType 'Disabled'
                 $testTargetResourceResult | Should Be $true
             }
 


### PR DESCRIPTION
There was a bug in Test-TargetResource for xService in which the Automative StartupType did not match the Auto StartMode. (#163)

I added a new function called ConvertTo-StartModeString to convert the StartupType string to the correct StartMode.
I also added the test given in #163 as well as two more tests for the two other StartupType options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/164)
<!-- Reviewable:end -->
