### PR TITLE
Move setting of $global:DSCMachineStatus to helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,9 @@
   [issue #494](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/494))
 - Fixes script analyzer issues in MSFT_xRemoteFile.psm1 missed from
   [issue #490](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/490).
+- Moves calls to set $global:DSCMachineStatus = 1 into a helper function to
+  reduce the number of locations where we need to suppress PSScriptAnalyzer
+  rules PSAvoidGlobalVars and PSUseDeclaredVarsMoreThanAssignments.
 
 ## 8.4.0.0
 

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -176,5 +176,32 @@ function Get-LocalizedData
     return $localizedData
 }
 
+<#
+    .SYNOPSIS
+        Sets the Global DSCMachineStatus variable to the desired value.
+
+    .PARAMETER NewDSCMachineStatus
+        The value to set $global:DSCMachineStatus to.
+#>
+function Set-DSCMachineStatus
+{
+    # Suppressing this rule because $global:DSCMachineStatus is used to trigger a reboot.
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
+    <#
+        Suppressing this rule because $global:DSCMachineStatus is only set,
+        never used (by design of Desired State Configuration).
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory=$true)]
+        [System.Int32]
+        $NewDSCMachineStatus
+    )
+
+    $global:DSCMachineStatus = $NewDSCMachineStatus
+}
+
 Export-ModuleMember -Function @( 'Test-IsNanoServer', 'New-InvalidArgumentException',
     'New-InvalidOperationException', 'Get-LocalizedData' )

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -183,7 +183,7 @@ function Get-LocalizedData
     .PARAMETER NewDSCMachineStatus
         The value to set $global:DSCMachineStatus to.
 #>
-function Set-DSCMachineStatus
+function Set-DSCMachineRebootRequired
 {
     # Suppressing this rule because $global:DSCMachineStatus is used to trigger a reboot.
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -178,10 +178,7 @@ function Get-LocalizedData
 
 <#
     .SYNOPSIS
-        Sets the Global DSCMachineStatus variable to the desired value.
-
-    .PARAMETER NewDSCMachineStatus
-        The value to set $global:DSCMachineStatus to.
+        Sets the Global DSCMachineStatus variable to a value of 1.
 #>
 function Set-DSCMachineRebootRequired
 {
@@ -195,12 +192,9 @@ function Set-DSCMachineRebootRequired
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
-        [System.Int32]
-        $NewDSCMachineStatus
     )
 
-    $global:DSCMachineStatus = $NewDSCMachineStatus
+    $global:DSCMachineStatus = 1
 }
 
 Export-ModuleMember -Function @( 'Test-IsNanoServer', 'New-InvalidArgumentException',

--- a/DSCResources/CommonResourceHelper.psm1
+++ b/DSCResources/CommonResourceHelper.psm1
@@ -197,5 +197,11 @@ function Set-DSCMachineRebootRequired
     $global:DSCMachineStatus = 1
 }
 
-Export-ModuleMember -Function @( 'Test-IsNanoServer', 'New-InvalidArgumentException',
-    'New-InvalidOperationException', 'Get-LocalizedData' )
+Export-ModuleMember `
+    -Function @(
+        'Test-IsNanoServer',
+        'New-InvalidArgumentException',
+        'New-InvalidOperationException',
+        'Get-LocalizedData',
+        'Set-DSCMachineRebootRequired'
+    )

--- a/DSCResources/MSFT_xMsiPackage/MSFT_xMsiPackage.psm1
+++ b/DSCResources/MSFT_xMsiPackage/MSFT_xMsiPackage.psm1
@@ -1,5 +1,3 @@
-# Suppress Global Vars PSSA Error because $global:DSCMachineStatus must be allowed
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 param()
 
@@ -341,7 +339,7 @@ function Set-TargetResource
     if (($serverFeatureData -and $serverFeatureData.RequiresReboot) -or $rebootRequired)
     {
         Write-Verbose $script:localizedData.MachineRequiresReboot
-        $global:DSCMachineStatus = 1
+        Set-DSCMachineStatus -NewDSCMachineStatus 1
     }
     elseif ($Ensure -eq 'Present')
     {

--- a/DSCResources/MSFT_xMsiPackage/MSFT_xMsiPackage.psm1
+++ b/DSCResources/MSFT_xMsiPackage/MSFT_xMsiPackage.psm1
@@ -339,7 +339,7 @@ function Set-TargetResource
     if (($serverFeatureData -and $serverFeatureData.RequiresReboot) -or $rebootRequired)
     {
         Write-Verbose $script:localizedData.MachineRequiresReboot
-        Set-DSCMachineStatus -NewDSCMachineStatus 1
+        Set-DSCMachineRebootRequired
     }
     elseif ($Ensure -eq 'Present')
     {

--- a/DSCResources/MSFT_xPSSessionConfiguration/MSFT_xPSSessionConfiguration.psm1
+++ b/DSCResources/MSFT_xPSSessionConfiguration/MSFT_xPSSessionConfiguration.psm1
@@ -133,7 +133,6 @@ function Get-TargetResource
 function Set-TargetResource
 {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -343,7 +342,7 @@ function Set-TargetResource
         #>
         if ($restartNeeded)
         {
-            $global:DscMachineStatus = 1
+            Set-DSCMachineStatus -NewDSCMachineStatus 1
         }
     }
 

--- a/DSCResources/MSFT_xPSSessionConfiguration/MSFT_xPSSessionConfiguration.psm1
+++ b/DSCResources/MSFT_xPSSessionConfiguration/MSFT_xPSSessionConfiguration.psm1
@@ -342,7 +342,7 @@ function Set-TargetResource
         #>
         if ($restartNeeded)
         {
-            Set-DSCMachineStatus -NewDSCMachineStatus 1
+            Set-DSCMachineRebootRequired
         }
     }
 

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -669,7 +669,7 @@ function Set-TargetResource
     if (($serverFeatureData -and $serverFeatureData.RequiresReboot) -or $registryData -or $exitcode -eq 3010 -or $exitcode -eq 1641)
     {
         Write-Verbose $script:localizedData.MachineRequiresReboot
-        Set-DSCMachineStatus -NewDSCMachineStatus 1
+        Set-DSCMachineRebootRequired
     }
     elseif ($Ensure -eq 'Present')
     {

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -1,5 +1,3 @@
-# Suppress Global Vars PSSA Error because $global:DSCMachineStatus must be allowed
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
 param()
 
@@ -671,7 +669,7 @@ function Set-TargetResource
     if (($serverFeatureData -and $serverFeatureData.RequiresReboot) -or $registryData -or $exitcode -eq 3010 -or $exitcode -eq 1641)
     {
         Write-Verbose $script:localizedData.MachineRequiresReboot
-        $global:DSCMachineStatus = 1
+        Set-DSCMachineStatus -NewDSCMachineStatus 1
     }
     elseif ($Ensure -eq 'Present')
     {

--- a/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
+++ b/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
@@ -1,7 +1,3 @@
-# Global needed to indicate if a restart is required
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
-param ()
-
 Import-Module -Name (Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
                                -ChildPath 'CommonResourceHelper.psm1')
 
@@ -232,7 +228,7 @@ function Set-TargetResource
             if ($feature.RestartNeeded -eq 'Yes')
             {
                 Write-Verbose -Message $script:localizedData.RestartNeeded
-                $global:DSCMachineStatus = 1
+                Set-DSCMachineStatus -NewDSCMachineStatus 1
             }
         }
         else
@@ -283,7 +279,7 @@ function Set-TargetResource
             if ($feature.RestartNeeded -eq 'Yes')
             {
                 Write-Verbose -Message $script:localizedData.RestartNeeded
-                $global:DSCMachineStatus = 1
+                Set-DSCMachineStatus -NewDSCMachineStatus 1
             }
         }
         else

--- a/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
+++ b/DSCResources/MSFT_xWindowsFeature/MSFT_xWindowsFeature.psm1
@@ -228,7 +228,7 @@ function Set-TargetResource
             if ($feature.RestartNeeded -eq 'Yes')
             {
                 Write-Verbose -Message $script:localizedData.RestartNeeded
-                Set-DSCMachineStatus -NewDSCMachineStatus 1
+                Set-DSCMachineRebootRequired
             }
         }
         else
@@ -279,7 +279,7 @@ function Set-TargetResource
             if ($feature.RestartNeeded -eq 'Yes')
             {
                 Write-Verbose -Message $script:localizedData.RestartNeeded
-                Set-DSCMachineStatus -NewDSCMachineStatus 1
+                Set-DSCMachineRebootRequired
             }
         }
         else

--- a/DSCResources/MSFT_xWindowsOptionalFeature/MSFT_xWindowsOptionalFeature.psm1
+++ b/DSCResources/MSFT_xWindowsOptionalFeature/MSFT_xWindowsOptionalFeature.psm1
@@ -1,5 +1,3 @@
-# PSSA global rule suppression is allowed here because $global:DSCMachineStatus must be set
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
 param ()
 
 Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath 'CommonResourceHelper.psm1')
@@ -212,7 +210,7 @@ function Set-TargetResource
     if ($restartNeeded)
     {
         Write-Verbose -Message $script:localizedData.RestartNeeded
-        $global:DSCMachineStatus = 1
+        Set-DSCMachineStatus -NewDSCMachineStatus 1
     }
 
     Write-Verbose -Message ($script:localizedData.SetTargetResourceEndMessage -f $Name)

--- a/DSCResources/MSFT_xWindowsOptionalFeature/MSFT_xWindowsOptionalFeature.psm1
+++ b/DSCResources/MSFT_xWindowsOptionalFeature/MSFT_xWindowsOptionalFeature.psm1
@@ -210,7 +210,7 @@ function Set-TargetResource
     if ($restartNeeded)
     {
         Write-Verbose -Message $script:localizedData.RestartNeeded
-        Set-DSCMachineStatus -NewDSCMachineStatus 1
+        Set-DSCMachineRebootRequired
     }
 
     Write-Verbose -Message ($script:localizedData.SetTargetResourceEndMessage -f $Name)

--- a/Tests/Integration/MSFT_xMsiPackage.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMsiPackage.Integration.Tests.ps1
@@ -13,7 +13,7 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
 $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceModuleName 'xPSDesiredStateConfiguration' `
     -DscResourceName 'MSFT_xMsiPackage' `
-    -TestType 'Unit'
+    -TestType 'Integration'
 
 try
 {

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -186,5 +186,27 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
             }
         }
+
+        Describe 'Set-DSCMachineStatus' {
+            Context 'When called' {
+                It 'Should set the desired DSCMachineStatus value' {
+                    # A new value we'll attempt to set to $global:DSCMachineStatus
+                    $newValue = 100
+
+                    # Store the previous $global:DSCMachineStatus value
+                    $prevDSCMachineStatus = $global:DSCMachineStatus
+                    
+                    # Make sure DSCMachineStatus is set to a value that will have to be updated
+                    $global:DSCMachineStatus = 99
+
+                    # Set and test for the new value
+                    Set-DSCMachineStatus -NewDSCMachineStatus $newValue
+                    $global:DSCMachineStatus | Should -Be $newValue
+
+                    # Revert to previous $global:DSCMachineStatus value
+                    $global:DSCMachineStatus = $prevDSCMachineStatus
+                }
+            }
+        }
     }
 }

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -190,18 +190,15 @@ Describe 'CommonResourceHelper Unit Tests' {
         Describe 'Set-DSCMachineRebootRequired' {
             Context 'When called' {
                 It 'Should set the desired DSCMachineStatus value' {
-                    # A new value we'll attempt to set to $global:DSCMachineStatus
-                    $newValue = 100
-
                     # Store the previous $global:DSCMachineStatus value
                     $prevDSCMachineStatus = $global:DSCMachineStatus
-                    
+
                     # Make sure DSCMachineStatus is set to a value that will have to be updated
-                    $global:DSCMachineStatus = 99
+                    $global:DSCMachineStatus = 0
 
                     # Set and test for the new value
-                    Set-DSCMachineRebootRequired -NewDSCMachineStatus $newValue
-                    $global:DSCMachineStatus | Should -Be $newValue
+                    Set-DSCMachineRebootRequired
+                    $global:DSCMachineStatus | Should -Be 1
 
                     # Revert to previous $global:DSCMachineStatus value
                     $global:DSCMachineStatus = $prevDSCMachineStatus

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -187,7 +187,7 @@ Describe 'CommonResourceHelper Unit Tests' {
             }
         }
 
-        Describe 'Set-DSCMachineStatus' {
+        Describe 'Set-DSCMachineRebootRequired' {
             Context 'When called' {
                 It 'Should set the desired DSCMachineStatus value' {
                     # A new value we'll attempt to set to $global:DSCMachineStatus
@@ -200,7 +200,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     $global:DSCMachineStatus = 99
 
                     # Set and test for the new value
-                    Set-DSCMachineStatus -NewDSCMachineStatus $newValue
+                    Set-DSCMachineRebootRequired -NewDSCMachineStatus $newValue
                     $global:DSCMachineStatus | Should -Be $newValue
 
                     # Revert to previous $global:DSCMachineStatus value

--- a/Tests/Unit/MSFT_xPackageResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xPackageResource.Tests.ps1
@@ -17,7 +17,7 @@ try
     InModuleScope 'MSFT_xPackageResource' {
         Describe 'MSFT_xPackageResource Unit Tests' {
             # Override helper functions from CommonResourceHelper.psm1
-            function Set-DSCMachineStatus {}
+            function Set-DSCMachineRebootRequired {}
 
             BeforeAll {
                 $testsFolderFilePath = Split-Path $PSScriptRoot -Parent
@@ -503,7 +503,7 @@ try
                     Mock Invoke-Process { return [PSCustomObject] @{ ExitCode = 3010 } }
                     Mock Test-TargetResource { return $false }
                     Mock Get-ProductEntry { return $null }
-                    Mock -CommandName Set-DSCMachineStatus
+                    Mock -CommandName Set-DSCMachineRebootRequired
 
                     $packageParameters = @{
                         Path = $script:msiLocation
@@ -513,7 +513,7 @@ try
 
                     { Set-TargetResource -Ensure 'Present' @packageParameters } | Should Not Throw
 
-                    Assert-MockCalled -CommandName Set-DSCMachineStatus -Times 1
+                    Assert-MockCalled -CommandName Set-DSCMachineRebootRequired -Times 1
                 }
 
                 It 'Should install package using user credentials when specified' {

--- a/Tests/Unit/MSFT_xPackageResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xPackageResource.Tests.ps1
@@ -16,6 +16,9 @@ try
 {
     InModuleScope 'MSFT_xPackageResource' {
         Describe 'MSFT_xPackageResource Unit Tests' {
+            # Override helper functions from CommonResourceHelper.psm1
+            function Set-DSCMachineStatus {}
+
             BeforeAll {
                 $testsFolderFilePath = Split-Path $PSScriptRoot -Parent
                 $packageTestHelperFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'MSFT_xPackageResource.TestHelper.psm1'
@@ -500,6 +503,7 @@ try
                     Mock Invoke-Process { return [PSCustomObject] @{ ExitCode = 3010 } }
                     Mock Test-TargetResource { return $false }
                     Mock Get-ProductEntry { return $null }
+                    Mock -CommandName Set-DSCMachineStatus
 
                     $packageParameters = @{
                         Path = $script:msiLocation
@@ -508,6 +512,8 @@ try
                     }
 
                     { Set-TargetResource -Ensure 'Present' @packageParameters } | Should Not Throw
+
+                    Assert-MockCalled -CommandName Set-DSCMachineStatus -Times 1
                 }
 
                 It 'Should install package using user credentials when specified' {


### PR DESCRIPTION
#### Pull Request (PR) description
Moves calls to set $global:DSCMachineStatus = 1 into a helper function to reduce the number of locations where we need to suppress PSScriptAnalyzer rules PSAvoidGlobalVars and PSUseDeclaredVarsMoreThanAssignments. This is an effort to partially address #543.

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/552)
<!-- Reviewable:end -->
