### PR TITLE
CommonTestHelper.psm1: Prevent multiple calls to git clone or git pull of the same module in the same build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@
   - Corrected style guideline violations. ([issue #496](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/496))
 - Changes to PSWSIISEndpoint.psm1
   - Fixes most PSScriptAnalyzer issues.
+- Updates test helper Enter-DscResourceTestEnvironment to only clone or pull
+  DscResource.Tests a maximum of one time per build. Currently it will clone or
+  pull every time this function is hit.
 - Changes to xRegistry
   - Fixed an issue that fails to remove reg key when the `Key` is specified as
     common registry path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,22 @@
 - Added unit tests for `New-InvalidArgumentException`, `New-InvalidDataException` and
   `New-InvalidOperationException` CommonResourceHelper.psm1 functions.
 - Changes to `MSFT_xDSCWebService`
-  - Fixed [issue #528](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/528): Unable to disable selfsigned certificates using AcceptSelfSignedCertificates=$false
-  - Fixed [issue #460](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/460): Redeploy DSC Pull Server fails with error
+  - Fixed
+    [issue #528](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/528)
+    : Unable to disable selfsigned certificates using AcceptSelfSignedCertificates=$false
+  - Fixed
+    [issue #460](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/460)
+    : Redeploy DSC Pull Server fails with error
+- Updates test helper Enter-DscResourceTestEnvironment to only clone or pull
+  DscResource.Tests a maximum of one time per build. Currently it will clone or
+  pull every time this function is hit.
 
 ## 8.5.0.0
 
 - Pull server module publishing
-  - Removed forced verbose logging from CreateZipFromSource, Publish-DSCModulesAndMof and Publish-MOFToPullServer as it polluted the console
+  - Removed forced verbose logging from CreateZipFromSource,
+    Publish-DSCModulesAndMof and Publish-MOFToPullServer as it polluted the
+    console
 - Corrected GitHub Pull Request template to remove referral to
   `BestPractices.MD` which has been combined into `StyleGuidelines.md`
   ([issue #520](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/520)).
@@ -104,9 +113,6 @@
   - Corrected style guideline violations. ([issue #496](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/496))
 - Changes to PSWSIISEndpoint.psm1
   - Fixes most PSScriptAnalyzer issues.
-- Updates test helper Enter-DscResourceTestEnvironment to only clone or pull
-  DscResource.Tests a maximum of one time per build. Currently it will clone or
-  pull every time this function is hit.
 - Changes to xRegistry
   - Fixed an issue that fails to remove reg key when the `Key` is specified as
     common registry path.

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -728,7 +728,7 @@ function Enter-DscResourceTestEnvironment
         $TestType
     )
 
-    $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:moduleRoot = Split-Path -Parent $PSScriptRoot
 
     if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
          (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -741,7 +741,7 @@ function Enter-DscResourceTestEnvironment
 
         $Global:UpdatedDscResourceTestsModule = $true
     }
-    elseif (-not ($Global:UpdatedDscResourceTestsModule))
+    elseif (($Global:UpdatedDscResourceTestsModule -eq $false))
     {
         $gitInstalled = $null -ne (Get-Command -Name 'git' -ErrorAction 'SilentlyContinue')
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -728,33 +728,15 @@ function Enter-DscResourceTestEnvironment
         $TestType
     )
 
-    $moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
-    $dscResourceTestsPath = Join-Path -Path $moduleRootPath -ChildPath 'DSCResource.Tests'
-    $testHelperFilePath = Join-Path -Path $dscResourceTestsPath -ChildPath 'TestHelper.psm1'
+    $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 
-    if (-not (Test-Path -Path $dscResourceTestsPath))
+    if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+         (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
     {
-        Push-Location $moduleRootPath
-        git clone 'https://github.com/PowerShell/DscResource.Tests' --quiet
-        Pop-Location
-    }
-    else
-    {
-        $gitInstalled = $null -ne (Get-Command -Name 'git' -ErrorAction 'SilentlyContinue')
-
-        if ($gitInstalled)
-        {
-            Push-Location $dscResourceTestsPath
-            git pull origin dev --quiet
-            Pop-Location
-        }
-        else
-        {
-            Write-Verbose -Message 'Git not installed. Leaving current DSCResource.Tests as is.'
-        }
+        & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath 'DscResource.Tests'))
     }
 
-    Import-Module -Name $testHelperFilePath
+    Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 
     return Initialize-TestEnvironment `
         -DSCModuleName $DscResourceModuleName `

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -741,8 +741,7 @@ function Enter-DscResourceTestEnvironment
 
         $Global:UpdatedDscResourceTestsModule = $true
     }
-    elseif (($null -eq $Global:UpdatedDscResourceTestsModule -or `
-             $Global:UpdatedDscResourceTestsModule -eq $false))
+    elseif (($null -eq $Global:UpdatedDscResourceTestsModule))
     {
         $gitInstalled = $null -ne (Get-Command -Name 'git' -ErrorAction 'SilentlyContinue')
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -741,7 +741,8 @@ function Enter-DscResourceTestEnvironment
 
         $Global:UpdatedDscResourceTestsModule = $true
     }
-    elseif (($Global:UpdatedDscResourceTestsModule -eq $false))
+    elseif (($null -eq $Global:UpdatedDscResourceTestsModule -or `
+             $Global:UpdatedDscResourceTestsModule -eq $false))
     {
         $gitInstalled = $null -ne (Get-Command -Name 'git' -ErrorAction 'SilentlyContinue')
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -741,7 +741,8 @@ function Enter-DscResourceTestEnvironment
 
         $Global:UpdatedDscResourceTestsModule = $true
     }
-    elseif (($null -eq $Global:UpdatedDscResourceTestsModule))
+    elseif (-not (Test-Path -Path Variable:Global:UpdatedDscResourceTestsModule) -or
+                 ($Global:UpdatedDscResourceTestsModule -eq $false))
     {
         $gitInstalled = $null -ne (Get-Command -Name 'git' -ErrorAction 'SilentlyContinue')
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -733,7 +733,7 @@ function Enter-DscResourceTestEnvironment
     $dscResourceTestsPath = Join-Path -Path $moduleRootPath -ChildPath 'DSCResource.Tests'
     $testHelperFilePath = Join-Path -Path $dscResourceTestsPath -ChildPath 'TestHelper.psm1'
 
-    # Populate the variable to track whether we've updated DSCResource.Tests recently
+    # If necessary, populate the variable to track whether we've updated DSCResource.Tests recently
     if (-not (Test-Path -Path Variable:Global:UpdatedDscResourceTestsModule))
     {
         $Global:UpdatedDscResourceTestsModule = $false

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -758,7 +758,8 @@ function Enter-DscResourceTestEnvironment
                       Select-Object -First 1
 
         # Update DSCResource.Tests if it hasn't been updated within the past hour
-        if ((([DateTime]::Now) - $newestFile.LastWriteTime).TotalHours -gt 1.0)
+        if ($null -eq $newestFile.LastWriteTime -or
+            (([DateTime]::Now) - $newestFile.LastWriteTime).TotalHours -gt 1.0)
         {
             $gitInstalled = $null -ne (Get-Command -Name 'git' -ErrorAction 'SilentlyContinue')
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -753,7 +753,7 @@ function Enter-DscResourceTestEnvironment
     {
         # Get the last modified date of the newest file in DSCResource.Tests
         $newestFile = Get-ChildItem -Path $dscResourceTestsPath -Recurse | `
-                      Where-Object -FilterScript {$_.GetType() -like "FileInfo"} | `
+                      Where-Object -FilterScript {$_.GetType().Name -like 'FileInfo'} | `
                       Sort-Object -Property LastWriteTime -Descending | `
                       Select-Object -First 1
 
@@ -765,6 +765,8 @@ function Enter-DscResourceTestEnvironment
 
             if ($gitInstalled)
             {
+                Write-Verbose -Message 'DSCResource.Tests has not been updated in over an hour. Performing a git pull against repository.'
+
                 Push-Location $dscResourceTestsPath
                 git pull origin dev --quiet
                 Pop-Location


### PR DESCRIPTION
#### Pull Request (PR) description
Updates test helper Enter-DscResourceTestEnvironment to only clone or pull DscResource.Tests a maximum of one time per build. Currently it will clone or pull every time this function is hit. This doesn't directly address #505, but makes it far less likely to occur, as git clone will only be called once per build, instead of once per test file.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/516)
<!-- Reviewable:end -->
