### PR TITLE
Add DatabasePath property to xDSCWebService

### DIFF
--- a/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.Schema.mof
+++ b/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.Schema.mof
@@ -8,6 +8,7 @@ class MSFT_xDSCWebService : OMI_BaseResource
   [write] string PhysicalPath;
   [write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
   [write,ValueMap{"Started","Stopped"},Values{"Started", "Stopped"}] string State;
+  [write] string DatabasePath;
   [write] string ModulePath;
   [write] string ConfigurationPath;
   [read] string DSCServerUrl;  

--- a/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
+++ b/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
@@ -130,6 +130,7 @@ function Set-TargetResource
         [string]$State = "Started",
 
         # Location on the disk where the database is stored
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $DatabasePath = "$env:PROGRAMFILES\WindowsPowerShell\DscService",
 
@@ -325,6 +326,7 @@ function Test-TargetResource
         [string]$State = "Started",
 
         # Location on the disk where the database is stored
+        [ValidateNotNullOrEmpty()]
         [System.String]
         $DatabasePath = "$env:PROGRAMFILES\WindowsPowerShell\DscService",
 

--- a/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
+++ b/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
@@ -407,11 +407,20 @@ function Test-TargetResource
                 "ESENT" {
                     $expectedConnectionString = "$DatabasePath\Devices.edb"
                 }
-
                 "System.Data.OleDb" {
                     $expectedConnectionString = "Provider=Microsoft.Jet.OLEDB.4.0;Data Source=$DatabasePath\Devices.mdb;"
                 }
+                default {
+                    $expectedConnectionString = [System.String]::Empty
+                }
             }
+            if (([System.String]::IsNullOrEmpty($expectedConnectionString)))
+            {
+                $DesiredConfigurationMatch = $false
+                Write-Verbose "The DB provider does not have a valid value: 'ESENT' or 'System.Data.OleDb'"
+                break
+            }
+
             if (-not (Test-WebConfigAppSetting -WebConfigFullPath $webConfigFullPath -AppSettingName "dbconnectionstr" -ExpectedAppSettingValue $expectedConnectionString))
             {
                 $DesiredConfigurationMatch = $false

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ These parameters will be the same for each Windows optional feature in the set. 
     * Added setting of enhanced security
     * Cleaned up Examples
     * Cleaned up pull server verification test
+    * xDscWebService: Add DatabasePath property to specify a custom database path and enable multiple pull server instances on one server.
 * xWindowsOptionalFeature:
     * Cleaned up resource (PSSA issues, formatting, etc.)
     * Added example script
@@ -480,7 +481,6 @@ because they were unavailable to Get-DscResource and Import-DscResource.
 * Merged the in-box Service resource with xService and added tests for xService
 * Merged the in-box Archive resource with xArchive and added tests for xArchive
 * Merged the in-box Group resource with xGroup and added tests for xGroup
-* xDscWebService: Add DatabasePath property to specific a custom database path and enable multiple pull server instances on one server.
 
 ### 3.10.0.0
 

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ because they were unavailable to Get-DscResource and Import-DscResource.
 * Merged the in-box Service resource with xService and added tests for xService
 * Merged the in-box Archive resource with xArchive and added tests for xArchive
 * Merged the in-box Group resource with xGroup and added tests for xGroup
+* xDscWebService: Add DatabasePath property to specific a custom database path and enable multiple pull server instances on one server.
 
 ### 3.10.0.0
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ These parameters will be the same for each Windows optional feature in the set. 
     * Added setting of enhanced security
     * Cleaned up Examples
     * Cleaned up pull server verification test
-    * xDscWebService: Add DatabasePath property to specify a custom database path and enable multiple pull server instances on one server.
+    * Add DatabasePath property to specify a custom database path and enable multiple pull server instances on one server.
 * xWindowsOptionalFeature:
     * Cleaned up resource (PSSA issues, formatting, etc.)
     * Added example script


### PR DESCRIPTION
In order to be able to host multiple DSC pull servers on a single system, it's required to have a configuration option for the database path. With this commit, I've added a new property called DatabasePath to the xDSCWebService to specify the location. The default value is set for backwards compatibility - no existing xDSCWebService configuration will break. In addition I've added support for the ESENT and OLED database version. This commit is offline testes on a WS2012 R2 with WMF 5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/233)
<!-- Reviewable:end -->
