### PR TITLE
xRegistry: Fails to remove key when specified as common registry path

### DIFF
--- a/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
+++ b/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
@@ -302,7 +302,7 @@ function Set-TargetResource
                     if (-not [String]::IsNullOrEmpty($ValueName))
                     {
                         # If the user specified a registry key value with a name to remove, remove the registry key value with the specified name
-                        $null = Remove-ItemProperty -Path $Key -Name $ValueName -Force
+                        $null = Remove-RegistryKeyValue -RegistryKey $registryKey -RegistryKeyValueName $ValueName
                     }
                     else
                     {
@@ -329,7 +329,7 @@ function Set-TargetResource
                 {
                     # Remove the registry key
                     Write-Verbose -Message ($script:localizedData.RemovingRegistryKey -f $Key)
-                    $null = Remove-Item -Path $Key -Recurse -Force
+                    $null = Remove-RegistryKey -RegistryKey $registryKey
                 }
             }
         }

--- a/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
+++ b/DSCResources/MSFT_xRegistryResource/MSFT_xRegistryResource.psm1
@@ -1409,6 +1409,58 @@ function Test-RegistryKeyValuesMatch
 
 <#
     .SYNOPSIS
+        Removes the specified registry key and child subkeys recursively.
+
+    .PARAMETER RegistryKey
+        The registry key to remove.
+#>
+function Remove-RegistryKey
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Win32.RegistryKey]
+        $RegistryKey
+    )
+
+    $parentKeyName = Split-Path -Path $RegistryKey.Name -Parent
+    $targetKeyName = Split-Path -Path $RegistryKey.Name -Leaf
+
+    $parentRegistryKey = Get-RegistryKey -RegistryKeyPath $parentKeyName -WriteAccessAllowed
+
+    $null = $parentRegistryKey.DeleteSubKeyTree($targetKeyName)
+}
+
+<#
+    .SYNOPSIS
+        Removes the specified value of the specified registry key.
+        This is a wrapper function for unit testing.
+
+    .PARAMETER RegistryKey
+        The registry key to remove the default value of.
+#>
+function Remove-RegistryKeyValue
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Win32.RegistryKey]
+        $RegistryKey,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNull()]
+        [AllowEmptyString()]
+        [String]
+        $RegistryKeyValueName
+    )
+
+    $null = $RegistryKey.DeleteValue($RegistryKeyValueName)
+}
+
+<#
+    .SYNOPSIS
         Removes the default value of the specified registry key.
         This is a wrapper function for unit testing.
         

--- a/README.md
+++ b/README.md
@@ -713,6 +713,8 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 ## Versions
 
 ### Unreleased
+* Changes to xRegistry
+  * Fixed an issue that fails to remove reg key when the `Key` is specified as common registry path. ([issue #444](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/444))
 
 * Changes to xService
   * Added support for Group Managed Service Accounts

--- a/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
@@ -145,6 +145,24 @@ try
                 $registryKeyExists | Should Be $false
             }
 
+            It 'Should remove a registry key (Common registry path)' {
+                $commonRegistryKeyPath = $script:registryKeyPath -replace 'HKLM:', 'HKEY_LOCAL_MACHINE'
+
+                # Create the test registry key
+                New-TestRegistryKey -KeyPath $script:registryKeyPath
+
+                # Verify that the registry key exists before removal
+                $registryKeyExists = Test-RegistryKeyExists -KeyPath $script:registryKeyPath
+                $registryKeyExists | Should Be $true
+
+                # Now remove the TestKey
+                Set-TargetResource -Key $commonRegistryKeyPath -ValueName '' -Ensure 'Absent'
+
+                # Verify that the registry key has been removed
+                $registryKeyExists = Test-RegistryKeyExists -KeyPath $script:registryKeyPath
+                $registryKeyExists | Should Be $false
+            }
+
             It 'Should remove a registry key tree' {
                 $registryKeyTreePath = Join-Path -Path (Join-Path -Path (Join-Path -Path $script:registryKeyPath -ChildPath 'A') -ChildPath 'B') -ChildPath 'C'
 
@@ -157,6 +175,25 @@ try
 
                 # Remove the test registry key tree
                 Set-TargetResource -Key $registryKeyTreePath -ValueName '' -Ensure 'Absent'
+
+                # Verify that the registry key tree has been removed
+                $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath
+                $registryKeyExists | Should Be $false
+            }
+
+            It 'Should remove a registry key tree (Common registry path)' {
+                $registryKeyTreePath = Join-Path -Path (Join-Path -Path (Join-Path -Path $script:registryKeyPath -ChildPath 'A') -ChildPath 'B') -ChildPath 'C'
+                $commonRegistryKeyTreePath = $registryKeyTreePath -replace 'HKLM:', 'HKEY_LOCAL_MACHINE'
+
+                # Create the test registry key
+                New-TestRegistryKey -KeyPath $registryKeyTreePath
+
+                # Verify that the registry key tree exists before removal
+                $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath
+                $registryKeyExists | Should Be $true
+
+                # Remove the test registry key tree
+                Set-TargetResource -Key $commonRegistryKeyTreePath -ValueName '' -Ensure 'Absent'
 
                 # Verify that the registry key tree has been removed
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath

--- a/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
@@ -61,7 +61,7 @@ try
             # Remove the test registry key if it already exists
             if (Test-RegistryKeyExists -KeyPath $script:registryKeyPath)
             {
-                Remove-RegistryKey -KeyPath $script:registryKeyPath
+                Remove-TestRegistryKey -KeyPath $script:registryKeyPath
             }
         }
 
@@ -69,7 +69,7 @@ try
             # Remove the test registry key if it already exists
             if ((Test-RegistryKeyExists -KeyPath $script:registryKeyPath) -and -not $script:doNotDeleteRegistryKey)
             {
-                Remove-RegistryKey -KeyPath $script:registryKeyPath
+                Remove-TestRegistryKey -KeyPath $script:registryKeyPath
             }
         }
 

--- a/Tests/MSFT_xRegistryResource.TestHelper.psm1
+++ b/Tests/MSFT_xRegistryResource.TestHelper.psm1
@@ -215,7 +215,7 @@ function New-RegistryValue
         The path to the registry key to remove 
         Must include the registry hive.
 #>
-function Remove-RegistryKey
+function Remove-TestRegistryKey
 {
     [CmdletBinding()]
     param 
@@ -240,7 +240,7 @@ function Remove-RegistryKey
     .PARAMETER ValueName
         The name of the value to remove.
 #>
-function Remove-RegistryValue
+function Remove-TestRegistryValue
 {
     [CmdletBinding()]
     param 
@@ -396,7 +396,7 @@ Export-ModuleMember -Function `
     'Test-RegistryValueExists', `
     'New-TestRegistryKey', `
     'New-RegistryValue', `
-    'Remove-RegistryKey', `
-    'Remove-RegistryValue', `
+    'Remove-TestRegistryKey', `
+    'Remove-TestRegistryValue', `
     'Dismount-RegistryDrive', `
     'Test-RegistryDriveMounted'

--- a/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
@@ -447,11 +447,11 @@ try
             Mock -CommandName 'Get-RegistryKeyName' -MockWith { return $setTargetResourceParameters.Key }
             Mock -CommandName 'Set-RegistryKeyValue' -MockWith { }
             Mock -CommandName 'Test-RegistryKeyValuesMatch' -MockWith { return $true }
-            Mock -CommandName 'Remove-ItemProperty' -MockWith { }
+            Mock -CommandName 'Remove-RegistryKey' -MockWith { }
+            Mock -CommandName 'Remove-RegistryKeyValue' -MockWith { }
             Mock -CommandName 'Remove-DefaultRegistryKeyValue' -MockWith { }
             Mock -CommandName 'Get-RegistryKeySubKeyCount' -MockWith { return 0 }
-            Mock -CommandName 'Remove-Item' -MockWith { }
-            
+
 
             Context 'Registry key does not exist and Ensure specified as Absent' {
                 $setTargetResourceParameters = @{
@@ -518,7 +518,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -530,7 +530,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -608,7 +608,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -620,7 +620,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -695,7 +695,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -712,15 +712,12 @@ try
                 }
 
                 It 'Should remove the registry key' {
-                    $removeItemParameterFilter = {
-                        $pathParameterCorrect = $Path -eq $setTargetResourceParameters.Key
-                        $recurseParameterCorrect = $Recurse -eq $true
-                        $forceParameterCorrect = $Force -eq $true
-
-                        return $pathParameterCorrect -and $recurseParameterCorrect -and $forceParameterCorrect
+                    $removeRegistryKeyParameterFilter = {
+                        $registryKeyParameterCorrect = $null -eq (Compare-Object -ReferenceObject $script:testRegistryKey -DifferenceObject $RegistryKey)
+                        return $registryKeyParameterCorrect
                     }
 
-                    Assert-MockCalled -CommandName 'Remove-Item' -ParameterFilter $removeItemParameterFilter -Times 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -ParameterFilter $removeRegistryKeyParameterFilter -Times 1 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -810,7 +807,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -827,15 +824,12 @@ try
                 }
 
                 It 'Should remove the registry key' {
-                    $removeItemParameterFilter = {
-                        $pathParameterCorrect = $Path -eq $setTargetResourceParameters.Key
-                        $recurseParameterCorrect = $Recurse -eq $true
-                        $forceParameterCorrect = $Force -eq $true
-
-                        return $pathParameterCorrect -and $recurseParameterCorrect -and $forceParameterCorrect
+                    $removeRegistryKeyParameterFilter = {
+                        $registryKeyParameterCorrect = $null -eq (Compare-Object -ReferenceObject $script:testRegistryKey -DifferenceObject $RegistryKey)
+                        return $registryKeyParameterCorrect
                     }
 
-                    Assert-MockCalled -CommandName 'Remove-Item' -ParameterFilter $removeItemParameterFilter -Times 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -ParameterFilter $removeRegistryKeyParameterFilter -Times 1 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -918,7 +912,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -930,7 +924,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1003,7 +997,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -1015,7 +1009,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1117,7 +1111,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -1129,7 +1123,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1233,7 +1227,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -1245,7 +1239,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1350,7 +1344,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -1362,7 +1356,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1496,7 +1490,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -1508,7 +1502,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1624,7 +1618,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -1636,7 +1630,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1722,15 +1716,14 @@ try
                 }
 
                 It 'Should remove the registry key value' {
-                    $removeItemPropertyParameterFilter = {
-                        $pathParameterCorrect = $Path -eq $setTargetResourceParameters.Key
-                        $nameParameterCorrect = $Name -eq $setTargetResourceParameters.ValueName
-                        $forceParameterCorrect = $Force -eq $true
+                    $removeRegistryKeyValueParameterFilter = {
+                        $registryKeyParameterCorrect = $null -eq (Compare-Object -ReferenceObject $script:testRegistryKey -DifferenceObject $RegistryKey)
+                        $registryKeyValueNameParameterCorrect = $RegistryKeyValueName -eq $setTargetResourceParameters.ValueName
 
-                        return $pathParameterCorrect -and $nameParameterCorrect -and $forceParameterCorrect
+                        return $registryKeyParameterCorrect -and $registryKeyValueNameParameterCorrect
                     }
 
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -ParameterFilter $removeItemPropertyParameterFilter -Times 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -ParameterFilter $removeRegistryKeyValueParameterFilter -Times 1 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the default registry key value' {
@@ -1742,7 +1735,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {
@@ -1828,7 +1821,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key value' {
-                    Assert-MockCalled -CommandName 'Remove-ItemProperty' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKeyValue' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should remove the default registry key value' {
@@ -1845,7 +1838,7 @@ try
                 }
 
                 It 'Should not attempt to remove the registry key' {
-                    Assert-MockCalled -CommandName 'Remove-Item' -Times 0 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Remove-RegistryKey' -Times 0 -Scope 'Context'
                 }
 
                 It 'Should not return' {


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Fixes #444

I made the following changes.
+ Add two helper functions. (`Remove-RegistryKey` and `Remove-RegistryKeyValue`)
+ Replace current disposal for removing registry key / value with these new functions.
+ Modify unit tests
+ Add two tests to the integration test.
+ Add an entry to the change log in the README.md.

#### This Pull Request (PR) fixes the following issues
- Fixes #444

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/445)
<!-- Reviewable:end -->
