### PR TITLE
xWindowsOptionalFeature: Fix running tests creates/updates file in repo

### DIFF
--- a/Tests/Integration/MSFT_xWindowsOptionalFeature.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsOptionalFeature.Tests.ps1
@@ -6,8 +6,8 @@
 Describe "xWindowsOptionalFeature Integration Tests" {
     It "Install a valid Windows optional feature" {
         $configurationName = "InstallOptionalFeature"
-        $configurationPath = Join-Path -Path (Get-Location) -ChildPath $configurationName
-        $logPath = Join-Path -Path (Get-Location) -ChildPath 'InstallOptionalFeatureLog'
+        $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
+        $logPath = Join-Path -Path $TestDrive -ChildPath 'InstallOptionalFeature.log'
 
         $validFeatureName = 'TelnetClient'
 
@@ -59,8 +59,8 @@ Describe "xWindowsOptionalFeature Integration Tests" {
 
     It "Install an incorrect Windows optional feature" {
         $configurationName = "InstallIncorrectWindowsFeature"
-        $configurationPath = Join-Path -Path (Get-Location) -ChildPath $configurationName
-        $logPath = Join-Path -Path (Get-Location) -ChildPath 'InstallIncorrectWindowsFeatureLog'
+        $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
+        $logPath = Join-Path -Path $TestDrive -ChildPath 'InstallIncorrectWindowsFeature.log'
 
         try
         {

--- a/Tests/Integration/MSFT_xWindowsOptionalFeatureSet.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsOptionalFeatureSet.Tests.ps1
@@ -6,8 +6,8 @@
 Describe "xWindowsOptionalFeatureSet Integration Tests" {
     It "Install two valid Windows optional features" {
         $configurationName = "InstallOptionalFeature"
-        $configurationPath = Join-Path -Path (Get-Location) -ChildPath $configurationName
-        $logPath = Join-Path -Path (Get-Location) -ChildPath 'InstallOptionalFeatureLog'
+        $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
+        $logPath = Join-Path -Path $TestDrive -ChildPath 'InstallOptionalFeature.log'
 
         $validFeatureName1 = 'MicrosoftWindowsPowerShellV2'
         $validFeatureName2 = 'Internet-Explorer-Optional-amd64'
@@ -69,8 +69,8 @@ Describe "xWindowsOptionalFeatureSet Integration Tests" {
 
     It "Install an incorrect Windows optional feature" {
         $configurationName = "InstallIncorrectWindowsFeature"
-        $configurationPath = Join-Path -Path (Get-Location) -ChildPath $configurationName
-        $logPath = Join-Path -Path (Get-Location) -ChildPath 'InstallIncorrectWindowsFeatureLog'
+        $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
+        $logPath = Join-Path -Path $TestDrive -ChildPath 'InstallIncorrectWindowsFeature.log'
 
         try
         {


### PR DESCRIPTION
Updated the integration tests of xWindowsOptionalFeature and xWindowsOptionalFeatureSet to use the $TestDrive variable (pointing to a path under $env:TEMP managed by Pester) for the feature installation log files.

https://github.com/pester/Pester/wiki/TestDrive

Fixes #215 