### PR TITLE
xWindowsProcess: Fix timing issue in integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ None
 * **[Boolean] PasswordNeverExpires** _(Write)_: Indicates if the password will expire. To ensure that the password for this account will never expire, set this property to $true, and set it to $false if the password will expire.
    - Suported values: $true, $false
    - Default value: $false
-   
+
 #### Examples
 
 * [Create a new User](https://github.com/PowerShell/xPSDesiredStateConfiguration/blob/dev/Examples/Sample_xUser_CreateUser.ps1)
@@ -637,6 +637,9 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 ### Unreleased
 
 * README.md: Fixed typo
+* Changes to xWindowsProcess
+  * Integration tests for this resource should no longer fail randomly. A timing
+    issue made the tests fail in certain scenarios ([issue #420](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/420)).
 
 ### 8.2.0.0
 
@@ -671,7 +674,7 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 ### 6.2.0.0
 
 * xMsiPackage:
-    * Created high quality MSI package manager resource 
+    * Created high quality MSI package manager resource
 * xArchive:
     * Fixed a minor bug in the unit tests where sometimes the incorrect DateTime format was used.
 * xWindowsFeatureSet:
@@ -699,7 +702,7 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
     * Added unit and end-to-end tests.
     * Significantly cleaned the resource.
     * Minor Breaking Change where the resource will now throw an error if no value is provided, Ensure is set to present, and the variable does not exist, whereas before it would create an empty registry key on the machine in this case (if this is the desired outcome then use the Registry resource).
-    * Added a new Write property 'Target', which specifies whether the user wants to set the machine variable, the process variable, or both (previously it was setting both in most cases).  
+    * Added a new Write property 'Target', which specifies whether the user wants to set the machine variable, the process variable, or both (previously it was setting both in most cases).
 * xGroup:
     * Group members in the "NT Authority", "BuiltIn" and "NT Service" scopes should now be resolved without an error. If you were seeing the errors "Exception calling ".ctor" with "4" argument(s): "Server names cannot contain a space character."" or "Exception calling ".ctor" with "2" argument(s): "Server names cannot contain a space character."", this fix should resolve those errors. If you are still seeing one of the errors, there is probably another local scope we need to add. Please let us know.
     * The resource will no longer attempt to resolve group members if Members, MembersToInclude, and MembersToExclude are not specified.
@@ -744,7 +747,7 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
     * Added integration tests for BuiltInAccount and Credential.
 * xServiceSet:
     * Updated resource to use new ResouceSetHelper functions and added integration tests.
-    * Updated documentation and example 
+    * Updated documentation and example
 * xWindowsProcess
     * Cleaned resource as per high quality guidelines.
     * Added unit tests.
@@ -769,7 +772,7 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
     * Fixed bug in which the user could not set a Binary registry value to 0
     * Added unit and integration tests
     * Added examples and updated documentation
-    
+
 ### 5.0.0.0
 
 * xWindowsFeature:

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -23,6 +23,7 @@ try
     Describe 'xWindowsProcess Integration Tests without Credential' {
         $testProcessPath = Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
                                      -ChildPath 'WindowsProcessTestProcess.exe'
+
         $logFilePath = Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
                                  -ChildPath 'processTestLog.txt'
 
@@ -49,7 +50,10 @@ try
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should Not Throw
             }
-            
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -84,10 +88,13 @@ try
                                          -Ensure 'Present' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
-       
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -127,10 +134,13 @@ try
                                          -Ensure 'Present' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
-       
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -166,10 +176,13 @@ try
                                          -Ensure 'Absent' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
-       
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -204,14 +217,17 @@ try
                                          -Ensure 'Present' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
 
             It 'Should start another process running' {
                 Start-Process -FilePath $testProcessPath -ArgumentList @($logFilePath)
             }
-       
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -251,10 +267,13 @@ try
                                          -Ensure 'Absent' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
-       
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -272,7 +291,7 @@ try
             }
         }
     }
-    
+
     Describe 'xWindowsProcess Integration Tests with Credential' {
         $ConfigData = @{
             AllNodes = @(
@@ -315,9 +334,12 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
@@ -335,7 +357,7 @@ try
                 $pathResult | Should Be $false
             }
         }
-        
+
         Context 'Should start a new testProcess instance as running' {
             $configurationName = 'MSFT_xWindowsProcess_StartProcessWithCredential'
             $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
@@ -355,9 +377,12 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
@@ -400,10 +425,13 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
-       
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -441,10 +469,13 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
-       
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -481,14 +512,17 @@ try
                                          -Credential $testCredential `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
 
             It 'Should start another process running' {
                 Start-Process -FilePath $testProcessPath -ArgumentList @($logFilePath)
             }
-       
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
@@ -535,10 +569,13 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
                 } | Should Not Throw
             }
-       
+
+            # Wait a moment for the process to stop/start
+            $null = Start-Sleep -Seconds 1
+
             It 'Should be able to call Get-DscConfiguration without throwing' {
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }


### PR DESCRIPTION
- Changes to xWindowsProcess
  - Integration tests for this resource should no longer fail randomly. A timing
    issue made the tests fail in certain scenarios (issue #420).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/421)
<!-- Reviewable:end -->
