### PR TITLE
Module Publishing: Removing hard coded verbose logging

### DIFF
--- a/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
+++ b/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
@@ -2,13 +2,13 @@
 .SYNOPSIS
    Package DSC modules and mof configuration document and publish them on an enterprise DSC pull server in the required format.
 .DESCRIPTION
-   Uses Publish-DSCModulesAndMof function to package DSC modules into zip files with the version info. 
+   Uses Publish-DSCModulesAndMof function to package DSC modules into zip files with the version info.
    Publishes the zip modules on "$env:ProgramFiles\WindowsPowerShell\DscService\Modules".
    Publishes all mof configuration documents that are present in the $Source folder on "$env:ProgramFiles\WindowsPowerShell\DscService\Configuration"-
    Use $Force to overwrite the version of the module that exists in the PowerShell module path with the version from the $source folder.
    Use $ModuleNameList to specify the names of the modules to be published if the modules do not exist in $Source folder.
 .PARAMETER Source
-    The folder that contains the configuration mof documents and modules to be published on Pull server. 
+    The folder that contains the configuration mof documents and modules to be published on Pull server.
     Everything in this folder will be packaged and published.
 .PARAMETER Force
     Switch to overwrite the module in PSModulePath with the version provided in $Sources.
@@ -35,7 +35,7 @@ function Publish-DSCModuleAndMof
     New-Item -Path $tempFolder -ItemType Directory -Force -ErrorAction SilentlyContinue
 
     # Copy the mof documents from the $Source to working dir
-    Copy-Item -Path "$Source\*.mof" -Destination $tempFolder -Force -Verbose
+    Copy-Item -Path "$Source\*.mof" -Destination $tempFolder -Force
 
     # Start Deployment!
     Log -Scope $MyInvocation -Message 'Start Deployment'
@@ -68,12 +68,12 @@ function CreateZipFromPSModulePath
     # Move all required  modules from powershell module path to a temp folder and package them
     if ([string]::IsNullOrEmpty($ListModuleNames))
     {
-        Log -Scope $MyInvocation -Message "No additional modules are specified to be packaged." 
+        Log -Scope $MyInvocation -Message "No additional modules are specified to be packaged."
     }
-    
+
     foreach ($module in $ListModuleNames)
     {
-        $allVersions = Get-Module -Name $module -ListAvailable -Verbose        
+        $allVersions = Get-Module -Name $module -ListAvailable
         # Package all versions of the module
         foreach ($moduleVersion in $allVersions)
         {
@@ -83,15 +83,15 @@ function CreateZipFromPSModulePath
             $path    = $moduleVersion.ModuleBase
             $version = $moduleVersion.Version.ToString()
             Log -Scope $MyInvocation -Message "Zipping $name ($version)"
-            Compress-Archive -Path "$path\*" -DestinationPath "$source.zip" -Verbose -Force 
+            Compress-Archive -Path "$path\*" -DestinationPath "$source.zip" -Force
             $newName = "$Destination\$name" + "_" + "$version" + ".zip"
             # Rename the module folder to contain the version info.
             if (Test-Path $newName)
             {
-                Remove-Item $newName -Recurse -Force 
+                Remove-Item $newName -Recurse -Force
             }
-            Rename-Item -Path "$source.zip" -NewName $newName -Force    
-        } 
+            Rename-Item -Path "$source.zip" -NewName $newName -Force
+        }
     }
 }
 
@@ -109,19 +109,19 @@ function CreateZipFromPSModulePath
 function CreateZipFromSource
 {
     param($Source, $Destination)
-    # for each module under $Source folder create a zip package that has the same name as the folder. 
+    # for each module under $Source folder create a zip package that has the same name as the folder.
     $allModulesInSource = Get-ChildItem -Path $Source -Directory
     $modules = @()
-   
+
     foreach ($item in $allModulesInSource)
     {
         $name = $Item.Name
-        $alreadyExists = Get-Module -Name $name -ListAvailable -Verbose
+        $alreadyExists = Get-Module -Name $name -ListAvailable
         if (($alreadyExists -eq $null) -or ($Force))
         {
-            # Install the modules into PowerShell module path and overwrite the content 
-            Copy-Item -Path $item.FullName -Recurse -Force -Destination "$env:ProgramFiles\WindowsPowerShell\Modules" -Verbose            
-        }              
+            # Install the modules into PowerShell module path and overwrite the content
+            Copy-Item -Path $item.FullName -Recurse -Force -Destination "$env:ProgramFiles\WindowsPowerShell\Modules"
+        }
         else
         {
             Write-Warning "Skipping module overwrite. Module with the name $name already exists."
@@ -148,12 +148,12 @@ function PublishModulesAndChecksum
     if ((Get-Module ServerManager -ListAvailable) -and (Test-Path $moduleRepository))
     {
         Log -Scope $MyInvocation -Message "Copying modules and checksums to [$moduleRepository]."
-        Copy-Item -Path "$Source\*.zip*" -Destination $moduleRepository -Force -Verbose
+        Copy-Item -Path "$Source\*.zip*" -Destination $moduleRepository -Force
     }
     else
     {
         Write-Warning "Copying modules to Pull server module repository skipped because the machine is not a server sku or Pull server endpoint is not deployed."
-    }   
+    }
 }
 
 
@@ -168,10 +168,10 @@ function PublishMofDocuments
    param($Source)
     # Check if the current machine is a server sku.
     $mofRepository = "$env:ProgramFiles\WindowsPowerShell\DscService\Configuration"
-    if ((Get-Module ServerManager -ListAvailable) -and (Test-Path $mofRepository))    
+    if ((Get-Module ServerManager -ListAvailable) -and (Test-Path $mofRepository))
     {
         Log -Scope $MyInvocation -Message "Copying mofs and checksums to [$mofRepository]."
-        Copy-Item -Path "$Source\*.mof*" -Destination $mofRepository -Force -Verbose
+        Copy-Item -Path "$Source\*.mof*" -Destination $mofRepository -Force
     }
     else
     {
@@ -183,7 +183,7 @@ Function Log
 {
     Param(
         $Date = $(Get-Date),
-        $Scope, 
+        $Scope,
         $Message
     )
 
@@ -195,7 +195,7 @@ Function Log
 .SYNOPSIS
    Deploy DSC modules to the pullserver.
 .DESCRIPTION
-   Publish DSC module using Module Info object as an input. 
+   Publish DSC module using Module Info object as an input.
    The cmdlet will figure out the location of the module repository using web.config of the pullserver.
 .PARAMETER Name
     Name of the module.
@@ -221,12 +221,12 @@ function Publish-ModuleToPullServer
                    ValueFromPipelineByPropertyName=$true,
                    Position=0)]
         $Name,
-          
+
         [Parameter(Mandatory=$true,
                    ValueFromPipelineByPropertyName=$true,
                    Position=1)]
         $ModuleBase,
-        
+
         [Parameter(Mandatory=$true,
                    ValueFromPipelineByPropertyName=$true,
                    Position=2)]
@@ -261,20 +261,20 @@ function Publish-ModuleToPullServer
 
       if (Test-Path $targetPath)
       {
-            Compress-Archive -DestinationPath $targetPath -Path "$($ModuleBase)\*" -Update -Verbose
+            Compress-Archive -DestinationPath $targetPath -Path "$($ModuleBase)\*" -Update
       }
       else
       {
-            Compress-Archive -DestinationPath $targetPath -Path "$($ModuleBase)\*" -Verbose
+            Compress-Archive -DestinationPath $targetPath -Path "$($ModuleBase)\*"
       }
     }
     End
     {
        # Now that all the modules are published generate thier checksum.
        New-DscChecksum -Path $OutputFolderPath
-      
+
     }
-} 
+}
 
 
 <#
@@ -298,34 +298,34 @@ function Publish-MOFToPullServer
                    ValueFromPipelineByPropertyName=$true,
                    Position=0)]
         $FullName,
-       
+
         $PullServerWebConfig = "$env:SystemDrive\inetpub\wwwroot\PSDSCPullServer\web.config"
     )
 
     Begin
     {
-       $webConfigXml = [xml](cat $PullServerWebConfig)
+       $webConfigXml = [xml](Get-Content -Path $PullServerWebConfig)
        $configXElement = $webConfigXml.SelectNodes("//appSettings/add[@key = 'ConfigurationPath']")
        $OutputFolderPath =  $configXElement.Value
     }
     Process
     {
-        $fileInfo = [System.IO.FileInfo]::new($FullName)
+        $fileInfo = New-Item -Path $FullName -ItemType File
         if ($fileInfo.Extension -eq '.mof')
         {
-            if (Test-Path $FullName)
+            if (Test-Path -Path $FullName)
             {
-                copy $FullName $OutputFolderPath -Verbose -Force
+                Copy-Item -Path $FullName -Destination $OutputFolderPath -Force
             }
-            else 
+            else
             {
-                Throw "File not found at $FullName"
-            } 
+                throw "File not found at $FullName"
+            }
         }
         else
         {
             throw "Invalid file $FullName. Only mof files can be copied to the pullserver configuration repository"
-        }       
+        }
     }
     End
     {

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 ## Versions
 
 ### Unreleased
-* Pull server modulel publishing
+* Pull server module publishing
   * Removed forced verbose logging from CreateZipFromSource, Publish-DSCModulesAndMof and Publish-MOFToPullServer as it polluted the console
 * xWindowsOptionalFeature
   * Suppress useless verbose output from `Import-Module` cmdlet. ([issue 453](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/453))

--- a/README.md
+++ b/README.md
@@ -713,14 +713,15 @@ Publishes a 'FileInfo' object(s) to the pullserver configuration repository. It 
 ## Versions
 
 ### Unreleased
-
+* Pull server modulel publishing
+  * Removed forced verbose logging from CreateZipFromSource, Publish-DSCModulesAndMof and Publish-MOFToPullServer as it polluted the console
 * xWindowsOptionalFeature
   * Suppress useless verbose output from `Import-Module` cmdlet. ([issue 453](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/453))
 * Changes to xRemoteFile
   * Corrected a resource name in the example xRemoteFile_DownloadFileConfig.ps1
 * Fix `MSFT_xDSCWebService` to find
  `Microsoft.Powershell.DesiredStateConfiguration.Service.Resources.dll`
-  when server is configured with pt-BR Locales ([issue #284](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/284)).  
+  when server is configured with pt-BR Locales ([issue #284](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/284)).
 * Changes to xDSCWebService
   * Fixed an issue which prevented the removal of the IIS Application Pool created during deployment of an DSC Pull Server instance. ([issue #464](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/464))
   * Fixed an issue where a Pull Server cannot be deployed on a machine when IIS Express is installed aside a full blown IIS ([issue #191](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/191))


### PR DESCRIPTION
#### Pull Request (PR) description
The functions CreateZipFromSource, Publish-DSCModulesAndMof and Publish-MOFToPullServer always write verbose output without the caller asking for it. This PR removed the -Verbose switch and improves the code style a little bit.

#### This Pull Request (PR) fixes the following issues
none

#### Task list

This PR just affects the verbose log and should not have any impact on the functionality.

- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/517)
<!-- Reviewable:end -->
