### PR TITLE
SSMS Install Error

### DIFF
--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -613,7 +613,7 @@ function Set-TargetResource
             This is deliberately not in the finally block because we want to leave the downloaded
             file on disk if an error occurred as a debugging aid for the user.
         #>
-        Remove-Item -Path $downloadedFileName
+        Remove-Item -Path $downloadedFileName -ErrorAction SilentlyContinue
     }
 
     $operationMessageString = $script:localizedData.PackageUninstalled


### PR DESCRIPTION
During the installation of SQL Studio Manager DSC returns an error due to not having the correct permissions to delete the downloaded exe staged in the BuiltInProvCache folder.

Although not a terminating error it does cause DSC to stop as the ErrorActionPereference is set to Stop

Adding the ErrorAction to the Remove-Item cmdlet avoids this issue which following a successful DSC deploy and server reboot seems to clear the cache anyway

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/381)
<!-- Reviewable:end -->
