### PR TITLE
Added /preCondition:bitness32 when calling appCmd install module

### DIFF
--- a/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
+++ b/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.psm1
@@ -296,7 +296,7 @@ function Set-TargetResource
         Copy-Item "$pathPullServer\IISSelfSignedCertModule.dll" $env:windir\System32\inetsrv -Force
         Copy-Item "$env:windir\SysWOW64\WindowsPowerShell\v1.0\Modules\PSDesiredStateConfiguration\PullServer\IISSelfSignedCertModule.dll" $env:windir\SysWOW64\inetsrv -Force
 
-        & $script:appCmd install module /name:"IISSelfSignedCertModule(32bit)" /image:$env:windir\SysWOW64\inetsrv\IISSelfSignedCertModule.dll /add:false /lock:false
+        & $script:appCmd install module /name:"IISSelfSignedCertModule(32bit)" /image:$env:windir\SysWOW64\inetsrv\IISSelfSignedCertModule.dll /add:false /lock:false /preCondition:bitness32
         & $script:appCmd add module /name:"IISSelfSignedCertModule(32bit)"  /app.name:"PSDSCPullServer/"
     }
     else

--- a/README.md
+++ b/README.md
@@ -634,6 +634,8 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 ## Versions
 
 ### Unreleased
+* xDSCWebService
+    * Fixed an issue where all 64bit IIS application pools stop working after installing DSC Pull Server, because IISSelfSignedCertModule(32bit) module was registered without bitness32 precondition.
 
 ### 6.2.0.0
 


### PR DESCRIPTION
Added /preCondition:bitness32 when calling appCmd install module:"IISSelfSignedCertModule(32bit)"
This module breaks all 64bit app pools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/343)
<!-- Reviewable:end -->
