### PR TITLE
Updating commands to use -LiteralPath instead of -Path (Fixes #255)

### DIFF
--- a/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
+++ b/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
@@ -173,7 +173,7 @@ function Set-TargetResource
 
         Write-Verbose -Message $LocalizedData.ConfigurationStarted
 
-        if (-not (Test-Path -Path $Destination))
+        if (-not (Test-Path -LiteralPath $Destination))
         {
             New-Item -Path $Destination -ItemType Directory | Out-Null
         }
@@ -245,7 +245,7 @@ function Set-TargetResource
                 if (-not $Checksum -and $PSCmdlet.ShouldProcess(($LocalizedData.RemoveFile -f $archiveEntryDestinationPath), $null, $null))
                 {
                     Write-Verbose -Message ($LocalizedData.RemovingDir -f $archiveEntryDestinationPath)
-                    Remove-Item -Path $archiveEntryDestinationPath
+                    Remove-Item -LiteralPath $archiveEntryDestinationPath
                     continue
                 }
 
@@ -254,7 +254,7 @@ function Set-TargetResource
                     if ((Test-FileHashMatchesArchiveEntryHash -FilePath $archiveEntryDestinationPath -ArchiveEntry $archiveEntry -HashAlgorithmName $Checksum) -and $PSCmdlet.ShouldProcess(($LocalizedData.RemoveFile -f $archiveEntryDestinationPath), $null, $null))
                     {
                         Write-Verbose -Message ($LocalizedData.HashesOfExistingAndZipFilesMatchRemoving)
-                        Remove-Item -Path $archiveEntryDestinationPath
+                        Remove-Item -LiteralPath $archiveEntryDestinationPath
                     }
                     else
                     {
@@ -267,7 +267,7 @@ function Set-TargetResource
                     if ($relevantTimestamp.Equals($archiveEntry.LastWriteTime.DateTime) -and $PSCmdlet.ShouldProcess(($LocalizedData.RemoveFile -f $archiveEntryDestinationPath), $null, $null))
                     {
                         Write-Verbose -Message ($LocalizedData.InSetTargetResourceexistsselectedtimestampmatched -f $archiveEntryDestinationPath, $Checksum)
-                        Remove-Item -Path $archiveEntryDestinationPath
+                        Remove-Item -LiteralPath $archiveEntryDestinationPath
                     }
                     else
                     {
@@ -296,7 +296,7 @@ function Set-TargetResource
                         -and $PSCmdlet.ShouldProcess(($LocalizedData.RemoveDirectory -f $fileInfoAtDestinationPath), $null, $null))
                 {
                     Write-Verbose -Message ($LocalizedData.ExistingaAppearsToBeAneEmptyDirectoryRemovingit -f $fileInfoAtDestinationPath)
-                    Remove-Item -Path $fileInfoAtDestinationPath
+                    Remove-Item -LiteralPath $fileInfoAtDestinationPath
                 }
             }
 
@@ -388,7 +388,7 @@ function Set-TargetResource
 
                         if ($PSCmdlet.ShouldProcess(($LocalizedData.RemoveDirectory -f $archiveEntryDestinationPath), $null, $null))
                         {
-                            Remove-Item -Path $archiveEntryDestinationPath -Recurse -Force | Out-Null
+                            Remove-Item -LiteralPath $archiveEntryDestinationPath -Recurse -Force | Out-Null
                         }
                     }
                     else
@@ -400,7 +400,7 @@ function Set-TargetResource
             }
 
             $archiveEntryDestinationParentPath = Split-Path -Path $archiveEntryDestinationPath
-            if (-not (Test-Path $archiveEntryDestinationParentPath) -and $PSCmdlet.ShouldProcess(($LocalizedData.MakeDirectory -f $archiveEntryDestinationParentPath), $null, $null))
+            if (-not (Test-Path -LiteralPath $archiveEntryDestinationParentPath) -and $PSCmdlet.ShouldProcess(($LocalizedData.MakeDirectory -f $archiveEntryDestinationParentPath), $null, $null))
             {
                 <#
                         TODO: This is an edge case we need to revisit. We should be correctly handling wrong file types along
@@ -451,9 +451,9 @@ function Set-TargetResource
                     $updatedTimestamp = $archiveEntry.LastWriteTime.DateTime
                     $archiveEntry.ExistingItemTimestamp = $updatedTimestamp
 
-                    Set-ItemProperty -Path $archiveEntryDestinationPath -Name 'LastWriteTime' -Value $updatedTimestamp
-                    Set-ItemProperty -Path $archiveEntryDestinationPath -Name 'LastAccessTime' -Value $updatedTimestamp
-                    Set-ItemProperty -Path $archiveEntryDestinationPath -Name 'CreationTime' -Value $updatedTimestamp
+                    Set-ItemProperty -LiteralPath $archiveEntryDestinationPath -Name 'LastWriteTime' -Value $updatedTimestamp
+                    Set-ItemProperty -LiteralPath $archiveEntryDestinationPath -Name 'LastAccessTime' -Value $updatedTimestamp
+                    Set-ItemProperty -LiteralPath $archiveEntryDestinationPath -Name 'CreationTime' -Value $updatedTimestamp
                 }
             }
             finally
@@ -571,7 +571,7 @@ function Test-TargetResource
                 if ($archiveEntryDestinationPath.EndsWith('\'))
                 {
                     $archiveEntryDestinationPath = $archiveEntryDestinationPath.TrimEnd('\')
-                    if (-not (Test-Path -Path $archiveEntryDestinationPath -PathType Container))
+                    if (-not (Test-Path -LiteralPath $archiveEntryDestinationPath -PathType Container))
                     {
                         Write-Verbose ($LocalizedData.DestMissingOrIncorrectTypeReason -f $archiveEntryDestinationPath)
                         $individualResult = $result = $false
@@ -749,7 +749,7 @@ function Get-CacheEntry
     Write-Verbose -Message ($LocalizedData.UsingKeyToRetrieveHashValue -f $cacheEntryKey)
 
     $cacheEntryPath = Join-Path -Path $script:cacheLocation -ChildPath $cacheEntryKey
-    if (-not (Test-Path -Path $cacheEntryPath))
+    if (-not (Test-Path -LiteralPath $cacheEntryPath))
     {
         Write-Verbose -Message ($LocalizedData.NoCacheValueFound)
     }
@@ -758,7 +758,7 @@ function Get-CacheEntry
         # ErrorAction seems to have no affect on this exception, (see: https://microsoft.visualstudio.com/web/wi.aspx?pcguid=cb55739e-4afe-46a3-970f-1b49d8ee7564&id=1185735)
         try
         {
-            $cacheEntry = Import-CliXml -Path $cacheEntryPath
+            $cacheEntry = Import-CliXml -LiteralPath $cacheEntryPath
             Write-Verbose -Message ($LocalizedData.CacheValueFoundReturning -f $cacheEntry)
         }
         catch [System.Xml.XmlException]
@@ -805,12 +805,12 @@ function Set-CacheEntry
     $cacheEntryPath = Join-Path -Path $script:cacheLocation -ChildPath $cacheEntryKey
 
     Write-Verbose -Message ($LocalizedData.AboutToCacheValueInputObject -f $InputObject)
-    if (-not (Test-Path -Path $script:cacheLocation))
+    if (-not (Test-Path -LiteralPath $script:cacheLocation))
     {
         New-Item -Path $script:cacheLocation -ItemType Directory | Out-Null
     }
 
-    Export-CliXml -Path $cacheEntryPath -InputObject $InputObject
+    Export-CliXml -LiteralPath $cacheEntryPath -InputObject $InputObject
 }
 
 <#
@@ -833,7 +833,7 @@ function Assert-PathArgumentValid
 
     $ErrorActionPreference = 'Stop'
 
-    if (-not (Test-Path -Path $Path -PathType Leaf))
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf))
     {
         New-InvalidArgumentException -Message ($LocalizedData.InvalidSourcePath -f $Path) -ArgumentName 'Path'
     }
@@ -1090,7 +1090,7 @@ function Mount-NetworkPath
     $psDrive = $null
 
     # Mount the drive only if not accessible
-    if (Test-Path -Path $Path -ErrorAction Ignore)
+    if (Test-Path -LiteralPath $Path -ErrorAction Ignore)
     {
         Write-Verbose -Message  ($LocalizedData.PathPathIsAlreadyAccessiableNoMountNeeded -f $Path)
     }
@@ -1169,7 +1169,7 @@ function New-Directory
             if ($Force -and $PSCmdlet.ShouldProcess(($LocalizedData.RemoveFileAndRecreateAsDirectory -f $Path), $null, $null))
             {
                 Write-Verbose -Message ($LocalizedData.RemovingDir -f $Path)
-                Remove-Item -Path $Path | Out-Null
+                Remove-Item -LiteralPath $Path | Out-Null
                 New-Item -Path $Path -ItemType Directory | Out-Null
             }
             else

--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ None
     * Fixes null verbose log output error. This resolves issue [#224](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/224).
 * xDSCWebService
 	* Fixed issue where resource would fail to read redirection.config file. This resolves issue [#191] (https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/191)
+* xArchive
+	* Fixed issue where resource would throw exception when file name contains brackets. This resolves issue [#255](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/255).
 
 ### 5.0.0.0
 

--- a/Tests/Unit/MSFT_xArchive.TestHelper.psm1
+++ b/Tests/Unit/MSFT_xArchive.TestHelper.psm1
@@ -38,7 +38,7 @@ function ConvertTo-FileStructure
         {
             $newFilePath = Join-Path -Path $ParentPath -ChildPath $key
             New-Item -Path $newFilePath -ItemType File | Out-Null
-            Set-Content -Path $newFilePath -Value $ZipFileStructure[$key]
+            Set-Content -LiteralPath $newFilePath -Value $ZipFileStructure[$key]
         }
         else
         {

--- a/Tests/Unit/MSFT_xArchive.Tests.ps1
+++ b/Tests/Unit/MSFT_xArchive.Tests.ps1
@@ -273,7 +273,7 @@ try
                     $testPathResult = Test-Path -Path "$destinationDirectoryPath\Folder1\Folder12\Folder13\Folder14"
                     $testPathResult | Should Be $false
                 }
-
+                
                 It 'Should not remove an added file with Validate and any Checksum value specified'{
                     $zipFileName = 'ChecksumWithModifiedFile'
                     $fileToEditName = 'File1'
@@ -329,6 +329,19 @@ try
             }
 
             Context 'Test-TargetResource' {
+                It 'Should not throw when zip file contains wildcard characters' {
+                    $zipFileName = 'ReturnCorrectValue['
+
+                    $zipFileStructure = @{
+                        Folder1 = @{
+                            File1 = 'Fake file contents'
+                        }
+                    }
+
+                    $zipFilePath = New-ZipFileFromHashtable -Name $zipFileName -ParentPath $script:currentTestDirectoryPath -ZipFileStructure $zipFileStructure
+
+                    { Test-TargetResource -Ensure 'Present' -Path $zipFilePath -Destination $script:currentTestDirectoryPath } | Should not throw
+                }
                 It 'Should return correct value based on presence or absence of an archive at the given location' {
                     $zipFileName = 'ReturnCorrectValue'
 


### PR DESCRIPTION
I guess this is second part of the fix I did in the past for Get-Item.
This time I'm adding -LiteralPath instead of -Path to fix some issues I've observed when either zip or one of the files inside zip have a name that looks like wildcard pattern (or worse - not complete wildcard path). Example of such path is `[.exe` that is a part of [gnu utils for win32](http://gnuwin32.sourceforge.net/packages/coreutils.htm).

I've added test for that issue (only for the file name - was not able to repro inside pester test behavior I've observed when running in context of DSC).

I also had to update helper module for the very same reason - initially test was failing because helper function was not able to create a file with bracket in the name.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/256)

<!-- Reviewable:end -->
