### PR TITLE
Fixes Issue #257: Changed call to Get-WmiObject to be Get-CimInstance to be compatibile…

### DIFF
--- a/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
+++ b/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
@@ -485,7 +485,7 @@ function ValidatePrerequisites
     $standardServerCore = 13
     $EnterpriseServerCore = 14
 
-    $operatingSystem = Get-WmiObject -Class Win32_operatingsystem
+    $operatingSystem = Get-CimInstance -Class Win32_operatingsystem
     if($operatingSystem.Version.StartsWith('6.1.') -and
         (($operatingSystem.OperatingSystemSKU -eq $datacenterServerCore) -or ($operatingSystem.OperatingSystemSKU -eq $standardServerCore) -or ($operatingSystem.OperatingSystemSKU -eq $EnterpriseServerCore)))
     {


### PR DESCRIPTION
… with Windows Nano.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/258)
<!-- Reviewable:end -->
