### PR TITLE
Fix Test-IsNanoServer to actually test for a NanoServer (Fixes #282)

### DIFF
--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -1,6 +1,6 @@
 ﻿<#
     .SYNOPSIS
-    Tests if the current machine is a Nano server.
+        Tests if the current machine is a Nano server.
 #>
 function Test-IsNanoServer
 {
@@ -8,7 +8,44 @@ function Test-IsNanoServer
     [CmdletBinding()]
     param ()
 
-    return $PSVersionTable.PSEdition -ieq 'Core'
+    $isNanoServer = $false
+    
+    if (Test-CommandExists -Name 'Get-ComputerInfo')
+    {
+        $computerInfo = Get-ComputerInfo
+
+        $computerIsServer = 'Server' -ieq $computerInfo.OsProductType
+
+        if ($computerIsServer)
+        {
+            $isNanoServer = 'NanoServer' -ieq $computerInfo.OsServerLevel
+        }
+    }
+
+    return $isNanoServer
+}
+
+<#
+    .SYNOPSIS
+        Tests whether or not the command with the specified name exists.
+
+    .PARAMETER Name
+        The name of the command to test for.
+#>
+function Test-CommandExists
+{
+    [OutputType([Boolean])]
+    [CmdletBinding()]
+    param 
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Name 
+    )
+
+    $command = Get-Command -Name $Name -ErrorAction 'SilentlyContinue'
+    return ($null -ne $command)
 }
 
 <#
@@ -37,11 +74,11 @@ function New-InvalidArgumentException
         $ArgumentName
     )
 
-    $argumentException = New-Object -TypeName 'ArgumentException' -ArgumentList @( $Message,
-        $ArgumentName )
+    $argumentException = New-Object -TypeName 'ArgumentException' `
+                                    -ArgumentList @($Message, $ArgumentName)
     $newObjectParams = @{
         TypeName = 'System.Management.Automation.ErrorRecord'
-        ArgumentList = @( $argumentException, $ArgumentName, 'InvalidArgument', $null )
+        ArgumentList = @($argumentException, $ArgumentName, 'InvalidArgument', $null)
     }
     $errorRecord = New-Object @newObjectParams
 
@@ -78,21 +115,21 @@ function New-InvalidOperationException
     }
     elseif ($null -eq $ErrorRecord)
     {
-        $invalidOperationException =
-            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message )
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' `
+                                                -ArgumentList @($Message)
     }
     else
     {
-        $invalidOperationException =
-            New-Object -TypeName 'InvalidOperationException' -ArgumentList @( $Message,
-                $ErrorRecord.Exception )
+        $invalidOperationException = New-Object -TypeName 'InvalidOperationException' `
+                                                -ArgumentList @($Message, $ErrorRecord.Exception)
     }
 
     $newObjectParams = @{
         TypeName = 'System.Management.Automation.ErrorRecord'
         ArgumentList = @( $invalidOperationException.ToString(), 'MachineStateIncorrect',
-            'InvalidOperation', $null )
+                          'InvalidOperation', $null )
     }
+
     $errorRecordToThrow = New-Object @newObjectParams
     throw $errorRecordToThrow
 }
@@ -104,11 +141,10 @@ function New-InvalidOperationException
 
     .PARAMETER ResourceName
         The name of the resource as it appears before '.strings.psd1' of the localized string file.
-
         For example:
-            For WindowsOptionalFeature: MSFT_xWindowsOptionalFeature
-            For Service: MSFT_xServiceResource
-            For Registry: MSFT_xRegistryResource
+            For xWindowsOptionalFeature: MSFT_xWindowsOptionalFeature
+            For xService: MSFT_xServiceResource
+            For xRegistry: MSFT_xRegistryResource
 #>
 function Get-LocalizedData
 {
@@ -121,7 +157,7 @@ function Get-LocalizedData
         $ResourceName
     )
 
-    $resourceDirectory = (Join-Path -Path $PSScriptRoot -ChildPath $ResourceName)
+    $resourceDirectory = Join-Path -Path $PSScriptRoot -ChildPath $ResourceName
     $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath $PSUICulture
 
     if (-not (Test-Path -Path $localizedStringFileLocation))

--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
     * Fixed error handling in xUser
 * xRegistry
     * Fixed bug where an error was thrown when running Get-DscConfiguration if the registry key already existed
+* Updated Test-IsNanoServer cmdlet to properly test for a Nano server rather than the core version of PowerShell
 
 ### 6.0.0.0
 

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -1,0 +1,181 @@
+﻿$errorActionPreference = 'Stop'
+Set-StrictMode -Version 'Latest'
+
+Describe 'CommonResourceHelper Unit Tests' {
+    BeforeAll {
+        # Import the CommonResourceHelper module to test
+        $testsFolderFilePath = Split-Path -Path $PSScriptRoot -Parent
+        $moduleRootFilePath = Split-Path -Path $testsFolderFilePath -Parent
+        $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
+        $commonResourceHelperFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'CommonResourceHelper.psm1'
+        Import-Module -Name $commonResourceHelperFilePath
+    }
+
+    InModuleScope 'CommonResourceHelper' {
+        # Declaring the function Get-ComputerInfo if we are testing on a machine with an older WMF
+        if ($null -eq (Get-Command -Name 'Get-ComputerInfo' -ErrorAction 'SilentlyContinue'))
+        {
+            function Get-ComputerInfo {}
+        }
+
+        Describe 'Test-IsNanoServer' {
+            $testComputerInfoNanoServer = @{
+                OsProductType = 'Server'
+                OsServerLevel = 'NanoServer'
+            }
+
+            $testComputerInfoServerNotNano = @{
+                OsProductType = 'Server'
+                OsServerLevel = 'NotNano'
+            }
+
+            $testComputerInfoNotServer = @{
+                OsProductType = 'NotServer'
+                OsServerLevel = 'NotNano'
+            }
+
+            Mock -CommandName 'Test-CommandExists' -MockWith { return $true }
+            Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoNanoServer }
+
+            Context 'Get-ComputerInfo command exists' {
+                Context 'Computer OS type is Server and OS server level is NanoServer' {
+                    It 'Should not throw' {
+                        { $null = Test-IsNanoServer } | Should Not Throw
+                    }
+
+                    It 'Should test if the Get-ComputerInfo command exists' {
+                        $testCommandExistsParameterFilter = {
+                            return $Name -eq 'Get-ComputerInfo'
+                        }
+
+                        Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should retrieve the computer info' {
+                        Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should return true' {
+                        Test-IsNanoServer | Should Be $true
+                    }
+                }
+
+                Context 'Computer OS type is Server and OS server level is not NanoServer' {
+                    Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoServerNotNano }
+                    
+                    It 'Should not throw' {
+                        { $null = Test-IsNanoServer } | Should Not Throw
+                    }
+
+                    It 'Should test if the Get-ComputerInfo command exists' {
+                        $testCommandExistsParameterFilter = {
+                            return $Name -eq 'Get-ComputerInfo'
+                        }
+
+                        Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should retrieve the computer info' {
+                        Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should return false' {
+                        Test-IsNanoServer | Should Be $false
+                    }
+                }
+
+                Context 'Computer OS type is not Server' {
+                    Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoNotServer }
+
+                    It 'Should not throw' {
+                        { $null = Test-IsNanoServer } | Should Not Throw
+                    }
+
+                    It 'Should test if the Get-ComputerInfo command exists' {
+                        $testCommandExistsParameterFilter = {
+                            return $Name -eq 'Get-ComputerInfo'
+                        }
+
+                        Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should retrieve the computer info' {
+                        Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should return false' {
+                        Test-IsNanoServer | Should Be $false
+                    }
+                }
+            }
+
+            Context 'Get-ComputerInfo command does not exist' {
+                Mock -CommandName 'Test-CommandExists' -MockWith { return $false }
+
+                It 'Should not throw' {
+                    { $null = Test-IsNanoServer } | Should Not Throw
+                }
+
+                It 'Should test if the Get-ComputerInfo command exists' {
+                    $testCommandExistsParameterFilter = {
+                        return $Name -eq 'Get-ComputerInfo'
+                    }
+
+                    Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should not attempt to retrieve the computer info' {
+                    Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 0 -Scope 'Context'
+                }
+
+                It 'Should return false' {
+                    Test-IsNanoServer | Should Be $false
+                }
+            }
+        }
+
+        Describe 'Test-CommandExists' {
+            $testCommandName = 'TestCommandName'
+
+            Mock -CommandName 'Get-Command' -MockWith { return $Name }
+
+            Context 'Get-Command returns the command' {
+                It 'Should not throw' {
+                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                }
+
+                It 'Should retrieve the command with the specified name' {
+                    $getCommandParameterFilter = {
+                        return $Name -eq $testCommandName
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-Command' -ParameterFilter $getCommandParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should return true' {
+                    Test-CommandExists -Name $testCommandName | Should Be $true
+                }
+            }
+
+            Context 'Get-Command returns null' {
+                Mock -CommandName 'Get-Command' -MockWith { return $null }
+
+                It 'Should not throw' {
+                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                }
+
+                It 'Should retrieve the command with the specified name' {
+                    $getCommandParameterFilter = {
+                        return $Name -eq $testCommandName
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-Command' -ParameterFilter $getCommandParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should return false' {
+                    Test-CommandExists -Name $testCommandName | Should Be $false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have updated Test-IsNanoServer to correctly test for a Nano server rather than for the core version of PowerShell.

I have also added unit tests for both Test-IsNanoServer and the new common function Test-CommandExists.

This fixes #282 
These are the same changes as https://github.com/PowerShell/PSDscResources/pull/42

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/331)
<!-- Reviewable:end -->
