### PR TITLE
Update CommonResourceHelper, ResourceHelper, MSFT_xDSCWebService and MSFT_xDSCWebService tests to Pester 4 standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,8 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
   standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
 * Update `MSFT_xDSCWebService` integration tests to meet Pester 4.0.0
   standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
+* Refactored `MSFT_xDSCWebService` integration tests to meet current
+  standards and to use Pester TestDrive.
 * xArchive
   * Fix end-to-end tests ([issue #457](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/457)).
   * Update integration tests to meet Pester 4.0.0 standards.

--- a/README.md
+++ b/README.md
@@ -714,6 +714,14 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 
 ### Unreleased
 
+* Update `CommonResourceHelper` unit tests to meet Pester 4.0.0
+  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
+* Update `ResourceHelper` unit tests to meet Pester 4.0.0
+  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
+* Update `MSFT_xDSCWebService` unit tests to meet Pester 4.0.0
+  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
+* Update `MSFT_xDSCWebService` integration tests to meet Pester 4.0.0
+  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
 * xArchive
   * Fix end-to-end tests ([issue #457](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/457)).
   * Update integration tests to meet Pester 4.0.0 standards.

--- a/Tests/Integration/MSFT_xDSCWebService.xxx.ps1
+++ b/Tests/Integration/MSFT_xDSCWebService.xxx.ps1
@@ -1,173 +1,183 @@
 ######################################################################################
 # Integration Tests for DSC Resource xDSCWebService
-# 
+#
 # There tests will make changes to your system, we are tyring to roll them back,
 # but you never know. Best to run this on a throwaway VM.
-# Run as an elevated administrator 
+# Run as an elevated administrator
 ######################################################################################
 
-$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+# Create a unique name that we use for our temp files and folders
+[System.String] $tempFolderName = 'xDSCWebServiceTests_' + (Get-Date).ToString("yyyyMMdd_HHmmss")
 
-# create a unique name that we use for our temp files and folders
-[string]$tempName = "xDSCWebServiceTests_" + (Get-Date).ToString("yyyyMMdd_HHmmss")
-
-Describe "xDSCWebService" {
-
-    function Verify-DSCPullServer ($protocol,$hostname,$port) {
-        ([xml](invoke-webrequest "$($protocol)://$($hostname):$($port)/psdscpullserver.svc" | % Content)).service.workspace.collection.href
-    }
-
-    function Remove-WebRoot([string]$filePath)
+Describe 'xDSCWebService' {
+    function Verify-DSCPullServer
     {
-       if (Test-Path $filePath)
-       {
-           Get-ChildItem $filePath -Recurse | Remove-Item -Recurse
-           Remove-Item $filePath
-       }
+        param
+        (
+            [Parameter(Mandatory = $true)]
+            [System.String]
+            $Protocol,
+
+            [Parameter(Mandatory = $true)]
+            [System.String]
+            $Hostname,
+
+            [Parameter(Mandatory = $true)]
+            [System.String]
+            $Port
+        )
+
+        ([xml](Invoke-WebRequest -Uri "$($Protocol)://$($Hostname):$($Port)/psdscpullserver.svc" | Foreach-Object -Process Content)).service.workspace.collection.href
     }
 
     try
     {
-
-
-        # before doing our changes, create a backup of the current config        
-        Backup-WebConfiguration -Name $tempName
-
+        # Before doing our changes, create a backup of the current config
+        Backup-WebConfiguration -Name $tempFolderName
 
         It 'Installing Service' -test {
-        {
-
-            # define the configuration
-            configuration InstallingService
             {
-                WindowsFeature DSCServiceFeature
+                # Define the configuration
+                Configuration InstallingService
                 {
-                    Ensure = ???Present???
-                    Name   = ???DSC-Service???
+                    WindowsFeature DSCServiceFeature
+                    {
+                        Ensure = 'Present'
+                        Name   = 'DSC-Service'
+                    }
                 }
-            }
 
-            # execute the configuration into a temp location
-            InstallingService -OutputPath $env:temp\$($tempName)_InstallingService
-            # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_InstallingService -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
+                $installingServiceMofPath = '{0}\{1}_InstallingService' -f $TestDrive, $tempFolderName
 
-            (Get-WindowsFeature -name DSC-Service | Where Installed).count | should -be 1
+                # Execute the configuration into a temp location
+                InstallingService -OutputPath $installingServiceMofPath
+
+                # Run the configuration, it should not throw any errors
+                Start-DscConfiguration -Path $installingServiceMofPath -Wait -Verbose -ErrorAction Stop -Force
+            } | Should -Not -Throw
+
+            (Get-WindowsFeature -Name DSC-Service | Where-Object -Property Installed -EQ $true).Count | Should -Be 1
         }
 
-        It 'Creating Sites' -test {
-        {
-            # define the configuration
-            configuration CreatingSites
+        It 'Creating Sites' -Test {
             {
-                Import-DSCResource -ModuleName xPSDesiredStateConfiguration
-                
-                xDscWebService PSDSCPullServer
+                # Define the configuration
+                Configuration CreatingSites
                 {
-                    EndpointName            = ???TestPSDSCPullServer???
-                    Port                    = 21001
-                    CertificateThumbPrint   = ???AllowUnencryptedTraffic???
+                    Import-DSCResource -ModuleName xPSDesiredStateConfiguration
+
+                    xDscWebService PSDSCPullServer
+                    {
+                        EndpointName             = 'TestPSDSCPullServer'
+                        Port                     = 21001
+                        CertificateThumbPrint    = 'AllowUnencryptedTraffic'
+                        UseSecurityBestPractices = $true
+                    }
                 }
-            }
 
-            # execute the configuration into a temp location
-            CreatingSites -OutputPath $env:temp\$($tempName)_CreatingSites
-            # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_CreatingSites -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
+                $creatingSitesMofPath = '{0}\{1}_CreatingSites' -f $TestDrive, $tempFolderName
 
-            # we now expect two sites starting with our prefix
-            (Get-ChildItem iis:\sites | Where-Object Name -match "^TestPSDSC").count | should -be 1
+                # Execute the configuration into a temp location
+                CreatingSites -OutputPath $creatingSitesMofPath
 
-            # we expect some files in the web root, using the defaults
-            (Test-Path "$env:SystemDrive\inetpub\TestPSDSCPullServer\web.config") | should -be $true
+                # Run the configuration, it should not throw any errors
+                Start-DscConfiguration -Path $creatingSitesMofPath -Wait -Verbose -ErrorAction Stop -Force
+            } | Should -Not -Throw
 
-            $FireWallRuleDisplayName = "Desired State Configuration - Pull Server Port:{0}"
-            $ruleName = ($($FireWallRuleDisplayName) -f "21001")
-            (Get-NetFirewallRule | Where-Object DisplayName -eq "$ruleName" | Measure-Object).count | should -be 1
+            # We now expect two sites starting with our prefix
+            (Get-ChildItem -Path IIS:\sites | Where-Object -Property Name -Match "^TestPSDSC").Count | Should -Be 1
 
-            # we also expect an XML document with certain strings at a certain URI
-            (Verify-DSCPullServer "http" "localhost" "21001") | should -match "Action|Module"
+            # We expect some files in the web root, using the defaults
+            (Test-Path -Path "$ENV:SystemDrive\inetpub\TestPSDSCPullServer\web.config") | Should -Be $true
 
+            $fireWallRuleDisplayName = 'Desired State Configuration - Pull Server Port:{0}'
+            $ruleName = ($fireWallRuleDisplayName -f '21001')
+            (Get-NetFirewallRule | Where-Object -Name DisplayName -EQ $ruleName | Measure-Object).Count | Should -Be 1
+
+            # We also expect an XML document with certain strings at a certain URI
+            Verify-DSCPullServer -Protocol 'http' -Hostname 'localhost' -Port '21001' | Should -Match 'Action|Module'
         }
 
-        It 'Removing Sites' -test {
-        {
-
-            # define the configuration
-            configuration RemovingSites
+        It 'Removing Sites' -Test {
             {
-                Import-DSCResource -ModuleName xPSDesiredStateConfiguration
-
-                xDscWebService PSDSCPullServer
+                # Define the configuration
+                Configuration RemovingSites
                 {
-                    Ensure                  = ???Absent???
-                    EndpointName            = ???TestPSDSCPullServer???
-                    CertificateThumbPrint   = ???NotUsed???
+                    Import-DSCResource -ModuleName xPSDesiredStateConfiguration
+
+                    xDscWebService PSDSCPullServer
+                    {
+                        Ensure                   = 'Absent'
+                        EndpointName             = 'TestPSDSCPullServer'
+                        CertificateThumbPrint    = 'NotUsed'
+                        UseSecurityBestPractices = $true
+                    }
                 }
-            }
 
-            # execute the configuration into a temp location
-            RemovingSites -OutputPath $env:temp\$($tempName)_RemovingSites
-            # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_RemovingSites -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
+                $removingSitesMofPath = '{0}\{1}_RemovingSites' -f $TestDrive, $tempFolderName
 
-            # we now expect two sites starting with our prefix
-            (Get-ChildItem iis:\sites | Where-Object Name -match "^TestPSDSC").count | should -be 0
+                # Execute the configuration into a temp location
+                RemovingSites -OutputPath $removingSitesMofPath
 
-            (Test-Path "$env:SystemDrive\inetpub\TestPSDSCPullServer\web.config") | should -be $false
+                # Run the configuration, it should not throw any errors
+                Start-DscConfiguration -Path $removingSitesMofPath -Wait -Verbose -ErrorAction Stop -Force
+            } | Should -Not -Throw
 
-            $FireWallRuleDisplayName = "Desired State Configuration - Pull Server Port:{0}"
-            $ruleName = ($($FireWallRuleDisplayName) -f "8081")
-            (Get-NetFirewallRule | Where-Object DisplayName -eq "$ruleName" | Measure-Object).count | should -be 0
+            # We now expect two sites starting with our prefix
+            (Get-ChildItem -Path IIS:\sites | Where-Object Name -match '^TestPSDSC').Count | Should -Be 0
 
+            Test-Path -Path "$ENV:SystemDrive\inetpub\TestPSDSCPullServer\web.config" | Should -Be $false
+
+            $fireWallRuleDisplayName = 'Desired State Configuration - Pull Server Port:{0}'
+            $ruleName = ($fireWallRuleDisplayName -f '8081')
+            (Get-NetFirewallRule | Where-Object -Property DisplayName -EQ $ruleName | Measure-Object).Count | Should -Be 0
         }
 
-        It 'CreatingSitesWithFTP' -test {
-        {
-            # create a new FTP site on IIS
-            If (!(Test-Path IIS:\Sites\DummyFTPSite))
+        It 'CreatingSitesWithFTP' -Test {
             {
-                New-WebFtpSite -Name "DummyFTPSite" -Port "21000"
-                # stop the site, we don't want it, it is just here to check whether setup works
-                (get-Website -Name "DummyFTPSite").ftpserver.stop()
-            }
-
-            # define the configuration
-            configuration CreatingSitesWithFTP
-            {
-                Import-DSCResource -ModuleName xPSDesiredStateConfiguration
-
-                xDscWebService PSDSCPullServer2
+                # Create a new FTP site on IIS
+                If (-not (Test-Path -Path IIS:\Sites\DummyFTPSite))
                 {
-                    EndpointName            = ???TestPSDSCPullServer2???
-                    Port                    = 21003
-                    CertificateThumbPrint   = ???AllowUnencryptedTraffic???
+                    New-WebFtpSite -Name 'DummyFTPSite' -Port '21000'
+
+                    # Stop the site, we don't want it, it is just here to check whether setup works
+                    (Get-Website -Name 'DummyFTPSite').ftpserver.stop()
                 }
-            }
 
-            # execute the configuration into a temp location
-            CreatingSitesWithFTP -OutputPath $env:temp\$($tempName)_CreatingSitesWithFTP
-            # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_CreatingSitesWithFTP -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
+                # Define the configuration
+                Configuration CreatingSitesWithFTP
+                {
+                    Import-DSCResource -ModuleName xPSDesiredStateConfiguration
 
+                    xDscWebService PSDSCPullServer2
+                    {
+                        EndpointName             = 'TestPSDSCPullServer2'
+                        Port                     = 21003
+                        CertificateThumbPrint    = 'AllowUnencryptedTraffic'
+                        UseSecurityBestPractices = $true
+                    }
+                }
+
+                $creatingSitesWithFtpMofPath = '{0}\{1}_CreatingSitesWithFTP' -f $TestDrive, $tempFolderName
+
+                # Execute the configuration into a temp location
+                CreatingSitesWithFTP -OutputPath $creatingSitesWithFtpMofPath
+
+                # Run the configuration, it should not throw any errors
+                Start-DscConfiguration -Path $creatingSitesWithFtpMofPath -Wait -Verbose -ErrorAction Stop -Force
+            }  | Should -Not -Throw
         }
-
     }
     finally
     {
-        # roll back our changes
-        Restore-WebConfiguration -Name $tempName
-        Remove-WebConfigurationBackup -Name $tempName
+        # Roll back our changes
+        Restore-WebConfiguration -Name $tempFolderName
+        Remove-WebConfigurationBackup -Name $tempFolderName
 
-        # remove possible web files
-        Remove-WebRoot -filePath "$env:SystemDrive\inetpub\TestPSDSCPullServer"
-        Remove-WebRoot -filePath "$env:SystemDrive\inetpub\TestPSDSCPullServer2"
+        # Remove the generated MoF files
+        Get-ChildItem -Path $ENV:TEMP -Filter $tempFolderName | Remove-Item -Recurse -Force
 
-        # remove the generated MoF files
-        Get-ChildItem $env:temp -Filter $tempName* | Remove-item -Recurse
-
-        # remove all firewall rules starting with port 21*
-        Get-NetFirewallRule | Where-Object DisplayName -match "^Desired State Configuration - Pull Server Port:21" | Remove-NetFirewallRule
-
-    } 
+        # Remove all firewall rules starting with port 21*
+        Get-NetFirewallRule | Where-Object -Property DisplayName -Match '^Desired State Configuration - Pull Server Port:21' | Remove-NetFirewallRule
+    }
 }

--- a/Tests/Integration/MSFT_xDSCWebService.xxx.ps1
+++ b/Tests/Integration/MSFT_xDSCWebService.xxx.ps1
@@ -42,17 +42,17 @@ Describe "xDSCWebService" {
             {
                 WindowsFeature DSCServiceFeature
                 {
-                    Ensure = “Present”
-                    Name   = “DSC-Service”
+                    Ensure = ???Present???
+                    Name   = ???DSC-Service???
                 }
             }
 
             # execute the configuration into a temp location
             InstallingService -OutputPath $env:temp\$($tempName)_InstallingService
             # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_InstallingService -Wait -Verbose -ErrorAction Stop -Force}  | should not throw
+            Start-DscConfiguration -Path $env:temp\$($tempName)_InstallingService -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
 
-            (Get-WindowsFeature -name DSC-Service | Where Installed).count | should be 1
+            (Get-WindowsFeature -name DSC-Service | Where Installed).count | should -be 1
         }
 
         It 'Creating Sites' -test {
@@ -64,29 +64,29 @@ Describe "xDSCWebService" {
                 
                 xDscWebService PSDSCPullServer
                 {
-                    EndpointName            = “TestPSDSCPullServer”
+                    EndpointName            = ???TestPSDSCPullServer???
                     Port                    = 21001
-                    CertificateThumbPrint   = “AllowUnencryptedTraffic”
+                    CertificateThumbPrint   = ???AllowUnencryptedTraffic???
                 }
             }
 
             # execute the configuration into a temp location
             CreatingSites -OutputPath $env:temp\$($tempName)_CreatingSites
             # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_CreatingSites -Wait -Verbose -ErrorAction Stop -Force}  | should not throw
+            Start-DscConfiguration -Path $env:temp\$($tempName)_CreatingSites -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
 
             # we now expect two sites starting with our prefix
-            (Get-ChildItem iis:\sites | Where-Object Name -match "^TestPSDSC").count | should be 1
+            (Get-ChildItem iis:\sites | Where-Object Name -match "^TestPSDSC").count | should -be 1
 
             # we expect some files in the web root, using the defaults
-            (Test-Path "$env:SystemDrive\inetpub\TestPSDSCPullServer\web.config") | should be $true
+            (Test-Path "$env:SystemDrive\inetpub\TestPSDSCPullServer\web.config") | should -be $true
 
             $FireWallRuleDisplayName = "Desired State Configuration - Pull Server Port:{0}"
             $ruleName = ($($FireWallRuleDisplayName) -f "21001")
-            (Get-NetFirewallRule | Where-Object DisplayName -eq "$ruleName" | Measure-Object).count | should be 1
+            (Get-NetFirewallRule | Where-Object DisplayName -eq "$ruleName" | Measure-Object).count | should -be 1
 
             # we also expect an XML document with certain strings at a certain URI
-            (Verify-DSCPullServer "http" "localhost" "21001") | should match "Action|Module"
+            (Verify-DSCPullServer "http" "localhost" "21001") | should -match "Action|Module"
 
         }
 
@@ -100,25 +100,25 @@ Describe "xDSCWebService" {
 
                 xDscWebService PSDSCPullServer
                 {
-                    Ensure                  = “Absent”
-                    EndpointName            = “TestPSDSCPullServer”
-                    CertificateThumbPrint   = “NotUsed”
+                    Ensure                  = ???Absent???
+                    EndpointName            = ???TestPSDSCPullServer???
+                    CertificateThumbPrint   = ???NotUsed???
                 }
             }
 
             # execute the configuration into a temp location
             RemovingSites -OutputPath $env:temp\$($tempName)_RemovingSites
             # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_RemovingSites -Wait -Verbose -ErrorAction Stop -Force}  | should not throw
+            Start-DscConfiguration -Path $env:temp\$($tempName)_RemovingSites -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
 
             # we now expect two sites starting with our prefix
-            (Get-ChildItem iis:\sites | Where-Object Name -match "^TestPSDSC").count | should be 0
+            (Get-ChildItem iis:\sites | Where-Object Name -match "^TestPSDSC").count | should -be 0
 
-            (Test-Path "$env:SystemDrive\inetpub\TestPSDSCPullServer\web.config") | should be $false
+            (Test-Path "$env:SystemDrive\inetpub\TestPSDSCPullServer\web.config") | should -be $false
 
             $FireWallRuleDisplayName = "Desired State Configuration - Pull Server Port:{0}"
             $ruleName = ($($FireWallRuleDisplayName) -f "8081")
-            (Get-NetFirewallRule | Where-Object DisplayName -eq "$ruleName" | Measure-Object).count | should be 0
+            (Get-NetFirewallRule | Where-Object DisplayName -eq "$ruleName" | Measure-Object).count | should -be 0
 
         }
 
@@ -139,16 +139,16 @@ Describe "xDSCWebService" {
 
                 xDscWebService PSDSCPullServer2
                 {
-                    EndpointName            = “TestPSDSCPullServer2”
+                    EndpointName            = ???TestPSDSCPullServer2???
                     Port                    = 21003
-                    CertificateThumbPrint   = “AllowUnencryptedTraffic”
+                    CertificateThumbPrint   = ???AllowUnencryptedTraffic???
                 }
             }
 
             # execute the configuration into a temp location
             CreatingSitesWithFTP -OutputPath $env:temp\$($tempName)_CreatingSitesWithFTP
             # run the configuration, it should not throw any errors
-            Start-DscConfiguration -Path $env:temp\$($tempName)_CreatingSitesWithFTP -Wait -Verbose -ErrorAction Stop -Force}  | should not throw
+            Start-DscConfiguration -Path $env:temp\$($tempName)_CreatingSitesWithFTP -Wait -Verbose -ErrorAction Stop -Force}  | should -not -throw
 
         }
 

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -40,7 +40,7 @@ Describe 'CommonResourceHelper Unit Tests' {
             Context 'Get-ComputerInfo command exists' {
                 Context 'Computer OS type is Server and OS server level is NanoServer' {
                     It 'Should not throw' {
-                        { $null = Test-IsNanoServer } | Should Not Throw
+                        { $null = Test-IsNanoServer } | Should -Not -Throw
                     }
 
                     It 'Should test if the Get-ComputerInfo command exists' {
@@ -56,7 +56,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     }
 
                     It 'Should return true' {
-                        Test-IsNanoServer | Should Be $true
+                        Test-IsNanoServer | Should -Be $true
                     }
                 }
 
@@ -64,7 +64,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoServerNotNano }
 
                     It 'Should not throw' {
-                        { $null = Test-IsNanoServer } | Should Not Throw
+                        { $null = Test-IsNanoServer } | Should -Not -Throw
                     }
 
                     It 'Should test if the Get-ComputerInfo command exists' {
@@ -80,7 +80,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     }
 
                     It 'Should return false' {
-                        Test-IsNanoServer | Should Be $false
+                        Test-IsNanoServer | Should -Be $false
                     }
                 }
 
@@ -88,7 +88,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoNotServer }
 
                     It 'Should not throw' {
-                        { $null = Test-IsNanoServer } | Should Not Throw
+                        { $null = Test-IsNanoServer } | Should -Not -Throw
                     }
 
                     It 'Should test if the Get-ComputerInfo command exists' {
@@ -104,7 +104,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     }
 
                     It 'Should return false' {
-                        Test-IsNanoServer | Should Be $false
+                        Test-IsNanoServer | Should -Be $false
                     }
                 }
             }
@@ -113,7 +113,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 Mock -CommandName 'Test-CommandExists' -MockWith { return $false }
 
                 It 'Should not throw' {
-                    { $null = Test-IsNanoServer } | Should Not Throw
+                    { $null = Test-IsNanoServer } | Should -Not -Throw
                 }
 
                 It 'Should test if the Get-ComputerInfo command exists' {
@@ -129,7 +129,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
 
                 It 'Should return false' {
-                    Test-IsNanoServer | Should Be $false
+                    Test-IsNanoServer | Should -Be $false
                 }
             }
         }
@@ -141,7 +141,7 @@ Describe 'CommonResourceHelper Unit Tests' {
 
             Context 'Get-Command returns the command' {
                 It 'Should not throw' {
-                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                    { $null = Test-CommandExists -Name $testCommandName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the command with the specified name' {
@@ -153,7 +153,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
 
                 It 'Should return true' {
-                    Test-CommandExists -Name $testCommandName | Should Be $true
+                    Test-CommandExists -Name $testCommandName | Should -Be $true
                 }
             }
 
@@ -161,7 +161,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 Mock -CommandName 'Get-Command' -MockWith { return $null }
 
                 It 'Should not throw' {
-                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                    { $null = Test-CommandExists -Name $testCommandName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the command with the specified name' {
@@ -173,7 +173,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
 
                 It 'Should return false' {
-                    Test-CommandExists -Name $testCommandName | Should Be $false
+                    Test-CommandExists -Name $testCommandName | Should -Be $false
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDSCWebService.Tests.ps1
+++ b/Tests/Unit/MSFT_xDSCWebService.Tests.ps1
@@ -146,11 +146,11 @@ try
                 $script:result = $null
 
                 It 'Should not throw' {
-                    {$script:result = Get-TargetResource @testParameters} | Should Not Throw
+                    {$script:result = Get-TargetResource @testParameters} | Should -Not -Throw
                 }
 
                 It 'Should return Ensure set to Absent' {
-                    $script:result.Ensure | Should Be 'Absent'
+                    $script:result.Ensure | Should -Be 'Absent'
                 }
             }
 
@@ -241,7 +241,7 @@ try
                )
 
                 It 'Should not throw' {
-                    {$script:result = Get-TargetResource @testParameters} | Should Not Throw
+                    {$script:result = Get-TargetResource @testParameters} | Should -Not -Throw
                 }
 
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
@@ -258,15 +258,15 @@ try
 
                     if ($Data -ne $null)
                     {
-                        $script:result.$Variable  | Should Be $Data
+                        $script:result.$Variable  | Should -Be $Data
                     }
                     else
                     {
-                         $script:result.$Variable  | Should Be Null
+                         $script:result.$Variable  | Should -Be Null
                     }
                 }
                 It 'Should return ''DisableSecurityBestPractices'' set to $null' {
-                    $script:result.DisableSecurityBestPractices | Should BeNullOrEmpty
+                    $script:result.DisableSecurityBestPractices | Should -BeNullOrEmpty
                 }
                 It 'Should call expected mocks' {
                     Assert-MockCalled -Exactly -Times 1 -CommandName Get-WebSite
@@ -290,7 +290,7 @@ try
                 )
 
                 It 'Should not throw' {
-                    {$script:result = Get-TargetResource @testParameters} | Should Not Throw
+                    {$script:result = Get-TargetResource @testParameters} | Should -Not -Throw
                 }
 
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
@@ -305,7 +305,7 @@ try
                         $Data
                     )
 
-                    $script:result.$Variable | Should Be $Data
+                    $script:result.$Variable | Should -Be $Data
                 }
                 It 'Should call expected mocks' {
                     Assert-VerifiableMock
@@ -340,7 +340,7 @@ try
                )
 
                 It 'Should not throw' {
-                    {$script:result = Get-TargetResource @altTestParameters} | Should Not Throw
+                    {$script:result = Get-TargetResource @altTestParameters} | Should -Not -Throw
                 }
 
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
@@ -357,11 +357,11 @@ try
 
                     if ($Data -ne $null)
                     {
-                        $script:result.$Variable  | Should Be $Data
+                        $script:result.$Variable  | Should -Be $Data
                     }
                     else
                     {
-                         $script:result.$Variable  | Should Be Null
+                         $script:result.$Variable  | Should -Be Null
                     }
                 }
                 It 'Should call expected mocks' {
@@ -394,7 +394,7 @@ try
                )
 
                 It 'Should not throw' {
-                    {$script:result = Get-TargetResource @altTestParameters} | Should Not Throw
+                    {$script:result = Get-TargetResource @altTestParameters} | Should -Not -Throw
                 }
 
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
@@ -411,11 +411,11 @@ try
 
                     if ($Data -ne $null)
                     {
-                        $script:result.$Variable  | Should Be $Data
+                        $script:result.$Variable  | Should -Be $Data
                     }
                     else
                     {
-                         $script:result.$Variable  | Should Be Null
+                         $script:result.$Variable  | Should -Be Null
                     }
                 }
                 It 'Should call expected mocks' {
@@ -431,13 +431,13 @@ try
                     $altTestParameters = $testParameters.Clone()
                     $altTestParameters.Remove('CertificateThumbPrint')
 
-                    {$script:result = Get-TargetResource @altTestParameters} | Should Throw
+                    {$script:result = Get-TargetResource @altTestParameters} | Should -Throw
                 }
                 It 'Should throw if CertificateThumbprint and CertificateSubject are both specifed' {
                     $altTestParameters = $testParameters.Clone()
                     $altTestParameters.Add('CertificateSubject', $certificateData[0].Subject)
 
-                    {$script:result = Get-TargetResource @altTestParameters} | Should Throw
+                    {$script:result = Get-TargetResource @altTestParameters} | Should -Throw
                 }
             }
         }
@@ -532,7 +532,7 @@ try
 
                     Set-TargetResource @testParameters @setTargetPaths -Ensure Present
 
-                    Test-Path -Path $Value | Should be $true
+                    Test-Path -Path $Value | Should -be $true
                 }
             }
 
@@ -655,7 +655,7 @@ try
 
                 It 'Should throw an error because no certificate specified' {
                     $message = "Error: Cannot use best practice security settings with unencrypted traffic. Please set UseSecurityBestPractices to `$false or use a certificate to encrypt pull server traffic."
-                    {Set-TargetResource @altTestParameters -Ensure Present} | Should throw $message
+                    {Set-TargetResource @altTestParameters -Ensure Present} | Should -throw $message
                 }
             }
 
@@ -698,7 +698,7 @@ try
                 }
 
                 It 'Should not throw an error' {
-                    {Set-TargetResource @altTestParameters @setTargetPaths -Ensure Present} | Should not throw
+                    {Set-TargetResource @altTestParameters @setTargetPaths -Ensure Present} | Should -not -throw
                 }
 
                 It 'Should call expected mocks' {
@@ -712,7 +712,7 @@ try
                     $altTestParameters = $testParameters.Clone()
                     $altTestParameters.Remove('CertificateThumbPrint')
 
-                    {$result = Set-TargetResource @altTestParameters} | Should Throw
+                    {$result = Set-TargetResource @altTestParameters} | Should -Throw
                 }
             }
         }
@@ -725,10 +725,10 @@ try
                 Mock -CommandName Get-Website
 
                 It 'Should return $true when Ensure is Absent' {
-                    Test-TargetResource @testParameters -Ensure Absent | Should Be $true
+                    Test-TargetResource @testParameters -Ensure Absent | Should -Be $true
                 }
                 It 'Should return $false when Ensure is Present' {
-                    Test-TargetResource @testParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present | Should -Be $false
                 }
             }
 
@@ -736,21 +736,21 @@ try
                 Mock -CommandName Get-Website -MockWith {$WebsiteDataHTTP}
 
                 It 'Should return $false when Ensure is Absent' {
-                    Test-TargetResource @testParameters -Ensure Absent | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Absent | Should -Be $false
                 }
                 It 'Should return $false if Port doesn''t match' {
-                    Test-TargetResource @testParameters -Ensure Present -Port 8081 | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present -Port 8081 | Should -Be $false
                 }
                 It 'Should return $false if Certificate Thumbprint is set' {
                     $altTestParameters = $testParameters.Clone()
                     $altTestParameters.CertificateThumbprint = $certificateData[0].Thumbprint
 
-                    Test-TargetResource @altTestParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @altTestParameters -Ensure Present | Should -Be $false
                 }
                 It 'Should return $false if Physical Path doesn''t match' {
                     Mock -CommandName Test-WebsitePath -MockWith {$true} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -759,14 +759,14 @@ try
                 Mock -CommandName Test-WebsitePath -MockWith {$false} -Verifiable
 
                 It 'Should return $false when State is set to Stopped' {
-                    Test-TargetResource @testParameters -Ensure Present -State Stopped | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present -State Stopped | Should -Be $false
 
                     Assert-VerifiableMock
                 }
                 It 'Should return $false when dbProvider is not set' {
                     Mock -CommandName Get-WebConfigAppSetting -MockWith {''} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -779,7 +779,7 @@ try
                     Mock -CommandName Get-WebConfigAppSetting -MockWith {'ESENT'} -Verifiable
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {param ($ExpectedAppSettingValue) Write-Verbose -Message 'Test-WebConfigAppSetting - dbconnectionstr (ESENT)'; ('{0}\Devices.edb' -f $DatabasePath) -eq $ExpectedAppSettingValue} -ParameterFilter {$AppSettingName -eq 'dbconnectionstr'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -DatabasePath $DatabasePath  | Should Be $true
+                    Test-TargetResource @testParameters -Ensure Present -DatabasePath $DatabasePath  | Should -Be $true
 
                     Assert-VerifiableMock
                 }
@@ -787,7 +787,7 @@ try
                     Mock -CommandName Get-WebConfigAppSetting -MockWith {'ESENT'} -Verifiable
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {Write-Verbose -Message 'Test-WebConfigAppSetting - dbconnectionstr (ESENT)'; $false} -ParameterFilter {$AppSettingName -eq 'dbconnectionstr'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -797,7 +797,7 @@ try
                     Mock -CommandName Get-WebConfigAppSetting -MockWith {'System.Data.OleDb'} -Verifiable
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {param ($ExpectedAppSettingValue) Write-Verbose -Message 'Test-WebConfigAppSetting - dbconnectionstr (OLE)'; ('Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0}\Devices.mdb;' -f $DatabasePath) -eq $ExpectedAppSettingValue} -ParameterFilter {$AppSettingName -eq 'dbconnectionstr'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -DatabasePath $DatabasePath | Should Be $true
+                    Test-TargetResource @testParameters -Ensure Present -DatabasePath $DatabasePath | Should -Be $true
 
                     Assert-VerifiableMock
                 }
@@ -805,7 +805,7 @@ try
                     Mock -CommandName Get-WebConfigAppSetting -MockWith {'System.Data.OleDb'} -Verifiable
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {Write-Verbose -Message 'Test-WebConfigAppSetting - dbconnectionstr (OLE)'; $false} -ParameterFilter {$AppSettingName -eq 'dbconnectionstr'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -818,14 +818,14 @@ try
 
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {param ($ExpectedAppSettingValue) Write-Verbose -Message 'Test-WebConfigAppSetting - ModulePath'; $modulePath -eq $ExpectedAppSettingValue} -ParameterFilter {$AppSettingName -eq 'ModulePath'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -ModulePath $modulePath | Should Be $true
+                    Test-TargetResource @testParameters -Ensure Present -ModulePath $modulePath | Should -Be $true
 
                     Assert-VerifiableMock
                 }
                 It 'Should return $false when ModulePath is not set the same as in web.config' {
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {Write-Verbose -Message 'Test-WebConfigAppSetting - ModulePath'; $false} -ParameterFilter {$AppSettingName -eq 'ModulePath'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -837,7 +837,7 @@ try
 
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {param ($ExpectedAppSettingValue) Write-Verbose -Message 'Test-WebConfigAppSetting - ConfigurationPath';  $configurationPath -eq $ExpectedAppSettingValue} -ParameterFilter {$AppSettingName -eq 'ConfigurationPath'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -ConfigurationPath $configurationPath | Should Be $true
+                    Test-TargetResource @testParameters -Ensure Present -ConfigurationPath $configurationPath | Should -Be $true
 
                     Assert-VerifiableMock
                 }
@@ -846,7 +846,7 @@ try
 
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {Write-Verbose -Message 'Test-WebConfigAppSetting - ConfigurationPath'; $false} -ParameterFilter {$AppSettingName -eq 'ConfigurationPath'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -ConfigurationPath $configurationPath | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present -ConfigurationPath $configurationPath | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -858,7 +858,7 @@ try
 
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {param ($ExpectedAppSettingValue) Write-Verbose -Message 'Test-WebConfigAppSetting - RegistrationKeyPath';  $registrationKeyPath -eq $ExpectedAppSettingValue} -ParameterFilter {$AppSettingName -eq 'RegistrationKeyPath'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -RegistrationKeyPath $registrationKeyPath | Should Be $true
+                    Test-TargetResource @testParameters -Ensure Present -RegistrationKeyPath $registrationKeyPath | Should -Be $true
 
                     Assert-VerifiableMock
                 }
@@ -867,7 +867,7 @@ try
 
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {Write-Verbose -Message 'Test-WebConfigAppSetting - RegistrationKeyPath'; $false} -ParameterFilter {$AppSettingName -eq 'RegistrationKeyPath'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -RegistrationKeyPath $registrationKeyPath | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present -RegistrationKeyPath $registrationKeyPath | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -876,7 +876,7 @@ try
 
                     Mock -CommandName Test-WebConfigModulesSetting -MockWith {param ($ExpectedInstallationStatus) Write-Verbose -Message 'Test-WebConfigAppSetting - IISSelfSignedCertModule'; $acceptSelfSignedCertificates -eq $ExpectedInstallationStatus} -ParameterFilter {$ModuleName -eq 'IISSelfSignedCertModule(32bit)'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -AcceptSelfSignedCertificates $acceptSelfSignedCertificates | Should Be $true
+                    Test-TargetResource @testParameters -Ensure Present -AcceptSelfSignedCertificates $acceptSelfSignedCertificates | Should -Be $true
 
                     Assert-VerifiableMock
                 }
@@ -885,7 +885,7 @@ try
 
                     Mock -CommandName Test-WebConfigModulesSetting -MockWith {Write-Verbose -Message 'Test-WebConfigAppSetting - IISSelfSignedCertModule'; $false} -ParameterFilter {$ModuleName -eq 'IISSelfSignedCertModule(32bit)'} -Verifiable
 
-                    Test-TargetResource @testParameters -Ensure Present -AcceptSelfSignedCertificates $acceptSelfSignedCertificates | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present -AcceptSelfSignedCertificates $acceptSelfSignedCertificates | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -897,7 +897,7 @@ try
                 #endregion
 
                 It 'Should return $false if Certificate Thumbprint is set to AllowUnencryptedTraffic' {
-                    Test-TargetResource @testParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @testParameters -Ensure Present | Should -Be $false
                 }
 
                 It 'Should return $false if Certificate Subject does not match the current certificate' {
@@ -906,7 +906,7 @@ try
 
                     Mock -CommandName Find-CertificateThumbprintWithSubjectAndTemplateName -MockWith {'ZZYYXXWWVVUUTTSSRRQQPPOONNMMLLKKJJIIHHGG'}
 
-                    Test-TargetResource @altTestParameters -Ensure Present -CertificateSubject 'Invalid Certifcate' | Should Be $false
+                    Test-TargetResource @altTestParameters -Ensure Present -CertificateSubject 'Invalid Certifcate' | Should -Be $false
                 }
 
                 Mock -CommandName Test-WebsitePath -MockWith {$false} -Verifiable
@@ -921,7 +921,7 @@ try
                     Mock -CommandName Test-WebConfigAppSetting -MockWith {$true} -ParameterFilter {$AppSettingName -eq 'ModulePath'} -Verifiable
                     Mock -CommandName Test-UseSecurityBestPractices -MockWith {$false} -Verifiable
 
-                    Test-TargetResource @altTestParameters -Ensure Present | Should Be $false
+                    Test-TargetResource @altTestParameters -Ensure Present | Should -Be $false
 
                     Assert-VerifiableMock
                 }
@@ -933,7 +933,7 @@ try
                     $altTestParameters = $testParameters.Clone()
                     $altTestParameters.Remove('CertificateThumbPrint')
 
-                    {$result = Test-TargetResource @altTestParameters} | Should Throw
+                    {$result = Test-TargetResource @altTestParameters} | Should -Throw
                 }
             }
         }
@@ -946,12 +946,12 @@ try
             Mock -CommandName Get-ItemProperty -MockWith {$endpointPhysicalPath}
 
             It 'Should return $true if Endpoint PhysicalPath doesn''t match PhysicalPath' {
-                Test-WebsitePath -EndpointName 'PesterSite' -PhysicalPath 'TestDrive:\SitePath2' | Should Be $true
+                Test-WebsitePath -EndpointName 'PesterSite' -PhysicalPath 'TestDrive:\SitePath2' | Should -Be $true
 
                 Assert-VerifiableMock
             }
             It 'Should return $true if Endpoint PhysicalPath doesn''t match PhysicalPath' {
-                Test-WebsitePath -EndpointName 'PesterSite' -PhysicalPath $endpointPhysicalPath | Should Be $false
+                Test-WebsitePath -EndpointName 'PesterSite' -PhysicalPath $endpointPhysicalPath | Should -Be $false
 
                 Assert-VerifiableMock
             }
@@ -990,7 +990,7 @@ try
                     [String]
                     $Value
                 )
-                Test-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName $Key -ExpectedAppSettingValue $Value | Should Be $true
+                Test-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName $Key -ExpectedAppSettingValue $Value | Should -Be $true
             }
             It 'Should return $false when ExpectedAppSettingValue is not <Value> for <Key>.' -TestCases $testCases {
                 param
@@ -1003,7 +1003,7 @@ try
                     [String]
                     $Value
                 )
-                Test-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName $Key -ExpectedAppSettingValue 'InvalidValue' | Should Be $false
+                Test-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName $Key -ExpectedAppSettingValue 'InvalidValue' | Should -Be $false
             }
         }
         Describe -Name "$dscResourceName\Get-WebConfigAppSetting" -Fixture {
@@ -1040,10 +1040,10 @@ try
                     [String]
                     $Value
                 )
-                Get-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName $Key | Should Be $Value
+                Get-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName $Key | Should -Be $Value
             }
             It 'Should return Null if Key is not found' {
-                Get-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName 'InvalidKey' | Should BeNullOrEmpty
+                Get-WebConfigAppSetting -WebConfigFullPath $webConfigPath -AppSettingName 'InvalidKey' | Should -BeNullOrEmpty
             }
         }
         Describe -Name "$dscResourceName\Test-WebConfigModulesSetting" -Fixture {
@@ -1055,16 +1055,16 @@ try
             $null = New-Item -Path $webConfigPath -Value $webConfig
 
             It 'Should return $true if Module is present in Web.config and expected to be installed.' {
-                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'IISSelfSignedCertModule(32bit)' -ExpectedInstallationStatus $true | Should Be $true
+                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'IISSelfSignedCertModule(32bit)' -ExpectedInstallationStatus $true | Should -Be $true
             }
             It 'Should return $false if Module is present in Web.config and not expected to be installed.' {
-                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'IISSelfSignedCertModule(32bit)' -ExpectedInstallationStatus $false | Should Be $false
+                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'IISSelfSignedCertModule(32bit)' -ExpectedInstallationStatus $false | Should -Be $false
             }
             It 'Should return $true if Module is not present in Web.config and not expected to be installed.' {
-                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'FakeModule' -ExpectedInstallationStatus $false | Should Be $true
+                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'FakeModule' -ExpectedInstallationStatus $false | Should -Be $true
             }
             It 'Should return $false if Module is not present in Web.config and expected to be installed.' {
-                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'FakeModule' -ExpectedInstallationStatus $true | Should Be $false
+                Test-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'FakeModule' -ExpectedInstallationStatus $true | Should -Be $false
             }
         }
         Describe -Name "$dscResourceName\Get-WebConfigModulesSetting" -Fixture {
@@ -1076,10 +1076,10 @@ try
             $null = New-Item -Path $webConfigPath -Value $webConfig
 
             It 'Should return the Module name if it is present in Web.config.' {
-                Get-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'IISSelfSignedCertModule(32bit)' | Should Be 'IISSelfSignedCertModule(32bit)'
+                Get-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'IISSelfSignedCertModule(32bit)' | Should -Be 'IISSelfSignedCertModule(32bit)'
             }
             It 'Should return an empty string if the module is not present in Web.config.' {
-                Get-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'FakeModule' | Should Be ''
+                Get-WebConfigModulesSetting -WebConfigFullPath $webConfigPath -ModuleName 'FakeModule' | Should -Be ''
             }
         }
         Describe -Name "$dscResourceName\Get-ScriptFolder" -Fixture {
@@ -1089,7 +1089,7 @@ try
 
             It 'Should return the directory that contains this script' {
                 Mock -CommandName Get-Variable -MockWith {@{Value = @{MyCommand = @{Path = 'TestDrive:\Directory\File.txt'}}}}
-                Get-ScriptFolder | Should Be 'TestDrive:\Directory'
+                Get-ScriptFolder | Should -Be 'TestDrive:\Directory'
             }
         }
         Describe -Name "$dscResourceName\Update-LocationTagInApplicationHostConfigForAuthentication" -Fixture {
@@ -1121,26 +1121,26 @@ try
 
             Mock -CommandName Get-ChildItem -MockWith {,@($certificateData)}
             It 'Should return the certificate thumbprint when the certificate is found' {
-                Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $certificateData[0].Subject -TemplateName 'WebServer' | Should Be $certificateData[0].Thumbprint
+                Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $certificateData[0].Subject -TemplateName 'WebServer' | Should -Be $certificateData[0].Thumbprint
             }
             It 'Should throw an error when the certificate is not found' {
                 $subject      = $certificateData[0].Subject
                 $templateName = 'Invalid Template Name'
 
                 $errorMessage = 'Certificate not found with subject containing {0} and using template "{1}".' -f $subject, $templateName
-                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should throw $errorMessage
+                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -throw $errorMessage
             }
             It 'Should throw an error when the more than one certificate is found' {
                 $subject      = $certificateData[1].Subject
                 $templateName = 'WebServer'
 
                 $errorMessage = 'More than one certificate found with subject containing {0} and using template "{1}".' -f $subject, $templateName
-                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should throw $errorMessage
+                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -throw $errorMessage
             }
         }
         Describe -Name "$dscResourceName\Get-OSVersion" -Fixture {
             It 'Should return a System.Version object' {
-                Get-OSVersion | Should BeOfType System.Version
+                Get-OSVersion | Should -BeOfType System.Version
             }
         }
     }

--- a/Tests/Unit/MSFT_xDSCWebService.Tests.ps1
+++ b/Tests/Unit/MSFT_xDSCWebService.Tests.ps1
@@ -247,11 +247,11 @@ try
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
                     param
                     (
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [String]
                         $Variable,
 
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [PSObject]
                         $Data
                     )
@@ -296,11 +296,11 @@ try
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
                     param
                     (
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [String]
                         $Variable,
 
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [PSObject]
                         $Data
                     )
@@ -346,11 +346,11 @@ try
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
                     param
                     (
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [String]
                         $Variable,
 
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [PSObject]
                         $Data
                     )
@@ -400,11 +400,11 @@ try
                 It 'Should return <Variable> set to <Data>' -TestCases $testData {
                     param
                     (
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [String]
                         $Variable,
 
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [PSObject]
                         $Data
                     )
@@ -521,18 +521,18 @@ try
                 It 'Should create the <Name> directory' -TestCases $testCases {
                     param
                     (
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [String]
                         $Name,
 
-                        [Parameter(Mandatory)]
+                        [Parameter(Mandatory = $true)]
                         [String]
                         $Value
                     )
 
                     Set-TargetResource @testParameters @setTargetPaths -Ensure Present
 
-                    Test-Path -Path $Value | Should -be $true
+                    Test-Path -Path $Value | Should -Be $true
                 }
             }
 
@@ -655,7 +655,7 @@ try
 
                 It 'Should throw an error because no certificate specified' {
                     $message = "Error: Cannot use best practice security settings with unencrypted traffic. Please set UseSecurityBestPractices to `$false or use a certificate to encrypt pull server traffic."
-                    {Set-TargetResource @altTestParameters -Ensure Present} | Should -throw $message
+                    {Set-TargetResource @altTestParameters -Ensure Present} | Should -Throw $message
                 }
             }
 
@@ -698,7 +698,7 @@ try
                 }
 
                 It 'Should not throw an error' {
-                    {Set-TargetResource @altTestParameters @setTargetPaths -Ensure Present} | Should -not -throw
+                    {Set-TargetResource @altTestParameters @setTargetPaths -Ensure Present} | Should -Not -throw
                 }
 
                 It 'Should call expected mocks' {
@@ -982,11 +982,11 @@ try
             It 'Should return $true when ExpectedAppSettingValue is <Value> for <Key>.' -TestCases $testCases {
                 param
                 (
-                    [Parameter(Mandatory)]
+                    [Parameter(Mandatory = $true)]
                     [String]
                     $Key,
 
-                    [Parameter(Mandatory)]
+                    [Parameter(Mandatory = $true)]
                     [String]
                     $Value
                 )
@@ -995,11 +995,11 @@ try
             It 'Should return $false when ExpectedAppSettingValue is not <Value> for <Key>.' -TestCases $testCases {
                 param
                 (
-                    [Parameter(Mandatory)]
+                    [Parameter(Mandatory = $true)]
                     [String]
                     $Key,
 
-                    [Parameter(Mandatory)]
+                    [Parameter(Mandatory = $true)]
                     [String]
                     $Value
                 )
@@ -1032,11 +1032,11 @@ try
             It 'Should return <Value> when Key is <Key>.' -TestCases $testCases {
                 param
                 (
-                    [Parameter(Mandatory)]
+                    [Parameter(Mandatory = $true)]
                     [String]
                     $Key,
 
-                    [Parameter(Mandatory)]
+                    [Parameter(Mandatory = $true)]
                     [String]
                     $Value
                 )
@@ -1128,14 +1128,14 @@ try
                 $templateName = 'Invalid Template Name'
 
                 $errorMessage = 'Certificate not found with subject containing {0} and using template "{1}".' -f $subject, $templateName
-                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -throw $errorMessage
+                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -Throw $errorMessage
             }
             It 'Should throw an error when the more than one certificate is found' {
                 $subject      = $certificateData[1].Subject
                 $templateName = 'WebServer'
 
                 $errorMessage = 'More than one certificate found with subject containing {0} and using template "{1}".' -f $subject, $templateName
-                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -throw $errorMessage
+                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -Throw $errorMessage
             }
         }
         Describe -Name "$dscResourceName\Get-OSVersion" -Fixture {

--- a/Tests/Unit/ResourceSetHelper.Tests.ps1
+++ b/Tests/Unit/ResourceSetHelper.Tests.ps1
@@ -25,7 +25,7 @@ InModuleScope 'ResourceSetHelper' {
             $keyParameterName = 'Name'
 
             $commonParameterString = New-ResourceSetCommonParameterString -KeyParameterName $keyParameterName -Parameters $parameters
-            $commonParameterString | Should Be "CommonStringParameter1 = `"CommonParameter1`"`r`n"
+            $commonParameterString | Should -Be "CommonStringParameter1 = `"CommonParameter1`"`r`n"
         }
 
         It 'Should return string containing one variable reference for one credential common parameter' {
@@ -40,7 +40,7 @@ InModuleScope 'ResourceSetHelper' {
             $keyParameterName = 'Name'
 
             $commonParameterString = New-ResourceSetCommonParameterString -KeyParameterName $keyParameterName -Parameters $parameters
-            $commonParameterString | Should Be "CommonCredentialParameter1 = `$CommonCredentialParameter1`r`n"
+            $commonParameterString | Should -Be "CommonCredentialParameter1 = `$CommonCredentialParameter1`r`n"
         }
 
         It 'Should return string containing all parameters for two string common parameters and two int common parameters' {
@@ -55,10 +55,10 @@ InModuleScope 'ResourceSetHelper' {
             $keyParameterName = 'Name'
 
             $commonParameterString = New-ResourceSetCommonParameterString -KeyParameterName $keyParameterName -Parameters $parameters
-            $commonParameterString.Contains("CommonStringParameter1 = `"CommonParameter1`"`r`n") | Should Be $true
-            $commonParameterString.Contains("CommonStringParameter2 = `"CommonParameter2`"`r`n") | Should Be $true
-            $commonParameterString.Contains("CommonIntParameter1 = `$CommonIntParameter1`r`n") | Should Be $true
-            $commonParameterString.Contains("CommonIntParameter2 = `$CommonIntParameter2`r`n") | Should Be $true
+            $commonParameterString.Contains("CommonStringParameter1 = `"CommonParameter1`"`r`n") | Should -Be $true
+            $commonParameterString.Contains("CommonStringParameter2 = `"CommonParameter2`"`r`n") | Should -Be $true
+            $commonParameterString.Contains("CommonIntParameter1 = `$CommonIntParameter1`r`n") | Should -Be $true
+            $commonParameterString.Contains("CommonIntParameter2 = `$CommonIntParameter2`r`n") | Should -Be $true
         }
     }
 
@@ -73,7 +73,7 @@ InModuleScope 'ResourceSetHelper' {
 
         It 'Should return string with module import and one resource for one key value' {
             $resourceString = New-ResourceSetConfigurationString @newResourceSetConfigurationStringParams
-            $resourceString | Should Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
+            $resourceString | Should -Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
                 "ResourceName Resource0`r`n{`r`nName = `"KeyValue1`"`r`n$($newResourceSetConfigurationStringParams['CommonParameterString'])}`r`n")
         }
 
@@ -81,7 +81,7 @@ InModuleScope 'ResourceSetHelper' {
 
         It 'Should return string with module import and two resources for two key values' {
             $resourceString = New-ResourceSetConfigurationString @newResourceSetConfigurationStringParams
-            $resourceString | Should Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
+            $resourceString | Should -Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
                 "ResourceName Resource0`r`n{`r`nName = `"KeyValue1`"`r`n$($newResourceSetConfigurationStringParams['CommonParameterString'])}`r`n" + `
                 "ResourceName Resource1`r`n{`r`nName = `"KeyValue2`"`r`n$($newResourceSetConfigurationStringParams['CommonParameterString'])}`r`n")
         }
@@ -108,11 +108,11 @@ InModuleScope 'ResourceSetHelper' {
         $newResourceSetConfigurationScriptBlock = New-ResourceSetConfigurationScriptBlock @newResourceSetConfigurationParams
 
         It 'Should return a ScriptBlock' {
-            $newResourceSetConfigurationScriptBlock -is [ScriptBlock] | Should Be $true
+            $newResourceSetConfigurationScriptBlock -is [ScriptBlock] | Should -Be $true
         }
 
         It 'Should return ScriptBlock of string returned from New-ResourceSetConfigurationString' {
-            $newResourceSetConfigurationScriptBlock | Should Match ([ScriptBlock]::Create($configurationString))
+            $newResourceSetConfigurationScriptBlock | Should -Match ([ScriptBlock]::Create($configurationString))
         }
 
         It 'Should call New-ResourceSetConfigurationString with the correct ModuleName' {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR:
* Update `CommonResourceHelper` unit tests to meet Pester 4.0.0
  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
* Update `ResourceHelper` unit tests to meet Pester 4.0.0
  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
* Update `MSFT_xDSCWebService` unit tests to meet Pester 4.0.0
  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).
* Update `MSFT_xDSCWebService` integration tests to meet Pester 4.0.0
  standards ([issue #473](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/473)).

#### This Pull Request (PR) fixes the following issues

- Does not fix any issues but contributes to #473 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju would you mind reviewing when you get a moment. Should be straight forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/475)
<!-- Reviewable:end -->
