### PR TITLE
xWindowsFeature: Added catch for RuntimeException to ignore and updated tests (Fixes #69).

### DIFF
--- a/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
+++ b/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
@@ -357,7 +357,7 @@ function Test-TargetResource
     Write-Verbose -Message ($script:localizedData.TestTargetResourceStartMessage -f $Name)
     
     Import-ServerManager
-    
+
     $testTargetResourceResult = $false
 
     $getWindowsFeatureParameters = @{
@@ -515,7 +515,19 @@ function Import-ServerManager
 
     try
     {
-        Import-Module -Name 'ServerManager'
+        Import-Module -Name 'ServerManager' -ErrorAction Stop
+    }
+    
+    catch [System.Management.Automation.RuntimeException] {
+        if ($_.Exception.Message -like "*Some or all identity references could not be translated*")
+        {
+            Write-Verbose $_.Exception.Message
+        }
+        else
+        {
+            Write-Verbose -Message $script:localizedData.ServerManagerModuleNotFoundMessage
+            New-InvalidOperationException -Message $script:localizedData.SkuNotSupported
+        }
     }
     catch
     {

--- a/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
+++ b/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
@@ -517,7 +517,6 @@ function Import-ServerManager
     {
         Import-Module -Name 'ServerManager' -ErrorAction Stop
     }
-    
     catch [System.Management.Automation.RuntimeException] {
         if ($_.Exception.Message -like "*Some or all identity references could not be translated*")
         {

--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ None
 
 ### Unreleased
 
+* xWindowsFeature:
+    * Added Catch to ignore RuntimeException when importing ServerManager module. This resolves issue [#69](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/69).
+    * Updated unit tests.
+
 ### 5.0.0.0
 
 * xWindowsFeature:

--- a/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
@@ -575,8 +575,6 @@ try {
                 Version = '6.1.'
                 OperatingSystemSKU = 10
             }
-            $mockIdentityReferenceRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Some or all identity references could not be translated'
-            $mockOtherRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Other error'
             Mock -CommandName Get-WmiObject -MockWith { return $mockOperatingSystem }
 
             It 'Should Not Throw' {
@@ -585,13 +583,15 @@ try {
             }
             
             It 'Should Not Throw when exception is Identity Reference Runtime Exception' {
-                Mock -CommandName Import-Module -MockWith { Throw $mockIdentityReferenceRuntimeException}
+                $mockIdentityReferenceRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Some or all identity references could not be translated'
+                Mock -CommandName Import-Module -MockWith { Throw $mockIdentityReferenceRuntimeException }
 
                 { Import-ServerManager } | Should Not Throw
             }
             
             It 'Should throw invalid operation exception when exception is not Identity Reference Runtime Exception' {
-                Mock -CommandName Import-Module -MockWith { Throw $mockOtherRuntimeException}
+                $mockOtherRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Other error'
+                Mock -CommandName Import-Module -MockWith { Throw $mockOtherRuntimeException }
 
                 { Import-ServerManager } | Should Throw ($script:localizedData.SkuNotSupported)
             }

--- a/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
@@ -575,11 +575,25 @@ try {
                 Version = '6.1.'
                 OperatingSystemSKU = 10
             }
+            $mockIdentityReferenceRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Some or all identity references could not be translated'
+            $mockOtherRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Other error'
             Mock -CommandName Get-WmiObject -MockWith { return $mockOperatingSystem }
 
             It 'Should Not Throw' {
                 Mock -CommandName Import-Module -MockWith {}
                 { Import-ServerManager } | Should Not Throw
+            }
+            
+            It 'Should Not Throw when exception is Identity Reference Runtime Exception' {
+                Mock -CommandName Import-Module -MockWith { Throw $mockIdentityReferenceRuntimeException}
+
+                { Import-ServerManager } | Should Not Throw
+            }
+            
+            It 'Should throw invalid operation exception when exception is not Identity Reference Runtime Exception' {
+                Mock -CommandName Import-Module -MockWith { Throw $mockOtherRuntimeException}
+
+                { Import-ServerManager } | Should Throw ($script:localizedData.SkuNotSupported)
             }
 
             It 'Should throw invalid operation exception' {


### PR DESCRIPTION
Added a catch block in the **Import-ServerManager** function to ignore **System.Management.Automation.RuntimeException** exceptions when the exception message is **Some or all identity references could not be translated**.

This fixes [#69](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/69).

Also updated the unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/267)
<!-- Reviewable:end -->
