### PR TITLE
Fix for issue #255

### DIFF
--- a/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
+++ b/DSCResources/MSFT_xArchive/MSFT_xArchive.psm1
@@ -833,7 +833,7 @@ function Assert-PathArgumentValid
 
     $ErrorActionPreference = 'Stop'
 
-    if (-not (Test-Path -Path $Path -PathType Leaf))
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf))
     {
         New-InvalidArgumentException -Message ($LocalizedData.InvalidSourcePath -f $Path) -ArgumentName 'Path'
     }


### PR DESCRIPTION
Quite a simple fix for issue #255 , changing parameter on Test-Path from -Path (which accepts regular expressions) to -LiteralPath (which doesn't accept regular expressions).

This will allow zip files to have regular expression syntax characters without causing an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/283)
<!-- Reviewable:end -->
