### PR TITLE
xRegistry: Fix Get-DSCConfiguration (Fixes #304)

### DIFF
--- a/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
+++ b/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
@@ -107,7 +107,7 @@ function Get-TargetResource
                 $actualValueType = Get-RegistryKeyValueType -RegistryKey $registryKey -RegistryKeyValueName $ValueName
 
                 # If the registry key value exists, convert it to a readable string
-                $registryKeyValueAsReadableString = ConvertTo-ReadableString -RegistryKeyValue $registryKeyValue -RegistryKeyValueType $actualValueType
+                $registryKeyValueAsReadableString = @() + (ConvertTo-ReadableString -RegistryKeyValue $registryKeyValue -RegistryKeyValueType $actualValueType)
 
                 $registryResource['Ensure'] = 'Present'
                 $registryResource['ValueType'] = $actualValueType

--- a/README.md
+++ b/README.md
@@ -602,6 +602,8 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
     * Updated documentation and examples
 * xUser
     * Fixed error handling in xUser
+* xRegistry
+    * Fixed bug where an error was thrown when running Get-DscConfiguration if the registry key already existed
 
 ### 6.0.0.0
 

--- a/Tests/Integration/MSFT_xRegistryResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_xRegistryResource.EndToEnd.Tests.ps1
@@ -54,6 +54,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKey = Get-Item -Path $registryParameters.Key -ErrorAction 'SilentlyContinue'
 
             It 'Should have created the registry key' {
@@ -80,6 +84,10 @@ try
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
                 } | Should Not Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
@@ -114,6 +122,10 @@ try
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
                 } | Should Not Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
@@ -172,6 +184,10 @@ try
                     } | Should Not Throw
                 }
 
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                }
+
                 $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
                 It 'Should be able to retrieve the registry key value' {
@@ -209,6 +225,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should be able to retrieve the registry key value' {
@@ -241,6 +261,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
@@ -271,6 +295,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
@@ -297,6 +325,10 @@ try
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
                 } | Should Not Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
 
             $registryKey = Get-Item -Path $registryParameters.Key -ErrorAction 'SilentlyContinue'


### PR DESCRIPTION
Fixed a bug in which xRegistry would always throw an error when Get-DscConfiguration was called if the registry key already existed.

Also added tests to make sure Get-DscConfiguration works for xRegistry.

This fixes #304.
This is the same change as https://github.com/PowerShell/PSDscResources/pull/44.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/330)
<!-- Reviewable:end -->
