### PR TITLE
[#285] DSC - xRegistry support for '/' in key names

### DIFF
--- a/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
+++ b/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
@@ -994,8 +994,10 @@ function New-RegistryKey
         $RegistryKeyPath
     )
 
-    $parentRegistryKeyPath = Split-Path -Path $RegistryKeyPath -Parent
-    $newRegistryKeyName = Split-Path -Path $RegistryKeyPath -Leaf
+    # registry key names can contain forward slashes, so we can't use Split-Path here (it will split on /)
+    $lastSep = $RegistryKeyPath.LastIndexOf('\')
+    $parentRegistryKeyPath = $RegistryKeyPath.Substring(0, $lastSep)
+    $newRegistryKeyName = $RegistryKeyPath.Substring($lastSep + 1)
 
     $parentRegistryKey = Get-RegistryKey -RegistryKeyPath $parentRegistryKeyPath -WriteAccessAllowed
 

--- a/README.md
+++ b/README.md
@@ -558,6 +558,9 @@ None
 
 ### Unreleased
 
+* xRegistry:
+    * Added support for forward slashes in registry key names. This resolves issue [#285](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/285).
+
 ### 5.1.0.0
 
 * xWindowsFeature:


### PR DESCRIPTION
Replaced usages of Split-Path in New-RegistryKey with String.LastIndexOf
and String.Substring, splitting registry paths on backslash only.