### PR TITLE
Update xGroupResource to high quality resource

### DIFF
--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -37,8 +37,13 @@ function New-InvalidArgumentException
         $ArgumentName
     )
 
-    $argumentException = New-Object -TypeName 'ArgumentException' -ArgumentList @( $Message, $ArgumentName )
-    $errorRecord = New-Object -TypeName 'System.Management.Automation.ErrorRecord' -ArgumentList @( $argumentException, $ArgumentName, 'InvalidArgument', $null)
+    $argumentException = New-Object -TypeName 'ArgumentException' -ArgumentList @( $Message,
+        $ArgumentName )
+    $newObjectParams = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @( $argumentException, $ArgumentName, 'InvalidArgument', $null )
+    }
+    $errorRecord = New-Object @newObjectParams
 
     throw $errorRecord
 }
@@ -73,14 +78,22 @@ function New-InvalidOperationException
     }
     elseif ($null -eq $ErrorRecord)
     {
-        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message )
+        $invalidOperationException =
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message )
     }
     else
     {
-        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message, $ErrorRecord.Exception)
+        $invalidOperationException =
+            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message,
+                $ErrorRecord.Exception )
     }
 
-    $errorRecordToThrow = New-Object -TypeName 'System.Management.Automation.ErrorRecord' -ArgumentList @( $invalidOperationException.ToString(), 'MachineStateIncorrect', 'InvalidOperation' ,$null)
+    $newObjectParams = @{
+        TypeName = 'System.Management.Automation.ErrorRecord'
+        ArgumentList = @( $invalidOperationException.ToString(), 'MachineStateIncorrect',
+            'InvalidOperation', $null )
+    }
+    $errorRecordToThrow = New-Object @newObjectParams
     throw $errorRecordToThrow
 }
 
@@ -125,8 +138,5 @@ function Get-LocalizedData
     return $localizedData
 }
 
-Export-ModuleMember -Function `
-    Test-IsNanoServer, `
-    New-InvalidArgumentException, `
-    New-InvalidOperationException, `
-    Get-LocalizedData
+Export-ModuleMember -Function @( 'Test-IsNanoServer', 'New-InvalidArgumentException',
+    'New-InvalidOperationException', 'Get-LocalizedData' )

--- a/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
+++ b/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
@@ -211,7 +211,6 @@ function Get-TargetResource
 function Set-TargetResource
 {
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -2487,11 +2486,6 @@ function Split-MemberName
 #>
 function Remove-DisposableObject
 {
-    <#
-        Suppress script analyzer warning because this function should use the Remove verb 
-        as per our discussion on https://github.com/PowerShell/xPSDesiredStateConfiguration/pull/240
-    #>
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding()]
     param
     (

--- a/README.md
+++ b/README.md
@@ -362,6 +362,13 @@ These parameters will be the same for each Windows optional feature in the set. 
     * Added setting of enhanced security
     * Cleaned up Examples
     * Cleaned up pull server verification test
+* xGroup:
+    * Fixed PSSA issues
+    * Formatting updated as per style guidelines
+    * Missing comment-based help added for Get-/Set-/Test-TargetResource
+    * Typos fixed in Unit test script
+    * Unit test 'Get-TargetResource/Should return hashtable with correct values when group 
+    has no members' updated to handle the expected empty Members array correctly
 * xProcess:
     * Fixed PSSA issues
     * Corrected most style guideline issues

--- a/README.md
+++ b/README.md
@@ -355,6 +355,13 @@ These parameters will be the same for each Windows optional feature in the set. 
 
 * xDSCWebService:
     * Add DatabasePath property to specify a custom database path and enable multiple pull server instances on one server.
+* xGroup:
+    * Fixed PSSA issues
+    * Formatting updated as per style guidelines
+    * Missing comment-based help added for Get-/Set-/Test-TargetResource
+    * Typos fixed in Unit test script
+    * Unit test 'Get-TargetResource/Should return hashtable with correct values when group 
+    has no members' updated to handle the expected empty Members array correctly    
 
 ### 4.0.0.0
 
@@ -362,13 +369,6 @@ These parameters will be the same for each Windows optional feature in the set. 
     * Added setting of enhanced security
     * Cleaned up Examples
     * Cleaned up pull server verification test
-* xGroup:
-    * Fixed PSSA issues
-    * Formatting updated as per style guidelines
-    * Missing comment-based help added for Get-/Set-/Test-TargetResource
-    * Typos fixed in Unit test script
-    * Unit test 'Get-TargetResource/Should return hashtable with correct values when group 
-    has no members' updated to handle the expected empty Members array correctly
 * xProcess:
     * Fixed PSSA issues
     * Corrected most style guideline issues

--- a/Tests/Integration/MSFT_xGroupResource.Tests.ps1
+++ b/Tests/Integration/MSFT_xGroupResource.Tests.ps1
@@ -1,10 +1,11 @@
 ﻿Import-Module "$PSScriptRoot\..\..\DSCResource.Tests\TestHelper.psm1" -Force
 
-Initialize-TestEnvironment `
-    -DSCModuleName 'xPSDesiredStateConfiguration' `
-    -DSCResourceName 'MSFT_xGroupResource' `
-    -TestType Integration `
-    | Out-Null
+$initializeTestEnvironmentParams = @{
+    DSCModuleName = 'xPSDesiredStateConfiguration'
+    DSCResourceName = 'MSFT_xGroupResource'
+    TestType = 'Integration'
+}
+$null = Initialize-TestEnvironment @initializeTestEnvironmentParams
 
 Describe 'xGroup Integration Tests'  {
     BeforeAll {
@@ -22,8 +23,8 @@ Describe 'xGroup Integration Tests'  {
 
         try
         {
-            Configuration $configurationName 
-            { 
+            Configuration $configurationName
+            {
                 param ()
 
                 Import-DSCResource -ModuleName 'xPSDesiredStateConfiguration'
@@ -70,8 +71,8 @@ Describe 'xGroup Integration Tests'  {
 
         try
         {
-            Configuration $configurationName 
-            { 
+            Configuration $configurationName
+            {
                 param ()
 
                 Import-DSCResource -ModuleName 'xPSDesiredStateConfiguration'

--- a/Tests/Unit/MSFT_xGroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xGroupResource.Tests.ps1
@@ -442,8 +442,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 and that creating a group without a credential does not throw any errors
                 when we have domain trust set up.
             #>
-            $itName = 'Should correctly create a group with a domain user and credential'
-            It $itName -Skip:$script:skipTestsWithCredentials {
+            It 'Should correctly create a group with a domain user and credential' -Skip:$script:skipTestsWithCredentials {
                 $testUserName1 = 'LocalTestUser1'
                 $testUserName2 = 'LocalTestUser2'
 
@@ -525,8 +524,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 The credential for the domain local administrator user is used to
                 resolve all user accounts.
             #>
-            $itName = 'Should create a new group with the trusted domain accounts and credential'
-            It $itName -Skip:$script:skipTestsWithCredentials {
+            It 'Should create a new group with the trusted domain accounts and credential' -Skip:$script:skipTestsWithCredentials {
                 $testGroupName = 'LocalTestGroup'
                 $testDescription = 'Some Description'
 
@@ -589,9 +587,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 The credential for the domain local administrator user is used to
                 resolve all user accounts.
             #>
-            $itName =
-                'Should create a group with a domain user and credential and add a user by UPN name'
-            It $itName -Skip:$script:skipTestsWithCredentials {
+            It 'Should create a group with a domain user and credential and add a user by UPN name' -Skip:$script:skipTestsWithCredentials {
                 $testGroupName = 'LocalTestGroup'
                 $testDescription = 'Some Description'
 
@@ -643,8 +639,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 }
             }
 
-            $itName = 'Should not create a group with a credential and an invalid domain user'
-            It $itName -Skip:$script:skipTestsWithCredentials {
+            It 'Should not create a group with a credential and an invalid domain user' -Skip:$script:skipTestsWithCredentials {
                 $testGroupName = 'LocalTestGroup'
                 $testDescription = 'Some Description'
 
@@ -678,8 +673,7 @@ InModuleScope 'MSFT_xGroupResource' {
 
                 The domain trust is used to resolve all user accounts.
             #>
-            $itName = 'Should create a group with a domain user but no credential'
-            It $itName -Skip:$script:skipTestsWithCredentials {
+            It 'Should create a group with a domain user but no credential' -Skip:$script:skipTestsWithCredentials {
                 $testGroupName = 'LocalTestGroup'
                 $testDescription = 'Some Description'
 
@@ -726,8 +720,7 @@ InModuleScope 'MSFT_xGroupResource' {
             }
 
             # Verify that test group cannot be created with an invalid credential
-            $itName = 'Should not create a group with an invalid credential'
-            It $itName -Skip:$script:skipTestsWithCredentials {
+            It 'Should not create a group with an invalid credential' -Skip:$script:skipTestsWithCredentials {
                 $testGroupName = 'LocalTestGroup'
                 $testDescription = 'Some Description'
 
@@ -777,8 +770,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 Verify that test group cannot be created with invalid user info
                 (cannot resolve user) when using domain trust
             #>
-            $itName = 'Should not create a group with an invalid domain user without a credential'
-            It $itName -Skip:$script:skipTestsWithCredentials {
+            It 'Should not create a group with an invalid domain user without a credential' -Skip:$script:skipTestsWithCredentials {
                 $testGroupName = 'LocalTestGroup'
                 $testDescription = 'Some Description'
 

--- a/Tests/Unit/MSFT_xGroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xGroupResource.Tests.ps1
@@ -31,13 +31,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -55,8 +50,7 @@ InModuleScope 'MSFT_xGroupResource' {
 
                     $testGetTargetResourceResultParams = @{
                         GetTargetResourceResult = $getTargetResourceResult
-                        GetTargetResourceResultProperties =
-                            @( 'GroupName', 'Ensure', 'Description', 'Members' )
+                        GetTargetResourceResultProperties = @( 'GroupName', 'Ensure', 'Description', 'Members' )
                     }
                     Test-GetTargetResourceResult @testGetTargetResourceResultParams
 
@@ -95,8 +89,7 @@ InModuleScope 'MSFT_xGroupResource' {
                     #>
                     $testGetTargetResourceResultParams = @{
                         GetTargetResourceResult = $getTargetResourceResult
-                        GetTargetResourceResultProperties = 
-                            @( 'GroupName', 'Ensure', 'Description' )
+                        GetTargetResourceResultProperties = @( 'GroupName', 'Ensure', 'Description' )
                     }
                     Test-GetTargetResourceResult @testGetTargetResourceResultParams
 
@@ -117,8 +110,7 @@ InModuleScope 'MSFT_xGroupResource' {
             It 'Should return hashtable with correct values when group is absent' {
                 $testGroupName = 'AbsentGroup'
 
-                $getTargetResourceResult =
-                    (Get-TargetResource -GroupName $testGroupName) -as [hashtable]
+                $getTargetResourceResult = (Get-TargetResource -GroupName $testGroupName) -as [hashtable]
 
                 $testGetTargetResourceResultParams = @{
                     GetTargetResourceResult = $getTargetResourceResult
@@ -164,13 +156,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams  -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -212,13 +199,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -260,13 +242,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -315,13 +292,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -357,13 +329,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -404,13 +371,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -452,13 +414,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -470,11 +427,7 @@ InModuleScope 'MSFT_xGroupResource' {
 
                     $secureDomainUserPassword =
                         ConvertTo-SecureString $domainUserPassword -AsPlainText -Force
-                    $newObjectParams = @{
-                        TypeName = 'PSCredential'
-                        ArgumentList = @( $domainUserName, $secureDomainUserPassword )
-                    }
-                    $domainCredential = New-Object @newObjectParams
+                    $domainCredential = New-Object -TypeName 'PSCredential' -ArgumentList @( $domainUserName, $secureDomainUserPassword )
 
                     $setTargetResourceParams = @{
                         GroupName = $testGroupName
@@ -491,12 +444,10 @@ InModuleScope 'MSFT_xGroupResource' {
                     }
                     Test-TargetResource  @testTargetResourceParams | Should Be $true
 
-                    $getTargetResourceResult =
-                        Get-TargetResource -GroupName $testGroupName -Credential $domainCredential
+                    $getTargetResourceResult = Get-TargetResource -GroupName $testGroupName -Credential $domainCredential
                     $testGetTargetResourceResultParams = @{
                         GetTargetResourceResult = $getTargetResourceResult
-                        GetTargetResourceResultProperties =
-                            @( 'GroupName', 'Ensure', 'Description', 'Members' )
+                        GetTargetResourceResultProperties = @( 'GroupName', 'Ensure', 'Description', 'Members' )
                     }
                     Test-GetTargetResourceResult @testGetTargetResourceResultParams
 
@@ -531,8 +482,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 $primaryDomainAccount = '?'
                 $twoWayTrustDomainAccount = '?'
 
-                $membersToInclude = @( $primaryDomainAccount['DomainUserName'],
-                    $twoWayTrustDomainAccount['DomainUserName'] )
+                $membersToInclude = @( $primaryDomainAccount['DomainUserName'], $twoWayTrustDomainAccount['DomainUserName'] )
                 $primaryDomainAccountCredential = $primaryDomainAccount['Credential']
 
                 try
@@ -560,8 +510,7 @@ InModuleScope 'MSFT_xGroupResource' {
 
                     $testGetTargetResourceResultParams = @{
                         GetTargetResourceResult = $getTargetResourceResult
-                        GetTargetResourceResultProperties =
-                            @( 'GroupName', 'Ensure', 'Description', 'Members' )
+                        GetTargetResourceResultProperties = @( 'GroupName', 'Ensure', 'Description', 'Members' )
                     }
                     Test-GetTargetResourceResult @testGetTargetResourceResultParams
 
@@ -594,8 +543,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 $primaryDomainAccount = '?'
                 $twoWayTrustDomainAccount = '?'
 
-                $membersToInclude = @( $primaryDomainAccount['UpnName'],
-                    $twoWayTrustDomainAccount['UpnName'] )
+                $membersToInclude = @( $primaryDomainAccount['UpnName'], $twoWayTrustDomainAccount['UpnName'] )
                 $primaryDomainAccountCredential = $primaryDomainAccount['Credential']
 
                 try
@@ -623,8 +571,7 @@ InModuleScope 'MSFT_xGroupResource' {
 
                     $testGetTargetResourceResultParams = @{
                         GetTargetResourceResult = $getTargetResourceResult
-                        GetTargetResourceResultProperties =
-                            @( 'GroupName', 'Ensure', 'Description', 'Members' )
+                        GetTargetResourceResultProperties = @( 'GroupName', 'Ensure', 'Description', 'Members' )
                     }
                     Test-GetTargetResourceResult @testGetTargetResourceResultParams
 
@@ -652,8 +599,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 {
                     $setTargetResourceParams = @{
                         GroupName = $testGroupName
-                        MembersToInclude = @( $primaryDomainAccount['UpnName'],
-                            $invalidDomainAccountUserName )
+                        MembersToInclude = @( $primaryDomainAccount['UpnName'], $invalidDomainAccountUserName )
                         Credential = $primaryDomainAccountCredential
                         Description = $testDescription
                     }
@@ -680,8 +626,7 @@ InModuleScope 'MSFT_xGroupResource' {
                 $primaryDomainAccount = '?'
                 $twoWayTrustDomainAccount = '?'
 
-                $membersToInclude = @( $primaryDomainAccount['DomainUserName'],
-                    $twoWayTrustDomainAccount['DomainUserName'] )
+                $membersToInclude = @( $primaryDomainAccount['DomainUserName'], $twoWayTrustDomainAccount['DomainUserName'] )
 
                 try
                 {
@@ -703,8 +648,7 @@ InModuleScope 'MSFT_xGroupResource' {
                     $getTargetResourceResult = Get-TargetResource -GroupName $testGroupName
                     $testGetTargetResourceResultParams = @{
                         GetTargetResourceResult = $getTargetResourceResult
-                        GetTargetResourceResultProperties =
-                            @( 'GroupName', 'Ensure', 'Description', 'Members' )
+                        GetTargetResourceResultProperties = @( 'GroupName', 'Ensure', 'Description', 'Members' )
                     }
                     Test-GetTargetResourceResult @testGetTargetResourceResultParams
 
@@ -728,22 +672,14 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testUserPassword = 'StrongOne7.'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                    ArgumentList = @( $testUserName1, $secureTestPassword )
-                }
-                $testCredential1 = New-Object @newObjectParams
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
 
                 # Domain user with invalid password
                 $domainUserName = '?'
                 $invalidDomainUserPassword = '?' + 'invalidstring'
-                $secureInvalidDomainUserPassword =
-                    ConvertTo-SecureString -String $invalidDomainUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'System.Management.Automation.PSCredential'
-                    ArgumentList = @($domainUserName, $invalidDomainUserPassword)
-                }
-                $invalidDomainUserCredential = New-Object @newObjectParams
+                $secureInvalidDomainUserPassword = ConvertTo-SecureString -String $invalidDomainUserPassword -AsPlainText -Force
+                $invalidDomainUserCredential = New-Object -TypeName 'System.Management.Automation.PSCredential' `
+                    -ArgumentList @($domainUserName, $invalidDomainUserPassword)
 
                 try
                 {
@@ -778,22 +714,14 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testUserPassword = 'StrongOne7.'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                    ArgumentList = @( $testUserName1, $secureTestPassword )
-                }
-                $testCredential1 = New-Object @newObjectParams
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
 
                 # Domain user with invalid username
                 $invalidDomainUserName = '?' + 'invalidstring'
                 $invalidDomainUserPassword = '?' + 'invalidstring'
-                $secureInvalidDomainUserPassword =
-                    ConvertTo-SecureString -String $invalidDomainUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'System.Management.Automation.PSCredential'
-                    ArgumentList = @( $invalidDomainUserName, $invalidDomainUserPassword )
-                }
-                $invalidDomainUserCredential = New-Object @newObjectParams
+                $secureInvalidDomainUserPassword = ConvertTo-SecureString -String $invalidDomainUserPassword -AsPlainText -Force
+                $invalidDomainUserCredential = New-Object -TypeName 'System.Management.Automation.PSCredential' `
+                    -ArgumentList @( $invalidDomainUserName, $invalidDomainUserPassword )
 
                 try
                 {
@@ -804,8 +732,7 @@ InModuleScope 'MSFT_xGroupResource' {
                             GroupName = $testGroupName
                             Credential = $invalidDomainUserCredential
                             Description = $testDescription
-                            MembersToInclude = @( $testUserName1,
-                                $invalidDomainUserName )
+                            MembersToInclude = @( $testUserName1, $invalidDomainUserName )
                         }
                         Set-TargetResource @setTargetResourceParams
                     } | Should Throw
@@ -869,13 +796,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -915,15 +837,9 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
-                $testCredential3 = New-Object @newObjectParams -ArgumentList @( $testUserName3,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
+                $testCredential3 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName3, $secureTestPassword )
 
                 try
                 {
@@ -964,13 +880,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -1009,13 +920,8 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
 
                 try
                 {
@@ -1055,15 +961,9 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
-                $testCredential3 = New-Object @newObjectParams -ArgumentList @( $testUserName3,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
+                $testCredential3 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName3, $secureTestPassword )
 
                 try
                 {
@@ -1106,17 +1006,10 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
-                $testCredential3 = New-Object @newObjectParams -ArgumentList @( $testUserName3,
-                    $secureTestPassword )
-                $testCredential4 = New-Object @newObjectParams -ArgumentList @( $testUserName4,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
+                $testCredential3 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName3, $secureTestPassword )
+                $testCredential4 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName4, $secureTestPassword )
 
                 try
                 {
@@ -1161,17 +1054,10 @@ InModuleScope 'MSFT_xGroupResource' {
                 $testGroupName = 'LocalTestGroup'
 
                 $secureTestPassword = ConvertTo-SecureString $testUserPassword -AsPlainText -Force
-                $newObjectParams = @{
-                    TypeName = 'PSCredential'
-                }
-                $testCredential1 = New-Object @newObjectParams -ArgumentList @( $testUserName1,
-                    $secureTestPassword )
-                $testCredential2 = New-Object @newObjectParams -ArgumentList @( $testUserName2,
-                    $secureTestPassword )
-                $testCredential3 = New-Object @newObjectParams -ArgumentList @( $testUserName3,
-                    $secureTestPassword )
-                $testCredential4 = New-Object @newObjectParams -ArgumentList @( $testUserName4,
-                    $secureTestPassword )
+                $testCredential1 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName1, $secureTestPassword )
+                $testCredential2 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName2, $secureTestPassword )
+                $testCredential3 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName3, $secureTestPassword )
+                $testCredential4 = New-Object -TypeName 'PSCredential' -ArgumentList @( $testUserName4, $secureTestPassword )
 
                 try
                 {


### PR DESCRIPTION
- Updates to resolve the reported PSSA issues
- Formatting updated as per style guidelines
- Comment-based help added to Get-/Set-/Test-TargetResource functions
- Typos fixed in Unit test script
- Unit test 'Get-TargetResource/Should return hashtable with correct values when group has no members' updated to handle the expected empty Members array correctly

Fixes #130

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/240)
<!-- Reviewable:end -->
