### PR TITLE
Correct Style Guideline violation in xGroup - Fixes #485

### DIFF
--- a/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
+++ b/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.psm1
@@ -96,6 +96,7 @@ function Get-TargetResource
         [String]
         $GroupName,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential
@@ -127,7 +128,7 @@ function Get-TargetResource
 
         To ensure that the group does exist, set this property to present.
         To ensure that the group does not exist, set this property to Absent.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -138,10 +139,10 @@ function Get-TargetResource
 
         This property will replace all the current group members with the specified members.
 
-        Members should be specified as strings in the format of their domain qualified name 
+        Members should be specified as strings in the format of their domain qualified name
         (domain\username), their UPN (username@domainname), their distinguished name (CN=username,DC=...),
-        or their username (for local machine accounts).  
-        
+        or their username (for local machine accounts).
+
         Using either the MembersToExclude or MembersToInclude properties in the same configuration
         as this property will generate an error.
 
@@ -150,7 +151,7 @@ function Get-TargetResource
 
         This property will only add members to a group.
 
-        Members should be specified as strings in the format of their domain qualified name 
+        Members should be specified as strings in the format of their domain qualified name
         (domain\username), their UPN (username@domainname), their distinguished name (CN=username,DC=...),
         or their username (for local machine accounts).
 
@@ -161,7 +162,7 @@ function Get-TargetResource
 
         This property will only remove members from a group.
 
-        Members should be specified as strings in the format of their domain qualified name 
+        Members should be specified as strings in the format of their domain qualified name
         (domain\username), their UPN (username@domainname), their distinguished name (CN=username,DC=...),
         or their username (for local machine accounts).
 
@@ -188,22 +189,28 @@ function Set-TargetResource
         [String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
+        [Parameter()]
         [String]
         $Description,
 
+        [Parameter()]
         [String[]]
         $Members,
 
+        [Parameter()]
         [String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -244,10 +251,10 @@ function Set-TargetResource
 
     .PARAMETER Members
         The list of members the group should have.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts.  
+        a unqualified (username) for local machine accounts.
 
         If you set this property in a configuration, do not use either the MembersToExclude or
         MembersToInclude property. Doing so will generate an error.
@@ -255,9 +262,9 @@ function Set-TargetResource
     .PARAMETER MembersToInclude
         A list of members that should be in the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts.  
+        a unqualified (username) for local machine accounts.
 
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
@@ -265,7 +272,7 @@ function Set-TargetResource
     .PARAMETER MembersToExclude
         A list of members that should not be in the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -286,22 +293,28 @@ function Test-TargetResource
         [String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
+        [Parameter()]
         [String]
         $Description,
 
+        [Parameter()]
         [String[]]
         $Members,
 
+        [Parameter()]
         [String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -343,6 +356,7 @@ function Get-TargetResourceOnFullSKU
         [String]
         $GroupName,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential
@@ -411,6 +425,7 @@ function Get-TargetResourceOnNanoServer
         [String]
         $GroupName,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential
@@ -454,10 +469,10 @@ function Get-TargetResourceOnNanoServer
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -465,31 +480,31 @@ function Get-TargetResourceOnNanoServer
 
     .PARAMETER Members
         Use this property to replace the current group membership with the specified members.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         an unqualified (username) for local machine accounts.
-        
-        If you set this property in a configuration, do not use either the MembersToExclude or 
+
+        If you set this property in a configuration, do not use either the MembersToExclude or
         MembersToInclude property. Doing so will generate an error.
 
     .PARAMETER MembersToInclude
         Use this property to add members to the existing membership of the group.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts. 
-        
+        a unqualified (username) for local machine accounts.
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
     .PARAMETER MembersToExclude
         Use this property to remove members from the existing membership of the group.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts. 
-        
+        a unqualified (username) for local machine accounts.
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
@@ -508,22 +523,28 @@ function Set-TargetResourceOnFullSKU
         [String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
+        [Parameter()]
         [String]
         $Description,
 
+        [Parameter()]
         [String[]]
         $Members,
 
+        [Parameter()]
         [String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -806,10 +827,10 @@ function Set-TargetResourceOnFullSKU
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -817,31 +838,31 @@ function Set-TargetResourceOnFullSKU
 
     .PARAMETER Members
         Use this property to replace the current group membership with the specified members.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
-        
-        If you set this property in a configuration, do not use either the MembersToExclude or 
+
+        If you set this property in a configuration, do not use either the MembersToExclude or
         MembersToInclude property. Doing so will generate an error.
 
     .PARAMETER MembersToInclude
         Use this property to add members to the existing membership of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
-        
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
     .PARAMETER MembersToExclude
         Use this property to remove members from the existing membership of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
-        
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
@@ -859,22 +880,28 @@ function Set-TargetResourceOnNanoServer
         [String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
+        [Parameter()]
         [String]
         $Description,
 
+        [Parameter()]
         [String[]]
         $Members,
 
+        [Parameter()]
         [String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -923,7 +950,7 @@ function Set-TargetResourceOnNanoServer
             }
 
             # Set the group properties.
-            if ($PSBoundParameters.ContainsKey('Description') -and 
+            if ($PSBoundParameters.ContainsKey('Description') -and
                 ((-not $groupOriginallyExists) -or ($Description -ne $group.Description)))
             {
                 Set-LocalGroup -Name $GroupName -Description $Description
@@ -1036,10 +1063,10 @@ function Set-TargetResourceOnNanoServer
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -1048,8 +1075,8 @@ function Set-TargetResourceOnNanoServer
     .PARAMETER Members
         Use this property to test if the existing membership of the group matches
         the list provided.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1058,9 +1085,9 @@ function Set-TargetResourceOnNanoServer
 
     .PARAMETER MembersToInclude
         Use this property to test if members need to be added to the existing membership
-        of the group. 
+        of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1071,7 +1098,7 @@ function Set-TargetResourceOnNanoServer
         Use this property to test if members need to removed from the existing membership
         of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1092,22 +1119,28 @@ function Test-TargetResourceOnFullSKU
         [String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
+        [Parameter()]
         [String]
         $Description,
 
+        [Parameter()]
         [String[]]
         $Members,
 
+        [Parameter()]
         [String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -1297,10 +1330,10 @@ function Test-TargetResourceOnFullSKU
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -1310,7 +1343,7 @@ function Test-TargetResourceOnFullSKU
         Use this property to test if the existing membership of the group matches
         the list provided.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1321,7 +1354,7 @@ function Test-TargetResourceOnFullSKU
         Use this property to test if members need to be added to the existing membership
         of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1332,7 +1365,7 @@ function Test-TargetResourceOnFullSKU
         Use this property to test if members need to removed from the existing membership
         of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1353,22 +1386,28 @@ function Test-TargetResourceOnNanoServer
         [String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present',
 
+        [Parameter()]
         [String]
         $Description,
 
+        [Parameter()]
         [String[]]
         $Members,
 
+        [Parameter()]
         [String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
@@ -1571,6 +1610,7 @@ function Get-MembersOnFullSKU
         [AllowEmptyCollection()]
         $Disposables,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential
@@ -1656,6 +1696,7 @@ function Get-MembersAsPrincipalsList
         [AllowEmptyCollection()]
         $Disposables,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential
@@ -1833,6 +1874,7 @@ function ConvertTo-UniquePrincipalsList
         [AllowEmptyCollection()]
         $Disposables,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential
@@ -1922,6 +1964,7 @@ function ConvertTo-Principal
         [AllowEmptyCollection()]
         $Disposables,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential
@@ -2061,6 +2104,7 @@ function Get-PrincipalContext
         [String]
         $Scope,
 
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential,
@@ -2117,7 +2161,7 @@ function Get-PrincipalContext
         }
 
         $principalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' `
-            -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Domain, $Scope, 
+            -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Domain, $Scope,
                 $principalContextName, $Credential.GetNetworkCredential().Password )
 
         # Cache the PrincipalContext for this scope for subsequent calls.
@@ -2329,6 +2373,7 @@ function Find-Principal
         [String]
         $IdentityValue,
 
+        [Parameter()]
         [System.DirectoryServices.AccountManagement.IdentityType]
         $IdentityType
     )
@@ -2341,7 +2386,7 @@ function Find-Principal
     {
         return [System.DirectoryServices.AccountManagement.Principal]::FindByIdentity($PrincipalContext, $IdentityValue)
     }
-    
+
 }
 
 <#
@@ -2435,7 +2480,7 @@ function Clear-GroupMembers
         [System.DirectoryServices.AccountManagement.GroupPrincipal]
         $Group
     )
-    
+
     $Group.Members.Clear()
 }
 
@@ -2517,7 +2562,7 @@ function Remove-Group
         [System.DirectoryServices.AccountManagement.GroupPrincipal]
         $Group
     )
-    
+
     $Group.Delete()
 }
 

--- a/README.md
+++ b/README.md
@@ -714,13 +714,15 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 
 ### Unreleased
 
+* xGroup
+  * Corrected style guideline violations. ([issue #485](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/485))
 * xWindowsOptionalFeature
-  * Suppress useless verbose output from `Import-Module` cmdlet. ([issue 453](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/453))
+  * Suppress useless verbose output from `Import-Module` cmdlet. ([issue #453](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/453))
 * Changes to xRemoteFile
   * Corrected a resource name in the example xRemoteFile_DownloadFileConfig.ps1
 * Fix `MSFT_xDSCWebService` to find
  `Microsoft.Powershell.DesiredStateConfiguration.Service.Resources.dll`
-  when server is configured with pt-BR Locales ([issue #284](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/284)).  
+  when server is configured with pt-BR Locales ([issue #284](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/284)).
 * Changes to xDSCWebService
   * Fixed an issue which prevented the removal of the IIS Application Pool created during deployment of an DSC Pull Server instance. ([issue #464](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/464))
   * Fixed an issue where a Pull Server cannot be deployed on a machine when IIS Express is installed aside a full blown IIS ([issue #191](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/191))


### PR DESCRIPTION
#### Pull Request (PR) description

This PR correct style guideline violations in xGroup. Trailing white space was also trimmed automatically by VSCode.

#### This Pull Request (PR) fixes the following issues

- Fixes #485

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
