### PR TITLE
Update xGroup with changes from PSDscResources

### DIFF
--- a/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
+++ b/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
@@ -965,7 +965,7 @@ function Set-TargetResourceOnNanoServer
             }
             elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -or $PSBoundParameters.ContainsKey('MembersToExclude'))
             {
-                $groupMembers = Get-MembersOnNanoServer -Group $group
+                [array]$groupMembers = Get-MembersOnNanoServer -Group $group
 
                 $uniqueMembersToInclude = $MembersToInclude | Select-Object -Unique
                 $uniqueMembersToExclude = $MembersToExclude | Select-Object -Unique
@@ -1419,7 +1419,7 @@ function Test-TargetResourceOnNanoServer
             }
         }
 
-        $groupMembers = Get-MembersOnNanoServer -Group $group
+        [array]$groupMembers = Get-MembersOnNanoServer -Group $group
 
         # Remove duplicate names as strings.
         $uniqueMembers = $Members | Select-Object -Unique
@@ -1508,7 +1508,7 @@ function Get-MembersOnNanoServer
         $Group
     )
 
-    $localMemberNames = New-Object -TypeName 'System.Collections.ArrayList'
+    $memberNames = New-Object -TypeName 'System.Collections.ArrayList'
 
     # Get the group members.
     $groupMembers = Get-LocalGroupMember -Group $Group
@@ -1518,16 +1518,17 @@ function Get-MembersOnNanoServer
         if ($groupMember.PrincipalSource -ieq 'Local')
         {
             $localMemberName = $groupMember.Name.Substring($groupMember.Name.IndexOf('\') + 1)
-            $null = $localMemberNames.Add($localMemberName)
+            $null = $memberNames.Add($localMemberName)
         }
         else
         {
-            Write-Verbose -Message ($script:localizedData.MemberIsNotALocalUser -f $groupMember.Name,
-                $groupMember.PrincipalSource)
+            Write-Verbose -Message ($script:localizedData.MemberIsNotALocalUser -f $groupMember.Name,$groupMember.PrincipalSource)
+            $domainMemberName = $groupMember.Name
+            $null = $memberNames.Add($domainMemberName)
         }
     }
 
-    return $localMemberNames.ToArray()
+    return $memberNames.ToArray()
 }
 
 <#

--- a/README.md
+++ b/README.md
@@ -635,7 +635,12 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 
 ### Unreleased
 
+* xGroup:
+    * Added updates from PSDscResources:
+        * Added support for domain based group members on Nano server
+
 ### 6.3.0.0
+
 * xDSCWebService
     * Fixed an issue where all 64bit IIS application pools stop working after installing DSC Pull Server, because IISSelfSignedCertModule(32bit) module was registered without bitness32 precondition.
 

--- a/Tests/Integration/MSFT_xGroupResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xGroupResource.Integration.Tests.ps1
@@ -163,9 +163,14 @@ try
                 MembersToInclude = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
-
-            New-Group -GroupName $testGroupName
+            try
+            {
+                New-Group -GroupName $testGroupName
+            }
+            catch
+            {
+                Write-Verbose "Group $testGroupName already exists OR there was an error creating it."
+            }
 
             Test-GroupExists -GroupName $testGroupName | Should Be $true
 
@@ -200,9 +205,14 @@ try
                 MembersToExclude = $groupMembersToExclude
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
-
-            New-Group -GroupName $testGroupName -Members $groupMembersToExclude
+            try
+            {
+                New-Group -GroupName $testGroupName -Members $groupMembersToExclude
+            }
+            catch
+            {
+                Write-Verbose "Group $testGroupName already exists OR there was an error creating it."
+            }
 
             Test-GroupExists -GroupName $testGroupName | Should Be $true
 


### PR DESCRIPTION
I am porting some changes from Group over to xPSDSC.
I have updated tests to cooperate with the Win 10 Creators update at least, so now the integration tests are all passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/347)
<!-- Reviewable:end -->
