### PR TITLE
xGroup: Fix when credential parameter does not contain local or domain context - Fixes #139

### DIFF
--- a/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
+++ b/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
@@ -1518,7 +1518,7 @@ function Get-MembersAsPrincipals
         # The account is domain qualified - credential required to resolve it.
         elseif ($null -ne $Credential -or $null -ne $principalContext)
         {
-            Write-Verbose -Message ($LocalizedData.ResolvingDomainAccount -f  $scope, $accountName)
+            Write-Verbose -Message ($LocalizedData.ResolvingDomainAccount -f  $accountName, $scope)
         }
         else
         {
@@ -1858,7 +1858,14 @@ function Get-PrincipalContext
     elseif ($null -ne $Credential)
     {
         # Create a PrincipalContext targeting $Scope using the network credentials that were passed in.
-        $principalContextName = "$($Credential.Domain)\$($Credential.UserName)"
+        if ($Credential.Domain)
+        {
+            $principalContextName = "$($Credential.Domain)\$($Credential.UserName)"
+        }
+        else
+        {
+            $principalContextName = $Credential.UserName
+        }
         $principalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Domain, $Scope, $principalContextName, $Credential.Password )
 
         # Cache the PrincipalContext for this scope for subsequent calls.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **xEnvironment** configures and manages environment variables.
 * **xWindowsFeature** provides a mechanism to ensure that roles and features are added or removed on a target node.
 * **xScript** provides a mechanism to run Windows PowerShell script blocks on target nodes.
-* **xGroupSet** configures multiple xGroups with common settings but different names. 
+* **xGroupSet** configures multiple xGroups with common settings but different names.
 * **xProcessSet** allows starting and stopping of a group of windows processes with no arguments.
 * **xServiceSet** allows starting, stopping and change in state or account type for a group of services.
 * **xWindowsFeatureSet** allows installation and uninstallation of a group of Windows features and their subfeatures.
@@ -334,6 +334,9 @@ These parameters will be the same for each Windows optional feature in the set. 
 ## Versions
 
 ### Unreleased
+
+* xGroup: Fix Verbose output in Get-MembersAsPrincipals function.
+          Fix bug when credential parameter passed does not contain local or domain context.
 
 ### 3.12.0.0
 


### PR DESCRIPTION
* xGroup: Fix Verbose output in Get-MembersAsPrincipals function.
          Fix bug when credential parameter passed does not contain local or domain context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/173)
<!-- Reviewable:end -->
