### PR TITLE
BREAKING CHANGE: Pass Test-TargetResource when Ensure = Present but service not installed when disabled

### DIFF
--- a/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
+++ b/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.psm1
@@ -456,6 +456,10 @@ function Test-TargetResource
     if ($serviceResource.Ensure -eq 'Absent')
     {
         Write-Verbose -Message ($script:localizedData.ServiceDoesNotExist -f $Name)
+        if($StartupType -eq 'Disabled')
+        {
+            return $true
+        }
         return ($Ensure -eq 'Absent')
     }
     else

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ None
 * **[String] BuiltInAccount** _(Write)_: The built-in account the service should start under. Cannot be specified at the same time as Credential. The user account specified by this property must have access to the service executable path defined by Path in order to start the service. { LocalService | LocalSystem | NetworkService }.
 * **[PSCredential] Credential** _(Write)_: The credential of the user account the service should start under. Cannot be specified at the same time as BuiltInAccount. The user specified by this credential will automatically be granted the Log on as a Service right. The user account specified by this property must have access to the service executable path defined by Path in order to start the service.
 * **[Boolean] DesktopInteract** _(Write)_: Indicates whether or not the service should be able to communicate with a window on the desktop. Must be false for services not running as LocalSystem. The default value is False.
-* **[String] StartupType** _(Write)_: The startup type of the service. { Automatic | Disabled | Manual }.
+* **[String] StartupType** _(Write)_: The startup type of the service. { Automatic | Disabled | Manual }. If StartupType is "Disabled" and Service is not installed the resource will complete as being DSC compliant.
 * **[String] State** _(Write)_: The state of the service. { *Running* | Stopped | Ignore }.
 * **[Uint32] StartupTimeout** _(Write)_: The time to wait for the service to start in milliseconds. Defaults to 30000 (30 seconds).
 * **[Uint32] TerminateTimeout** _(Write)_: The time to wait for the service to stop in milliseconds. Defaults to 30000 (30 seconds).
@@ -634,7 +634,9 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 ## Versions
 
 ### Unreleased
-
+- xService
+    - Fixed an issue where services that are not installed but StartupType is "Disabled" in resource will error for not being installed. Change will now return as being in compliance.
+    
 ### 6.4.0.0
 
 * xGroup:

--- a/Tests/Unit/MSFT_xServiceResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xServiceResource.Tests.ps1
@@ -1005,6 +1005,38 @@ try
                 }
             }
 
+        Context 'Service does not exist, Ensure set to Present, and StartupType is set to Disabled' {
+                $testTargetResourceParameters = @{
+                    Name = $script:testServiceName
+                    Ensure = 'Present'
+                    StartupType = 'Disabled'
+                }
+                
+                It 'Should not throw' {
+                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                }
+
+                It 'Should not check for a startup type and state conflict' {
+                    Assert-MockCalled -CommandName 'Assert-NoStartupTypeStateConflict' -ParameterFilter { $ServiceName -eq $testTargetResourceParameters.Name -and $StartupType -eq $testTargetResourceParameters.StartupType } -Times 1 -Scope 'Context'
+                }
+
+                It 'Should attempt retrieve the service' {
+                    Assert-MockCalled -CommandName 'Get-TargetResource' -ParameterFilter { $Name -eq $testTargetResourceParameters.Name } -Times 1 -Scope 'Context'
+                }
+
+                It 'Should not attempt to test if the service path matches the specified path' {
+                    Assert-MockCalled -CommandName 'Test-PathsMatch' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should not attempt to convert a credential username to a service start name' {
+                    Assert-MockCalled -CommandName 'ConvertTo-StartName' -Times 0 -Scope 'Context'
+                }
+
+                It 'Should return true' {
+                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                }
+            }
+
             $serviceResourceWithAllProperties = @{
                 Name            = $script:testServiceName
                 Ensure          = 'Present'


### PR DESCRIPTION
Pass Test-TargetResource when Ensure = Present, if Service is not installed and Startup Type is Disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/366)
<!-- Reviewable:end -->
