### PR TITLE
fixing error handling in xUser Fixes #322

### DIFF
--- a/DSCResources/MSFT_xUserResource/MSFT_xUserResource.psm1
+++ b/DSCResources/MSFT_xUserResource/MSFT_xUserResource.psm1
@@ -379,7 +379,15 @@ function Set-TargetResourceOnFullSKU
 
     try
     {
-        $user = [System.DirectoryServices.AccountManagement.UserPrincipal]::FindByIdentity($principalContext, $UserName)
+        try
+        {
+            $user = [System.DirectoryServices.AccountManagement.UserPrincipal]::FindByIdentity($principalContext, $UserName)
+        }
+        catch
+        {
+             New-InvalidOperationException -Message ($script:localizedData.MultipleMatches + $_)
+        }
+
         if ($Ensure -eq 'Present')
         {
             $whatIfShouldProcess = $true
@@ -511,7 +519,7 @@ function Set-TargetResourceOnFullSKU
     }
     catch
     {
-         New-InvalidOperationException -Message ($script:localizedData.MultipleMatches + $_)
+         New-InvalidOperationException -Message $_
     }
     finally
     {

--- a/README.md
+++ b/README.md
@@ -570,7 +570,11 @@ None
 
 ### Unreleased
 
+
 * Moved DSC pull server setup tests to DSCPullServerSetup folder for new common tests
+
+* xUser
+    * Fixed error handling in xUser
 
 ### 6.0.0.0
 


### PR DESCRIPTION
Narrowing scope to when the 'MultipleMatches' error is thrown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/323)
<!-- Reviewable:end -->
