### PR TITLE
Removing compilation part from Sample_xDscWebServiceRegistration

### DIFF
--- a/Examples/Sample_xDscWebServiceRegistration.ps1
+++ b/Examples/Sample_xDscWebServiceRegistration.ps1
@@ -11,11 +11,6 @@
 
 # The Sample_MetaConfigurationToRegisterWithLessSecurePullServer register a DSC client node with the pull server
 
-# ======================================== Arguments ======================================== #
-$thumbprint = (New-SelfSignedCertificate -Subject "TestPullServer").Thumbprint
-$registrationkey = [guid]::NewGuid()
-# ======================================== Arguments ======================================== #
-
 # =================================== Section Pull Server =================================== #
 configuration Sample_xDscWebServiceRegistration
 {
@@ -66,7 +61,11 @@ configuration Sample_xDscWebServiceRegistration
     }
 }
 
-Sample_xDscWebServiceRegistration -RegistrationKey $registrationkey -certificateThumbPrint $thumbprint
+# Sample use (please change values of parameters according to your scenario):
+# $thumbprint = (New-SelfSignedCertificate -Subject "TestPullServer").Thumbprint
+# $registrationkey = [guid]::NewGuid()
+# Sample_xDscWebServiceRegistration -RegistrationKey $registrationkey -certificateThumbPrint $thumbprint
+
 # =================================== Section Pull Server =================================== #
 
 # =================================== Section DSC Client =================================== #
@@ -107,5 +106,7 @@ configuration Sample_MetaConfigurationToRegisterWithLessSecurePullServer
     }
 }
 
-Sample_MetaConfigurationToRegisterWithLessSecurePullServer -RegistrationKey $registrationkey
+# Sample use (please change values of parameters according to your scenario):
+# Sample_MetaConfigurationToRegisterWithLessSecurePullServer -RegistrationKey $registrationkey
+
 # =================================== Section DSC Client =================================== #


### PR DESCRIPTION
All examples should be usable without having to manually modify it. 
That means example should not compile the configuration with some sample values as this will likely fail.

I commented out the compilation and default value code but left it for reference.

We should do the same for the remaining examples (some are following this pattern, some don't). Doing it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/269)
<!-- Reviewable:end -->
