### PR TITLE
xWindowsOptionalFeature: Fix tests for running on Nano Server

### DIFF
--- a/DSCResources/MSFT_xWindowsOptionalFeature/MSFT_xWindowsOptionalFeature.psm1
+++ b/DSCResources/MSFT_xWindowsOptionalFeature/MSFT_xWindowsOptionalFeature.psm1
@@ -344,7 +344,7 @@ function Convert-FeatureStateToEnsure
         target machine.
 
         Current prerequisites are:
-            - Must be running either a Windows client or at least Windows Server 2012
+            - Must be running either a Windows client, at least Windows Server 2012, or Nano Server
             - Must be running as an administrator
             - The DISM PowerShell module must be available for import
 #>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **xWindowsOptionalFeature** provides a mechanism to enable or disable optional features on a target node.
 * **xWindowsOptionalFeatureSet** allows installation and uninstallation of a group of optional Windows features.
 
+Resources that work on Nano Server:
+
+* xWindowsOptionalFeature
+
 ### xArchive
 
 * **Destination**: (Key) Specifies the location where you want to ensure the archive contents are extracted.
@@ -292,10 +296,11 @@ These parameters will be the same for each Windows feature in the set. Please re
 
 ### xWindowsOptionalFeature
 Provides a mechanism to enable or disable optional features on a target node.
+This resource works on Nano Server.
 
 #### Requirements
 
-* Target machine must be running either a Windows client operating system or Windows Server 2012 or later.
+* Target machine must be running a Windows client operating system, Windows Server 2012 or later, or Nano Server.
 * Target machine must have access to the DISM PowerShell module
 
 #### Parameters


### PR DESCRIPTION
I ran the WindowsOptionalFeature tests on Nano Server. There seems to be a bug in Pester on Nano Server involving previously mocked functions that do not have any parameters.

The work-around for this was just to move the problematic test to the beginning of the test file so that the function is not previously mocked.

All unit and integration tests passed.
WOF is now confirmed working on Nano Server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/243)
<!-- Reviewable:end -->
