### PR TITLE
xPackage fixes and updates

### DIFF
--- a/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
+++ b/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
@@ -678,7 +678,7 @@ function Update-LocationTagInApplicationHostConfigForAuthentication
 
     [System.Reflection.Assembly]::LoadWithPartialName("Microsoft.Web.Administration") | Out-Null
 
-    $webAdminSrvMgr = new-object Microsoft.Web.Administration.ServerManager
+    $webAdminSrvMgr = [Microsoft.Web.Administration.ServerManager]::OpenRemote("127.0.0.1")
 
     $appHostConfig = $webAdminSrvMgr.GetApplicationHostConfiguration()
 

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -1045,7 +1045,7 @@ function Set-TargetResource
 
         [String]
         $InstalledCheckRegValueData,
-        
+
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.CredentialAttribute()]
         $RunAsCredential
@@ -1645,7 +1645,7 @@ function Assert-FileSignatureValid
 
     .DESCRIPTION
         Allows mocking and testing of process arguments.
-    
+
     .PARAMETER Process
         The System.Diagnositics.Process object to start.
 
@@ -1681,8 +1681,8 @@ function Invoke-Process
 <#
     .SYNOPSIS
         Runs a process as the specified user via PInvoke.
-    
-    .PARAMETER ProcessCommandLine
+
+    .PARAMETER CommandLine
         The command line (including arguments) of the process to start.
 
     .PARAMETER Credential

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -430,7 +430,10 @@ function Test-TargetResource
         $InstalledCheckRegValueName,
 
         [String]
-        $InstalledCheckRegValueData
+        $InstalledCheckRegValueData,
+
+        [PSCredential]
+        $RunAsCredential
     )
 
     Assert-PathExtensionValid -Path $Path
@@ -1041,7 +1044,11 @@ function Set-TargetResource
         $InstalledCheckRegValueName,
 
         [String]
-        $InstalledCheckRegValueData
+        $InstalledCheckRegValueData,
+        
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.CredentialAttribute()]
+        $RunAsCredential
     )
 
     $ErrorActionPreference = 'Stop'
@@ -1279,11 +1286,12 @@ function Set-TargetResource
                 $startInfo.Arguments += ' /log "{0}"' -f $LogPath
             }
 
-            $startInfo.Arguments += " /quiet"
+            $startInfo.Arguments += " /quiet /norestart"
 
             if ($Arguments)
             {
-                $startInfo.Arguments += "$Arguments"
+                # Append any specified arguments with a space (#195)
+                $startInfo.Arguments += ' {0}' -f $Arguments
             }
         }
         else
@@ -1330,7 +1338,8 @@ function Set-TargetResource
 
                 if ($Arguments)
                 {
-                    $startInfo.Arguments += "$Arguments"
+                    # Append the specified arguments with a space (#195)
+                    $startInfo.Arguments += ' {0}' -f $Arguments
                 }
             }
         }
@@ -1341,29 +1350,22 @@ function Set-TargetResource
         {
             try
             {
-                $exitCode = 0
-
-                $process.Start() | Out-Null
-
-                # Identical to $fileExtension -eq '.exe' -and $logPath
-                if ($logStream)
+                [int] $exitCode = 0
+                if($PSBoundParameters.ContainsKey('RunAsCredential'))
                 {
-                    $process.BeginOutputReadLine()
-                    $process.BeginErrorReadLine()
+                    $commandLine = '"{0}" {1}' -f $startInfo.FileName, $startInfo.Arguments
+                    $exitCode = Invoke-PInvoke -CommandLine $commandLine -Credential $RunAsCredential
                 }
-
-                $process.WaitForExit()
-
-                if ($process)
+                else
                 {
-                    $exitCode = $process.ExitCode
+                   $process = Invoke-Process -Process $process -LogStream ($null -ne $logStream)
+                   $exitCode = $process.ExitCode
                 }
             }
             catch
             {
                 New-InvalidOperationException -Message ($LocalizedData.CouldNotStartProcess -f $Path) -ErrorRecord $_
             }
-
 
             if ($logStream)
             {
@@ -1372,7 +1374,7 @@ function Set-TargetResource
                 #on the fly and executing it, but the former is highly problematic from PowerShell
                 #and the latter doesn't let us get the return code for UI-based EXEs
                 $outputEvents = Get-Event -SourceIdentifier $LogPath
-                $errorEvents = Get-Event -SourceIdentifier $errLogPath
+                $errorEvents = Get-Event -SourceIdentifier $errorLogPath
                 $masterEvents = @() + $outputEvents + $errorEvents
                 $masterEvents = $masterEvents | Sort-Object -Property TimeGenerated
 
@@ -1382,7 +1384,7 @@ function Set-TargetResource
                 }
 
                 Remove-Event -SourceIdentifier $LogPath
-                Remove-Event -SourceIdentifier $errLogPath
+                Remove-Event -SourceIdentifier $errorLogPath
             }
 
             if (-not ($ReturnCode -contains $exitCode))
@@ -1455,8 +1457,7 @@ function Set-TargetResource
         Write-Verbose $LocalizedData.MachineRequiresReboot
         $global:DSCMachineStatus = 1
     }
-
-    if ($Ensure -eq 'Present')
+    elseif ($Ensure -eq 'Present')
     {
         $getProductEntryParameters = @{
             Name = $Name
@@ -1636,6 +1637,403 @@ function Assert-FileSignatureValid
     {
         throw ($LocalizedData.WrongSignerThumbprint -f $Path, $Thumbprint)
     }
+}
+
+<#
+    .SYNOPSIS
+        Starts and waits for a process.
+
+    .DESCRIPTION
+        Allows mocking and testing of process arguments.
+    
+    .PARAMETER Process
+        The System.Diagnositics.Process object to start.
+
+    .PARAMETER LogStream
+        Redirect STDOUT and STDERR output.
+#>
+function Invoke-Process
+{
+    [CmdletBinding()]
+    [OutputType([System.Diagnostics.Process])]
+    param (
+        [Parameter(Mandatory)]
+        [System.Diagnostics.Process]
+        $Process,
+
+        [Parameter()]
+        [System.Boolean]
+        $LogStream
+    )
+
+    $Process.Start() | Out-Null
+
+    if ($LogStream)
+    {
+        $Process.BeginOutputReadLine()
+        $Process.BeginErrorReadLine()
+    }
+
+    $Process.WaitForExit()
+    return $Process
+}
+
+<#
+    .SYNOPSIS
+        Runs a process as the specified user via PInvoke.
+    
+    .PARAMETER ProcessCommandLine
+        The command line (including arguments) of the process to start.
+
+    .PARAMETER Credential
+        The user credential to start the process as.
+#>
+function Invoke-PInvoke
+{
+    [CmdletBinding()]
+    [OutputType([System.Int32])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $CommandLine,
+
+        [Parameter(Mandatory)]
+        [PSCredential]
+        [System.Management.Automation.CredentialAttribute()]
+        $Credential
+    )
+
+    Register-PInvoke
+    [System.Int32] $exitCode = 0
+
+    [Source.NativeMethods]::CreateProcessAsUser($CommandLine, `
+        $Credential.GetNetworkCredential().Domain, `
+        $Credential.GetNetworkCredential().UserName, `
+        $Credential.GetNetworkCredential().Password, `
+        [ref] $exitCode
+    )
+
+    return $exitCode;
+}
+
+<#
+    .SYNOPSIS
+        Registers PInvoke to run a process as a user.
+#>
+function Register-PInvoke
+{
+    $programSource = @'
+        using System;
+        using System.Collections.Generic;
+        using System.Text;
+        using System.Security;
+        using System.Runtime.InteropServices;
+        using System.Diagnostics;
+        using System.Security.Principal;
+        using System.ComponentModel;
+        using System.IO;
+
+        namespace Source
+        {
+            [SuppressUnmanagedCodeSecurity]
+            public static class NativeMethods
+            {
+                //The following structs and enums are used by the various Win32 API's that are used in the code below
+
+                [StructLayout(LayoutKind.Sequential)]
+                public struct STARTUPINFO
+                {
+                    public Int32 cb;
+                    public string lpReserved;
+                    public string lpDesktop;
+                    public string lpTitle;
+                    public Int32 dwX;
+                    public Int32 dwY;
+                    public Int32 dwXSize;
+                    public Int32 dwXCountChars;
+                    public Int32 dwYCountChars;
+                    public Int32 dwFillAttribute;
+                    public Int32 dwFlags;
+                    public Int16 wShowWindow;
+                    public Int16 cbReserved2;
+                    public IntPtr lpReserved2;
+                    public IntPtr hStdInput;
+                    public IntPtr hStdOutput;
+                    public IntPtr hStdError;
+                }
+
+                [StructLayout(LayoutKind.Sequential)]
+                public struct PROCESS_INFORMATION
+                {
+                    public IntPtr hProcess;
+                    public IntPtr hThread;
+                    public Int32 dwProcessID;
+                    public Int32 dwThreadID;
+                }
+
+                [Flags]
+                public enum LogonType
+                {
+                    LOGON32_LOGON_INTERACTIVE = 2,
+                    LOGON32_LOGON_NETWORK = 3,
+                    LOGON32_LOGON_BATCH = 4,
+                    LOGON32_LOGON_SERVICE = 5,
+                    LOGON32_LOGON_UNLOCK = 7,
+                    LOGON32_LOGON_NETWORK_CLEARTEXT = 8,
+                    LOGON32_LOGON_NEW_CREDENTIALS = 9
+                }
+
+                [Flags]
+                public enum LogonProvider
+                {
+                    LOGON32_PROVIDER_DEFAULT = 0,
+                    LOGON32_PROVIDER_WINNT35,
+                    LOGON32_PROVIDER_WINNT40,
+                    LOGON32_PROVIDER_WINNT50
+                }
+                [StructLayout(LayoutKind.Sequential)]
+                public struct SECURITY_ATTRIBUTES
+                {
+                    public Int32 Length;
+                    public IntPtr lpSecurityDescriptor;
+                    public bool bInheritHandle;
+                }
+
+                public enum SECURITY_IMPERSONATION_LEVEL
+                {
+                    SecurityAnonymous,
+                    SecurityIdentification,
+                    SecurityImpersonation,
+                    SecurityDelegation
+                }
+
+                public enum TOKEN_TYPE
+                {
+                    TokenPrimary = 1,
+                    TokenImpersonation
+                }
+
+                [StructLayout(LayoutKind.Sequential, Pack = 1)]
+                internal struct TokPriv1Luid
+                {
+                    public int Count;
+                    public long Luid;
+                    public int Attr;
+                }
+
+                public const int GENERIC_ALL_ACCESS = 0x10000000;
+                public const int CREATE_NO_WINDOW = 0x08000000;
+                internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
+                internal const int TOKEN_QUERY = 0x00000008;
+                internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
+                internal const string SE_INCRASE_QUOTA = "SeIncreaseQuotaPrivilege";
+
+                [DllImport("kernel32.dll",
+                    EntryPoint = "CloseHandle", SetLastError = true,
+                    CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall)]
+                public static extern bool CloseHandle(IntPtr handle);
+
+                [DllImport("advapi32.dll",
+                    EntryPoint = "CreateProcessAsUser", SetLastError = true,
+                    CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
+                public static extern bool CreateProcessAsUser(
+                    IntPtr hToken,
+                    string lpApplicationName,
+                    string lpCommandLine,
+                    ref SECURITY_ATTRIBUTES lpProcessAttributes,
+                    ref SECURITY_ATTRIBUTES lpThreadAttributes,
+                    bool bInheritHandle,
+                    Int32 dwCreationFlags,
+                    IntPtr lpEnvrionment,
+                    string lpCurrentDirectory,
+                    ref STARTUPINFO lpStartupInfo,
+                    ref PROCESS_INFORMATION lpProcessInformation
+                    );
+
+                [DllImport("advapi32.dll", EntryPoint = "DuplicateTokenEx")]
+                public static extern bool DuplicateTokenEx(
+                    IntPtr hExistingToken,
+                    Int32 dwDesiredAccess,
+                    ref SECURITY_ATTRIBUTES lpThreadAttributes,
+                    Int32 ImpersonationLevel,
+                    Int32 dwTokenType,
+                    ref IntPtr phNewToken
+                    );
+
+                [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+                public static extern Boolean LogonUser(
+                    String lpszUserName,
+                    String lpszDomain,
+                    String lpszPassword,
+                    LogonType dwLogonType,
+                    LogonProvider dwLogonProvider,
+                    out IntPtr phToken
+                    );
+
+                [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+                internal static extern bool AdjustTokenPrivileges(
+                    IntPtr htok,
+                    bool disall,
+                    ref TokPriv1Luid newst,
+                    int len,
+                    IntPtr prev,
+                    IntPtr relen
+                    );
+
+                [DllImport("kernel32.dll", ExactSpelling = true)]
+                internal static extern IntPtr GetCurrentProcess();
+
+                [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+                internal static extern bool OpenProcessToken(
+                    IntPtr h,
+                    int acc,
+                    ref IntPtr phtok
+                    );
+
+                [DllImport("kernel32.dll", ExactSpelling = true)]
+                internal static extern int WaitForSingleObject(
+                    IntPtr h,
+                    int milliseconds
+                    );
+
+                [DllImport("kernel32.dll", ExactSpelling = true)]
+                internal static extern bool GetExitCodeProcess(
+                    IntPtr h,
+                    out int exitcode
+                    );
+
+                [DllImport("advapi32.dll", SetLastError = true)]
+                internal static extern bool LookupPrivilegeValue(
+                    string host,
+                    string name,
+                    ref long pluid
+                    );
+
+                public static void CreateProcessAsUser(string strCommand, string strDomain, string strName, string strPassword, ref int ExitCode )
+                {
+                    var hToken = IntPtr.Zero;
+                    var hDupedToken = IntPtr.Zero;
+                    TokPriv1Luid tp;
+                    var pi = new PROCESS_INFORMATION();
+                    var sa = new SECURITY_ATTRIBUTES();
+                    sa.Length = Marshal.SizeOf(sa);
+                    Boolean bResult = false;
+                    try
+                    {
+                        bResult = LogonUser(
+                            strName,
+                            strDomain,
+                            strPassword,
+                            LogonType.LOGON32_LOGON_BATCH,
+                            LogonProvider.LOGON32_PROVIDER_DEFAULT,
+                            out hToken
+                            );
+                        if (!bResult)
+                        {
+                            throw new Win32Exception("Logon error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+                        IntPtr hproc = GetCurrentProcess();
+                        IntPtr htok = IntPtr.Zero;
+                        bResult = OpenProcessToken(
+                                hproc,
+                                TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+                                ref htok
+                            );
+                        if(!bResult)
+                        {
+                            throw new Win32Exception("Open process token error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+                        tp.Count = 1;
+                        tp.Luid = 0;
+                        tp.Attr = SE_PRIVILEGE_ENABLED;
+                        bResult = LookupPrivilegeValue(
+                            null,
+                            SE_INCRASE_QUOTA,
+                            ref tp.Luid
+                            );
+                        if(!bResult)
+                        {
+                            throw new Win32Exception("Lookup privilege error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+                        bResult = AdjustTokenPrivileges(
+                            htok,
+                            false,
+                            ref tp,
+                            0,
+                            IntPtr.Zero,
+                            IntPtr.Zero
+                            );
+                        if(!bResult)
+                        {
+                            throw new Win32Exception("Token elevation error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+
+                        bResult = DuplicateTokenEx(
+                            hToken,
+                            GENERIC_ALL_ACCESS,
+                            ref sa,
+                            (int)SECURITY_IMPERSONATION_LEVEL.SecurityIdentification,
+                            (int)TOKEN_TYPE.TokenPrimary,
+                            ref hDupedToken
+                            );
+                        if(!bResult)
+                        {
+                            throw new Win32Exception("Duplicate Token error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+                        var si = new STARTUPINFO();
+                        si.cb = Marshal.SizeOf(si);
+                        si.lpDesktop = "";
+                        bResult = CreateProcessAsUser(
+                            hDupedToken,
+                            null,
+                            strCommand,
+                            ref sa,
+                            ref sa,
+                            false,
+                            0,
+                            IntPtr.Zero,
+                            null,
+                            ref si,
+                            ref pi
+                            );
+                        if(!bResult)
+                        {
+                            throw new Win32Exception("Create process as user error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+
+                        int status = WaitForSingleObject(pi.hProcess, -1);
+                        if(status == -1)
+                        {
+                            throw new Win32Exception("Wait during create process failed user error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+
+                        bResult = GetExitCodeProcess(pi.hProcess, out ExitCode);
+                        if(!bResult)
+                        {
+                            throw new Win32Exception("Retrieving status error #" + Marshal.GetLastWin32Error().ToString());
+                        }
+                    }
+                    finally
+                    {
+                        if (pi.hThread != IntPtr.Zero)
+                        {
+                            CloseHandle(pi.hThread);
+                        }
+                        if (pi.hProcess != IntPtr.Zero)
+                        {
+                            CloseHandle(pi.hProcess);
+                        }
+                        if (hDupedToken != IntPtr.Zero)
+                        {
+                            CloseHandle(hDupedToken);
+                        }
+                    }
+                }
+            }
+        }
+'@
+    Add-Type -TypeDefinition $programSource -ReferencedAssemblies 'System.ServiceProcess'
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.schema.mof
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.schema.mof
@@ -25,4 +25,5 @@ class MSFT_xPackageResource : OMI_BaseResource
   [write] string InstalledCheckRegValueName;
   [write] string InstalledCheckRegValueData;
   [write] boolean CreateCheckRegValue;
+  [write,EmbeddedInstance("MSFT_Credential")] string RunAsCredential;
 };

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ None
 * **Path**: The source path of the package.
 * **ProductId**: The product ID of the package (usually a GUID).
 * **Arguments**: Command line arguments passed on the installation command line.
+    - When installing MSI packages, the `/quiet` and `/norestart` arguments are automatically applied.
 * **Credential**: PSCredential needed to access Path.
 * **ReturnCode**: An array of return codes that are returned after a successful installation.
 * **LogPath**: The destination path of the log.
@@ -172,6 +173,7 @@ None
 * **SignerSubject**: The certificate subject that should match that of the package file's signing certificate.
 * **SignerThumbprint**: The certificate thumbprint that should match that of the package file's signing certificate.
 * **ServerCertificateValidationCallback**: A callback function to validate the server certificate.
+* **RunAsCredential**: Credential used to install the package on the local system.
 
 Read-Only Properties:
 * **PackageDescription**: A text description of the package being installed.
@@ -430,6 +432,11 @@ None
 * xWindowsFeature:
     * Added Catch to ignore RuntimeException when importing ServerManager module. This resolves issue [#69](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/69).
     * Updated unit tests.
+* xPackage:
+    * No longer checks for package installation when a reboot is required. This resolves issue [#52](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/52).
+    * Ensures a space is added to MSI installation arguments. This resolves issue [#195](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/195).
+    * Adds RunAsCredential parameter to permit installing packages with specific user account. This resolves issue [#221](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/221).
+    * Fixes null verbose log output error. This resolves issue [#224](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/224).
 
 ### 5.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ None
     * Ensures a space is added to MSI installation arguments. This resolves issue [#195](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/195).
     * Adds RunAsCredential parameter to permit installing packages with specific user account. This resolves issue [#221](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/221).
     * Fixes null verbose log output error. This resolves issue [#224](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/224).
+* xDSCWebService
+	* Fixed issue where resource would fail to read redirection.config file. This resolves issue [#191] (https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/191)
 
 ### 5.0.0.0
 

--- a/Tests/Unit/MSFT_xPackageResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xPackageResource.Tests.ps1
@@ -26,6 +26,7 @@ try
 
                 $script:msiName = 'DSCSetupProject.msi'
                 $script:msiLocation = Join-Path -Path $script:testDirectoryPath -ChildPath $script:msiName
+                $script:msiArguments = '/NoReboot'
 
                 $script:packageName = 'DSCUnitTestPackage'
                 $script:packageId = '{deadbeef-80c6-41e6-a1b9-8bdb8a05027f}'
@@ -33,6 +34,7 @@ try
                 New-TestMsi -DestinationPath $script:msiLocation | Out-Null
 
                 $script:testExecutablePath = Join-Path -Path $script:testDirectoryPath -ChildPath 'TestExecutable.exe'
+                
                 New-TestExecutable -DestinationPath $script:testExecutablePath | Out-Null
 
                 Clear-xPackageCache | Out-Null
@@ -433,7 +435,7 @@ try
                     $msiUrl = "$baseUrl" + "package.msi"
                     New-MockFileServer -FilePath $script:msiLocation -Https
 
-                    # Test pipe connection as testing server readiness
+                    # Test pipe connection as testing server reasdiness
                     $pipe = New-Object -TypeName 'System.IO.Pipes.NamedPipeServerStream' -ArgumentList @( '\\.\pipe\dsctest1' )
                     $pipe.WaitForConnection()
                     $pipe.Dispose()
@@ -463,6 +465,53 @@ try
 
                     Test-Path -Path $logPath | Should Be $true
                     Get-Content -Path $logPath | Should Not Be $null
+                }
+
+                It 'Should add space after .MSI installation arguments (#195)' {
+                    Mock Invoke-Process -ParameterFilter { $Process.StartInfo.Arguments.EndsWith($script:msiArguments) } { return @{ ExitCode = 0 } }
+                    Mock Test-TargetResource { return $false }
+                    Mock Get-ProductEntry { return $script:packageId }
+                    
+                    $packageParameters = @{
+                        Path = $script:msiLocation
+                        Name = [String]::Empty
+                        ProductId = $script:packageId
+                        Arguments = $script:msiArguments
+                    }
+
+                    Set-TargetResource -Ensure 'Present' @packageParameters
+
+                    Assert-MockCalled Invoke-Process -ParameterFilter { $Process.StartInfo.Arguments.EndsWith(" $script:msiArguments") } -Scope It
+                }
+
+                It 'Should not check for product installation when rebooted is required (#52)' {
+                    Mock Invoke-Process { return [PSCustomObject] @{ ExitCode = 3010 } }
+                    Mock Test-TargetResource { return $false }
+                    Mock Get-ProductEntry { }
+                                        
+                    $packageParameters = @{
+                        Path = $script:msiLocation
+                        Name = [String]::Empty
+                        ProductId = $script:packageId
+                    }
+
+                    { Set-TargetResource -Ensure 'Present' @packageParameters } | Should Not Throw
+                }
+
+                It 'Should install package using user credentials when specified' {
+                    Mock Invoke-PInvoke { }
+                    Mock Test-TargetResource { return $false }
+
+                    $packageCredential = [System.Management.Automation.PSCredential]::Empty
+                    $packageParameters = @{
+                        Path = $script:msiLocation
+                        Name = [String]::Empty
+                        ProductId = $script:packageId
+                        RunAsCredential = $packageCredential
+                    }
+                    Set-TargetResource -Ensure 'Present' @packageParameters
+
+                    Assert-MockCalled Invoke-PInvoke -ParameterFilter { $Credential -eq $packageCredential} -Scope It
                 }
             }
 

--- a/Tests/Unit/MSFT_xPackageResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xPackageResource.Tests.ps1
@@ -19,10 +19,10 @@ try
 
                 if (Test-Path -Path $script:testDirectoryPath)
                 {
-                    Remove-Item -Path $script:testDirectoryPath -Recurse -Force | Out-Null
+                    $null = Remove-Item -Path $script:testDirectoryPath -Recurse -Force
                 }
 
-                New-Item -Path $script:testDirectoryPath -ItemType 'Directory' | Out-Null
+                $null = New-Item -Path $script:testDirectoryPath -ItemType 'Directory'
 
                 $script:msiName = 'DSCSetupProject.msi'
                 $script:msiLocation = Join-Path -Path $script:testDirectoryPath -ChildPath $script:msiName
@@ -31,22 +31,22 @@ try
                 $script:packageName = 'DSCUnitTestPackage'
                 $script:packageId = '{deadbeef-80c6-41e6-a1b9-8bdb8a05027f}'
 
-                New-TestMsi -DestinationPath $script:msiLocation | Out-Null
+                $null = New-TestMsi -DestinationPath $script:msiLocation
 
                 $script:testExecutablePath = Join-Path -Path $script:testDirectoryPath -ChildPath 'TestExecutable.exe'
-                
-                New-TestExecutable -DestinationPath $script:testExecutablePath | Out-Null
 
-                Clear-xPackageCache | Out-Null
+                $null = New-TestExecutable -DestinationPath $script:testExecutablePath
+
+                $null = Clear-xPackageCache
             }
 
             BeforeEach {
-                Clear-xPackageCache | Out-Null
+                $null = Clear-xPackageCache
 
                 if (Test-PackageInstalledByName -Name $script:packageName)
                 {
-                    Start-Process -FilePath 'msiexec.exe' -ArgumentList @("/x$script:packageId", '/passive') -Wait | Out-Null
-                    Start-Sleep -Seconds 1 | Out-Null
+                    $null = Start-Process -FilePath 'msiexec.exe' -ArgumentList @("/x$script:packageId", '/passive') -Wait
+                    $null = Start-Sleep -Seconds 1
                 }
 
                 if (Test-PackageInstalledByName -Name $script:packageName)
@@ -58,15 +58,15 @@ try
             AfterAll {
                 if (Test-Path -Path $script:testDirectoryPath)
                 {
-                    Remove-Item -Path $script:testDirectoryPath -Recurse -Force | Out-Null
+                    $null = Remove-Item -Path $script:testDirectoryPath -Recurse -Force
                 }
 
-                Clear-xPackageCache | Out-Null
+                $null = Clear-xPackageCache
 
                 if (Test-PackageInstalledByName -Name $script:packageName)
                 {
-                    Start-Process -FilePath 'msiexec.exe' -ArgumentList @("/x$script:packageId", '/passive') -Wait | Out-Null
-                    Start-Sleep -Seconds 1 | Out-Null
+                    $null = Start-Process -FilePath 'msiexec.exe' -ArgumentList @("/x$script:packageId", '/passive') -Wait
+                    $null = Start-Sleep -Seconds 1
                 }
 
                 if (Test-PackageInstalledByName -Name $script:packageName)
@@ -471,7 +471,7 @@ try
                     Mock Invoke-Process -ParameterFilter { $Process.StartInfo.Arguments.EndsWith($script:msiArguments) } { return @{ ExitCode = 0 } }
                     Mock Test-TargetResource { return $false }
                     Mock Get-ProductEntry { return $script:packageId }
-                    
+
                     $packageParameters = @{
                         Path = $script:msiLocation
                         Name = [String]::Empty
@@ -488,7 +488,7 @@ try
                     Mock Invoke-Process { return [PSCustomObject] @{ ExitCode = 3010 } }
                     Mock Test-TargetResource { return $false }
                     Mock Get-ProductEntry { }
-                                        
+
                     $packageParameters = @{
                         Path = $script:msiLocation
                         Name = [String]::Empty


### PR DESCRIPTION
xPackage:
* No longer checks for package installation when a reboot is required
  - Fixes #52 
* Ensures a space is added to MSI installation arguments
  - Fixes #195 
* Adds RunAsCredential parameter to permit installing packages with specific user account
  - Fixes #221 
* Fixes null verbose log output error
  - Fixes #224

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/278)
<!-- Reviewable:end -->
