### PR TITLE
Updating xPackageResource

### DIFF
--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -397,6 +397,9 @@ function Test-TargetResource
         [UInt32[]]
         $ReturnCode = @( 0, 1641, 3010 ),
 
+        [Boolean]
+        $IsMSIPackage = $true,
+
         [String]
         $LogPath,
 
@@ -563,6 +566,9 @@ function Get-TargetResource
         [AllowEmptyString()]
         [String]
         $ProductId,
+
+        [Boolean]
+        $IsMSIPackage = $true,
 
         [Boolean]
         $CreateCheckRegValue = $false,
@@ -1011,6 +1017,9 @@ function Set-TargetResource
         [UInt32[]]
         $ReturnCode = @( 0, 1641, 3010 ),
 
+        [Boolean]
+        $IsMSIPackage = $true,
+
         [String]
         $LogPath,
 
@@ -1299,7 +1308,7 @@ function Set-TargetResource
             # EXE
             Write-Verbose -Message $LocalizedData.TheBinaryIsAnExe
 
-            if ($Ensure -eq 'Present')
+            if ($Ensure -eq 'Present' -or !$IsMSIPackage)
             {
                 $startInfo.FileName = $Path
                 $startInfo.Arguments = $Arguments
@@ -1636,7 +1645,7 @@ function Assert-FileSignatureValid
     if ($null -ne $Thumbprint -and ($signature.SignerCertificate.Thumbprint -ne $Thumbprint))
     {
         throw ($LocalizedData.WrongSignerThumbprint -f $Path, $Thumbprint)
-    }
+    } 
 }
 
 <#

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.schema.mof
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.schema.mof
@@ -9,6 +9,7 @@ class MSFT_xPackageResource : OMI_BaseResource
   [write,EmbeddedInstance("MSFT_Credential")] string Credential;
   [write] uint32 ReturnCode[];
   [write] string LogPath;
+  [write] boolean IsMSIPackage;
   [read] string PackageDescription;
   [read] string Publisher;
   [read] string InstalledOn;

--- a/Tests/Unit/MSFT_xPackageResource.TestHelper.psm1
+++ b/Tests/Unit/MSFT_xPackageResource.TestHelper.psm1
@@ -198,11 +198,17 @@ function New-TestExecutable
                 string self = cmdline.Substring(0, endIndex);
                 string other = cmdline.Substring(self.Length + 1);
                 string msiexecpath = System.IO.Path.Combine(System.Environment.SystemDirectory, "msiexec.exe");
+                
+                var arguments = new List<string>((string[])args);
 
                 self = self.Replace("\"", "");
                 string packagePath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(self), "DSCSetupProject.msi");
-
-                string msiexecargs = String.Format("/i {0} {1}", packagePath, other);
+                
+                if (arguments.Contains("/remove"))
+                {
+                    arguments.Remove("/remove");
+                }
+                string msiexecargs = String.Format("/i {0} {1}", packagePath, String.Join(" ", arguments));
                 System.Diagnostics.Process.Start(msiexecpath, msiexecargs).WaitForExit();
             }
         }


### PR DESCRIPTION
There are two items here:

1. Adding a ` $IsMSIPackage` parameter to xPackageResource. Setting this parameter to `$false` explicitly uses the EXE file and provided arguments to install/uninstall the package.

2. Updated the test EXE and added a `/remove` option to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/298)
<!-- Reviewable:end -->
