### PR TITLE
Added a don't care state to xService resource

### DIFF
--- a/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.schema.mof
+++ b/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.schema.mof
@@ -9,7 +9,7 @@ class MSFT_xServiceResource : OMI_BaseResource
   [write,Description("Indicates the sign-in account to use for the service."),ValueMap{"LocalSystem", "LocalService", "NetworkService"},Values{"LocalSystem", "LocalService", "NetworkService"}] string BuiltInAccount;
   [write,Description("The credential to run the service under."),EmbeddedInstance("MSFT_Credential")] string Credential;
   [Write,Description("The service can create or communicate with a window on the desktop. Must be false for services not running as LocalSystem. Defaults to False.")] boolean DesktopInteract;
-  [write,Description("Indicates the state you want to ensure for the service. Defaults to Running."),ValueMap{"Running", "Stopped"},Values{"Running", "Stopped"}] string State;
+  [write,Description("Indicates the state you want to ensure for the service. Defaults to Running. An empty string means ignore the current state."),ValueMap{"Running", "Stopped", ""},Values{"Running", "Stopped", ""}] string State;
   [write,Description("The display name of the service.")] string DisplayName;
   [write,Description("The description of the service.")] string Description;
   [write,Description("An array of strings indicating the names of the dependencies of the service.")] string Dependencies[];

--- a/Tests/Unit/MSFT_xServiceResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xServiceResource.Tests.ps1
@@ -773,6 +773,52 @@ try
             }
         }
 
+        Describe "$DSCResourceName\Test-EmptyState" {
+            Context 'Service does not exist, but should as stopped, updating StartupType without State should not start the service' {
+                BeforeAll {
+                    #if (Get-Service -Name $script:splatServiceExistsAutomatic.Name)
+                    #{
+                    #    Stop-Service -Name $script:splatServiceExistsAutomatic.Name
+                    #}
+                    $Splat = $script:splatServiceExistsAutomatic.Clone()
+                    $Splat.Ensure = "Absent"
+                    Set-TargetResource @Splat -Verbose
+                }
+
+                It 'Should not throw an exception while making sure the service exists' {
+                    $Splat = $script:splatServiceExistsAutomatic.Clone()
+                    $Splat.StartupType = "Manual"
+                    $Splat.State = "Stopped"
+                    { Set-TargetResource @Splat -Verbose } | Should not Throw
+                }
+                
+                It 'Should exist' {
+                    $script:CurrentTestServices = Get-Service -Name $script:splatServiceExistsAutomatic.Name
+                    $script:CurrentTestServices.Count | Should be 1
+                }
+                
+                It 'Should be stopped' {
+                    $script:CurrentTestServices.Status | Should be 'Stopped'
+                }
+
+                It 'Should not throw an exception while updating service the StartupType' {
+                    $Splat = $script:splatServiceExistsAutomatic.Clone()
+                    $Splat.StartupType = "Disabled"
+                    $Splat.State = ""
+                    { Set-TargetResource @Splat -Verbose } | Should not Throw
+                }
+
+                It 'Should still exist' {
+                    $script:CurrentTestServices = Get-Service -Name $script:splatServiceExistsAutomatic.Name
+                    $script:CurrentTestServices.Count | Should be 1
+                }
+
+                It 'Should still be stopped' {
+                    $script:CurrentTestServices.Status | Should be 'Stopped'
+                }
+            }
+        }
+
         Describe "$DSCResourceName\Test-StartupType" {
             Context 'Service is stopped, startup is automatic' {
                 $errorRecord = Get-InvalidArgumentError `


### PR DESCRIPTION
Added a *don't care* state to `xService` resource. Providing an empty string now means ignore the current state. This value is used in `Test-TargetResource` and `Set-TargetResource` functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/241)
<!-- Reviewable:end -->
