### PR TITLE
Updates Should statements in Pester tests to use dashes before parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@
 - Changes to xPackage
   - Fix an misnamed variable that causes an error during error message output.
     [issue #449](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/449))
+- Updates Should statements in Pester tests to use dashes before parameters.
 
 ## 8.4.0.0
 

--- a/DSCPullServerSetup/PullServerDeploymentVerificationTest/PullServerSetupTests.ps1
+++ b/DSCPullServerSetup/PullServerDeploymentVerificationTest/PullServerSetupTests.ps1
@@ -59,17 +59,17 @@ Describe PullServerInstallationTests {
     }
     Context "Verify general pull server functionality" {
         It "$DscRegKeyPath exists" {
-            $DscRegKeyPath | Should Exist
+            $DscRegKeyPath | Should -Exist
         }
         It "Module repository $DscModulePath exists" {
-            $DscModulePath | Should Exist
+            $DscModulePath | Should -Exist
         }
         It "Configuration repository $DscConfigPath exists" {
-            $DscConfigPath | Should Exist
+            $DscConfigPath | Should -Exist
         }
         It "Verify server $DscPullServerURL is up and running" {
             $DscPullServerResponse = Invoke-WebRequest -Uri $DscPullServerURL -UseBasicParsing
-            $DscPullServerResponse.StatusCode | Should Be 200
+            $DscPullServerResponse.StatusCode | Should -Be 200
         }
     }
     Context "Verify pull end to end works" {
@@ -93,7 +93,7 @@ Describe PullServerInstallationTests {
             Set-DscLocalConfigurationManager -Path $DscTestMetaConfigPath -Verbose:$VerbosePreference -Force
 
             $DscLocalConfigNames = (Get-DscLocalConfigurationManager).ConfigurationDownloadManagers.ConfigurationNames
-            $DscLocalConfigNames -contains $DscTestConfigName | Should Be True
+            $DscLocalConfigNames -contains $DscTestConfigName | Should -Be True
         }
         It "Creates mof and checksum files in $DscConfigPath" {
             # Sample test configuration
@@ -114,15 +114,15 @@ Describe PullServerInstallationTests {
 
             # Create a mof file copy it to
             NoOpConfig -OutputPath $DscConfigPath -Verbose:$VerbosePreference
-            $DscTestMofPath | Should Exist
+            $DscTestMofPath | Should -Exist
 
             # Create checksum
             New-DscChecksum $DscConfigPath -Verbose:$VerbosePreference -Force
-            "$DscTestMofPath.checksum" | Should Exist
+            "$DscTestMofPath.checksum" | Should -Exist
         }
         It 'Updates DscConfiguration Successfully' {
             Update-DscConfiguration -Wait -Verbose:$VerbosePreference
-            (Get-DscConfiguration).ConfigurationName | Should Be "NoOpConfig"
+            (Get-DscConfiguration).ConfigurationName | Should -Be "NoOpConfig"
         }
     }
 }

--- a/DSCPullServerSetup/PullServerDeploymentVerificationTest/PullServerSetupTests.ps1
+++ b/DSCPullServerSetup/PullServerDeploymentVerificationTest/PullServerSetupTests.ps1
@@ -122,7 +122,7 @@ Describe PullServerInstallationTests {
         }
         It 'Updates DscConfiguration Successfully' {
             Update-DscConfiguration -Wait -Verbose:$VerbosePreference
-            (Get-DscConfiguration).ConfigurationName | Should -Be "NoOpConfig"
+            (Get-DscConfiguration).ConfigurationName | Should -Be 'NoOpConfig'
         }
     }
 }

--- a/DSCPullServerSetup/PullServerDeploymentVerificationTest/PullServerSetupTests.ps1
+++ b/DSCPullServerSetup/PullServerDeploymentVerificationTest/PullServerSetupTests.ps1
@@ -93,7 +93,7 @@ Describe PullServerInstallationTests {
             Set-DscLocalConfigurationManager -Path $DscTestMetaConfigPath -Verbose:$VerbosePreference -Force
 
             $DscLocalConfigNames = (Get-DscLocalConfigurationManager).ConfigurationDownloadManagers.ConfigurationNames
-            $DscLocalConfigNames -contains $DscTestConfigName | Should -Be True
+            $DscLocalConfigNames -contains $DscTestConfigName | Should -Be $true
         }
         It "Creates mof and checksum files in $DscConfigPath" {
             # Sample test configuration

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -199,13 +199,13 @@ function Invoke-GenericUnitTest {
     if ($ShouldThrow)
     {
         It "Should throw an error for $ErrorTestName" {
-            { $null = $($Function.Invoke($FunctionParameters)) } | Should Throw $ErrorMessage
+            { $null = $($Function.Invoke($FunctionParameters)) } | Should -Throw $ErrorMessage
         }
     }
     else
     {
         It 'Should not throw' {
-            { $null = $($Function.Invoke($FunctionParameters)) } | Should Not Throw
+            { $null = $($Function.Invoke($FunctionParameters)) } | Should -Not -Throw
         }
     }
 
@@ -251,7 +251,7 @@ function Invoke-GetTargetResourceUnitTest
     )
 
     It 'Should not throw' {
-        { $null = Get-TargetResource @GetTargetResourceParameters } | Should Not Throw
+        { $null = Get-TargetResource @GetTargetResourceParameters } | Should -Not -Throw
     }
 
     Invoke-ExpectedMocksAreCalledTest -MocksCalled $MocksCalled
@@ -259,17 +259,17 @@ function Invoke-GetTargetResourceUnitTest
     $getTargetResourceResult = Get-TargetResource @GetTargetResourceParameters
 
     It 'Should return a Hashtable' {
-        $getTargetResourceResult -is [Hashtable] | Should Be $true
+        $getTargetResourceResult -is [Hashtable] | Should -Be $true
     }
 
     It "Should return a Hashtable with $($ExpectedReturnValue.Keys.Count) properties" {
-        $getTargetResourceResult.Keys.Count | Should Be $ExpectedReturnValue.Keys.Count
+        $getTargetResourceResult.Keys.Count | Should -Be $ExpectedReturnValue.Keys.Count
     }
 
     foreach ($key in $ExpectedReturnValue.Keys)
     {
         It "Should return a Hashtable with the $key property as $($ExpectedReturnValue.$key)" {
-           $getTargetResourceResult.$key | Should Be $ExpectedReturnValue.$key
+           $getTargetResourceResult.$key | Should -Be $ExpectedReturnValue.$key
         }
     }
 }
@@ -326,13 +326,13 @@ function Invoke-SetTargetResourceUnitTest {
     if ($ShouldThrow)
     {
         It "Should throw an error for $ErrorTestName" {
-            { $null = Set-TargetResource @SetTargetResourceParameters } | Should Throw $ErrorMessage
+            { $null = Set-TargetResource @SetTargetResourceParameters } | Should -Throw $ErrorMessage
         }
     }
     else
     {
         It 'Should not throw' {
-            { $null = Set-TargetResource @SetTargetResourceParameters } | Should Not Throw
+            { $null = Set-TargetResource @SetTargetResourceParameters } | Should -Not -Throw
         }
     }
 
@@ -378,7 +378,7 @@ function Invoke-TestTargetResourceUnitTest
     )
 
     It 'Should not throw' {
-        { $null = Test-TargetResource @TestTargetResourceParameters } | Should Not Throw
+        { $null = Test-TargetResource @TestTargetResourceParameters } | Should -Not -Throw
     }
 
     Invoke-ExpectedMocksAreCalledTest -MocksCalled $MocksCalled
@@ -386,7 +386,7 @@ function Invoke-TestTargetResourceUnitTest
     $testTargetResourceResult = Test-TargetResource @TestTargetResourceParameters
 
     It "Should return $ExpectedReturnValue" {
-        $testTargetResourceResult | Should Be $ExpectedReturnValue
+        $testTargetResourceResult | Should -Be $ExpectedReturnValue
     }
 }
 
@@ -419,7 +419,7 @@ function Test-GetTargetResourceResult
 
     foreach ($property in $GetTargetResourceResultProperties)
     {
-        $GetTargetResourceResult[$property] | Should Not Be $null
+        $GetTargetResourceResult[$property] | Should -Not -Be $null
     }
 }
 
@@ -610,7 +610,7 @@ function Test-SetTargetResourceWithWhatIf
         Wait-ScriptBlockReturnTrue -ScriptBlock {-not (Test-IsFileLocked -Path $transcriptPath)}
 
         $transcriptContent = Get-Content -Path $transcriptPath -Raw
-        $transcriptContent | Should Not Be $null
+        $transcriptContent | Should -Not -Be $null
 
         $regexString = '\*+[^\*]*\*+'
 
@@ -628,13 +628,13 @@ function Test-SetTargetResourceWithWhatIf
 
         if ($null -eq $ExpectedOutput -or $ExpectedOutput.Count -eq 0)
         {
-            [String]::IsNullOrEmpty($transcriptContent) | Should Be $true
+            [String]::IsNullOrEmpty($transcriptContent) | Should -Be $true
         }
         else
         {
             foreach ($expectedOutputPiece in $ExpectedOutput)
             {
-                $transcriptContent.Contains($expectedOutputPiece) | Should Be $true
+                $transcriptContent.Contains($expectedOutputPiece) | Should -Be $true
             }
         }
     }

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -199,7 +199,7 @@ function Invoke-GenericUnitTest {
     if ($ShouldThrow)
     {
         It "Should throw an error for $ErrorTestName" {
-            { $null = $($Function.Invoke($FunctionParameters)) } | Should -Throw $ErrorMessage
+            { $null = $($Function.Invoke($FunctionParameters)) } | Should -Throw -ExpectedMessage $ErrorMessage
         }
     }
     else
@@ -326,7 +326,7 @@ function Invoke-SetTargetResourceUnitTest {
     if ($ShouldThrow)
     {
         It "Should throw an error for $ErrorTestName" {
-            { $null = Set-TargetResource @SetTargetResourceParameters } | Should -Throw $ErrorMessage
+            { $null = Set-TargetResource @SetTargetResourceParameters } | Should -Throw -ExpectedMessage $ErrorMessage
         }
     }
     else

--- a/Tests/Integration/MSFT_xEnvironmentResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_xEnvironmentResource.EndToEnd.Tests.ps1
@@ -75,18 +75,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $testValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $testValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -103,18 +103,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -131,18 +131,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -159,18 +159,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $null
-               $currentConfig.Ensure | Should Be 'Absent'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $null
+               $currentConfig.Ensure | Should -Be 'Absent'
             }
         }
 
@@ -199,18 +199,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $testValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $testValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -230,18 +230,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $expectedValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $expectedValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -261,18 +261,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $expectedValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $expectedValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -290,18 +290,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -319,18 +319,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $null
-               $currentConfig.Ensure | Should Be 'Absent'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $null
+               $currentConfig.Ensure | Should -Be 'Absent'
             }
         }
     }
@@ -381,18 +381,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $testValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $testValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -410,18 +410,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -439,18 +439,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -468,18 +468,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $null
-               $currentConfig.Ensure | Should Be 'Absent'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $null
+               $currentConfig.Ensure | Should -Be 'Absent'
             }
         }
 
@@ -503,18 +503,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $testValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $testValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -535,18 +535,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $expectedValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $expectedValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -567,18 +567,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $expectedValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $expectedValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -597,18 +597,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -627,18 +627,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $null
-               $currentConfig.Ensure | Should Be 'Absent'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $null
+               $currentConfig.Ensure | Should -Be 'Absent'
             }
         }
     }
@@ -692,18 +692,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $testValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $testValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -721,18 +721,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -750,18 +750,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -779,18 +779,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testEnvironmentVarName
-               $currentConfig.Value | Should Be $null
-               $currentConfig.Ensure | Should Be 'Absent'
+               $currentConfig.Name | Should -Be $testEnvironmentVarName
+               $currentConfig.Value | Should -Be $null
+               $currentConfig.Ensure | Should -Be 'Absent'
             }
         }
 
@@ -817,18 +817,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $testValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $testValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -849,18 +849,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $expectedValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $expectedValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -881,18 +881,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $expectedValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $expectedValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -911,18 +911,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $newTestValue
-               $currentConfig.Ensure | Should Be 'Present'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $newTestValue
+               $currentConfig.Ensure | Should -Be 'Present'
             }
         }
 
@@ -941,18 +941,18 @@ try
                                          -OutputPath $configurationPath `
                                          -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-               $currentConfig.Name | Should Be $testPathEnvironmentVarName
-               $currentConfig.Value | Should Be $null
-               $currentConfig.Ensure | Should Be 'Absent'
+               $currentConfig.Name | Should -Be $testPathEnvironmentVarName
+               $currentConfig.Value | Should -Be $null
+               $currentConfig.Ensure | Should -Be 'Absent'
             }
         }
     }

--- a/Tests/Integration/MSFT_xEnvironmentResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xEnvironmentResource.Integration.Tests.ps1
@@ -35,14 +35,14 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable $envVar is successfully retrieved
-            $retrievedVar.Ensure | Should Be 'Present'
+            $retrievedVar.Ensure | Should -Be 'Present'
 
             $regItem = Get-Item -Path 'HKLM:\\System\\CurrentControlSet\\Control\\Session Manager\\Environment'
             $matchVar = $regItem.GetValue($envVar)
             $retrievedVarValue = $retrievedVar.Value
 
             # Verify the $retrievedVar environmnet variable value matches the value retrieved using [Environment] API
-            $retrievedVarValue | Should Be $matchVar
+            $retrievedVarValue | Should -Be $matchVar
         }
 
         It 'Should return Absent for an environment variable that does not exists' {
@@ -53,7 +53,7 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable $envVar is not found
-            $retrievedVar.Ensure | Should Be 'Absent'
+            $retrievedVar.Ensure | Should -Be 'Absent'
         }
 
         It 'Should throw an error when creating a new environment variable with no Value specified' {
@@ -61,16 +61,16 @@ try
             $envVar = 'TestEnvVar'
             Set-TargetResource -Name $envVar -Ensure Absent
 
-            { Set-TargetResource -Name $envVar } | Should Throw
+            { Set-TargetResource -Name $envVar } | Should -Throw
 
             # Now retrieve the created variable
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable $envVar is successfully created
-            $retrievedVar.Ensure | Should Be 'Absent'
+            $retrievedVar.Ensure | Should -Be 'Absent'
 
             # Verify the create environmnet variable's value is set to default value [String]::Empty
-            $retrievedVar.Value | Should Be $null
+            $retrievedVar.Value | Should -Be $null
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -89,10 +89,10 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable $envVar is successfully created
-            $retrievedVar.Ensure | Should Be 'Present'
+            $retrievedVar.Ensure | Should -Be 'Present'
 
             # Verify the create environmnet variable's value is set
-            $retrievedVar.Value | Should Be $val
+            $retrievedVar.Value | Should -Be $val
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -113,7 +113,7 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable $envVar is successfully updated
-            $retrievedVar.Value | Should Be $newVal
+            $retrievedVar.Value | Should -Be $newVal
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -132,7 +132,7 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable no more exists
-            $retrievedVar.Ensure | Should Be 'Absent'
+            $retrievedVar.Ensure | Should -Be 'Absent'
         }
 
         It 'Should update a path environment variable' {
@@ -148,7 +148,7 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable no more exists
-            $retrievedVar.Value | Should Be $expectedFinalVal
+            $retrievedVar.Value | Should -Be $expectedFinalVal
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -167,7 +167,7 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable no more exists
-            $retrievedVar.Value | Should Be $expectedFinalVal
+            $retrievedVar.Value | Should -Be $expectedFinalVal
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -185,7 +185,7 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable no more exists
-            $retrievedVar.Ensure | Should Be 'Absent'
+            $retrievedVar.Ensure | Should -Be 'Absent'
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -198,7 +198,7 @@ try
             Set-TargetResource -Name $envVar -Value $val
 
             # Test the created environmnet variable
-            Test-TargetResource -Name $envVar | Should Be $true
+            Test-TargetResource -Name $envVar | Should -Be $true
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -210,7 +210,7 @@ try
             Set-TargetResource -Name $envVar -Value $val
 
             # Verify the environmnet variable exists
-            Test-TargetResource -Name $envVar -Value $val | Should Be $true
+            Test-TargetResource -Name $envVar -Value $val | Should -Be $true
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -221,7 +221,7 @@ try
             Set-TargetResource -Name $envVar -Ensure Absent
 
             # Verify the environmnet variable exists
-            Test-TargetResource -Name $envVar -Ensure Absent | Should Be $true
+            Test-TargetResource -Name $envVar -Ensure Absent | Should -Be $true
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -235,7 +235,7 @@ try
             $subpath = 'B'
 
             # Test a sub-path exists in environment variable
-            Test-TargetResource -Name $envVar -Value $subpath -Path $true | Should Be $true
+            Test-TargetResource -Name $envVar -Value $subpath -Path $true | Should -Be $true
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -248,7 +248,7 @@ try
 
             $subpath = 'B;a;c'
 
-            Test-TargetResource -Name $envVar -Value $subpath -Path $true | Should Be $true
+            Test-TargetResource -Name $envVar -Value $subpath -Path $true | Should -Be $true
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -261,7 +261,7 @@ try
 
             $subpath = 'D;E'
 
-            Test-TargetResource -Name $envVar -Value $subpath -Path $true -Ensure Absent | Should Be $true
+            Test-TargetResource -Name $envVar -Value $subpath -Path $true -Ensure Absent | Should -Be $true
 
             # Remove the created test variable
             Set-TargetResource -Name $envVar -Ensure Absent
@@ -273,13 +273,13 @@ try
             $retrievedVar = Get-TargetResource -Name $envVar
 
             # Verify the environmnet variable $envVar is successfully retrieved
-            $retrievedVar.Ensure | Should Be 'Present'
+            $retrievedVar.Ensure | Should -Be 'Present'
 
             $matchVar = '%SystemRoot%'
             $retrievedVarValue = $retrievedVar.Value
 
             # Verify the $retrievedVar environmnet variable value matches the value retrieved using [Environment] API
-            $retrievedVarValue | Should Be $matchVar
+            $retrievedVarValue | Should -Be $matchVar
         }
     }
 }

--- a/Tests/Integration/MSFT_xGroupResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xGroupResource.Integration.Tests.ps1
@@ -61,7 +61,7 @@ try
                 GroupName = $testGroupName
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             try
             {
@@ -69,9 +69,9 @@ try
                     . $script:confgurationWithMembersFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -Members @() | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -Members @() | Should -Be $true
             }
             finally
             {
@@ -91,15 +91,15 @@ try
                 GroupName = $testGroupName
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             {
                 . $script:confgurationNoMembersFilePath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @resourceParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
         }
 
         It 'Should add a member to the built-in Users group with MembersToInclude' {
@@ -112,15 +112,15 @@ try
                 MembersToInclude = $testUsername1
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             {
                 . $script:confgurationWithMembersToIncludeExcludeFilePath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @resourceParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
 
-            Test-GroupExists -GroupName $testGroupName -MembersToInclude $testUsername1 | Should Be $true
+            Test-GroupExists -GroupName $testGroupName -MembersToInclude $testUsername1 | Should -Be $true
         }
 
         It 'Should create a group with two test users using Members' {
@@ -135,7 +135,7 @@ try
                 Members = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             try
             {
@@ -143,9 +143,9 @@ try
                     . $script:confgurationWithMembersFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -Members $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -Members $groupMembers | Should -Be $true
             }
             finally
             {
@@ -177,7 +177,7 @@ try
                 Write-Verbose "Group $testGroupName already exists OR there was an error creating it."
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             try
             {
@@ -185,9 +185,9 @@ try
                     . $script:confgurationWithMembersToIncludeExcludeFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should -Be $true
             }
             finally
             {
@@ -219,7 +219,7 @@ try
                 Write-Verbose "Group $testGroupName already exists OR there was an error creating it."
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             try
             {
@@ -227,9 +227,9 @@ try
                     . $script:confgurationWithMembersToIncludeExcludeFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should -Be $true
             }
             finally
             {
@@ -249,11 +249,11 @@ try
                 GroupName = $testGroupName
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             New-Group -GroupName $testGroupName
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             try
             {
@@ -261,9 +261,9 @@ try
                     . $script:confgurationWithMembersFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName | Should Be $false
+                Test-GroupExists -GroupName $testGroupName | Should -Be $false
             }
             finally
             {

--- a/Tests/Integration/MSFT_xMsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_xMsiPackage.EndToEnd.Tests.ps1
@@ -84,7 +84,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return True from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $true
+            $testTargetResourceInitialResult | Should -Be $true
 
             if ($testTargetResourceInitialResult -ne $true)
             {
@@ -98,7 +98,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
 
         It 'Should compile and run configuration' {
@@ -106,15 +106,15 @@ Describe 'xMsiPackage End to End Tests' {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
     }
 
@@ -129,7 +129,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -143,7 +143,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
 
         It 'Should compile and run configuration' {
@@ -151,15 +151,15 @@ Describe 'xMsiPackage End to End Tests' {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
     }
 
@@ -174,7 +174,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return True from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $true
+            $testTargetResourceInitialResult | Should -Be $true
 
             if ($testTargetResourceInitialResult -ne $true)
             {
@@ -188,7 +188,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
 
         It 'Should compile and run configuration' {
@@ -196,15 +196,15 @@ Describe 'xMsiPackage End to End Tests' {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
     }
 
@@ -219,7 +219,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -233,7 +233,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
 
         It 'Should compile and run configuration' {
@@ -241,15 +241,15 @@ Describe 'xMsiPackage End to End Tests' {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
     }
 
@@ -272,7 +272,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -286,7 +286,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
 
         It 'Should compile and run configuration' {
@@ -294,19 +294,19 @@ Describe 'xMsiPackage End to End Tests' {
                 . $script:configurationFilePathLogPath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Should have created the log file' {
-            Test-Path -Path $logPath | Should Be $true
+            Test-Path -Path $logPath | Should -Be $true
         }
 
         It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
     }
 
@@ -329,7 +329,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -343,7 +343,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
 
         It 'Should compile and run configuration' {
@@ -351,19 +351,19 @@ Describe 'xMsiPackage End to End Tests' {
                 . $script:configurationFilePathLogPath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Should have created the log file' {
-            Test-Path -Path $logPath | Should Be $true
+            Test-Path -Path $logPath | Should -Be $true
         }
 
         It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
     }
 
@@ -384,7 +384,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -398,7 +398,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
 
         try
@@ -414,7 +414,7 @@ Describe 'xMsiPackage End to End Tests' {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
         }
         finally
@@ -427,11 +427,11 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
     }
 
@@ -452,7 +452,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -466,7 +466,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
 
         try
@@ -482,7 +482,7 @@ Describe 'xMsiPackage End to End Tests' {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
         }
         finally
@@ -495,11 +495,11 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Should return true from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
     }
 
@@ -520,7 +520,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -534,7 +534,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
 
         try
@@ -550,7 +550,7 @@ Describe 'xMsiPackage End to End Tests' {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
         }
         finally
@@ -563,11 +563,11 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Should return true from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
     }
 
@@ -588,7 +588,7 @@ Describe 'xMsiPackage End to End Tests' {
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
             $testTargetResourceInitialResult = MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters
-            $testTargetResourceInitialResult | Should Be $false
+            $testTargetResourceInitialResult | Should -Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
             {
@@ -602,7 +602,7 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
         }
 
         try
@@ -618,7 +618,7 @@ Describe 'xMsiPackage End to End Tests' {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
         }
         finally
@@ -631,11 +631,11 @@ Describe 'xMsiPackage End to End Tests' {
         }
 
         It 'Should return true from Test-TargetResource with the same parameters after configuration' {
-            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            MSFT_xMsiPackage\Test-TargetResource @msiPackageParameters | Should -Be $true
         }
 
         It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
         }
     }
 }

--- a/Tests/Integration/MSFT_xMsiPackage.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xMsiPackage.Integration.Tests.ps1
@@ -110,34 +110,34 @@ try
                         -Path $script:msiLocation `
                         -ProductId $script:packageId
 
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Absent' `
                         -Path $script:msiLocation `
                         -ProductId $script:packageId
 
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should return correct value when package is present' {
                     Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId $script:packageId
 
-                    Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+                    Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
 
                     $testTargetResourceResult = Test-TargetResource `
                             -Ensure 'Present' `
                             -Path $script:msiLocation `
                             -ProductId $script:packageId `
 
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Absent' `
                         -Path $script:msiLocation `
                         -ProductId $script:packageId `
 
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -145,25 +145,25 @@ try
                 It 'Should correctly install and remove a .msi package' {
                     Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId $script:packageId
 
-                    Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+                    Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
 
                     $getTargetResourceResult = Get-TargetResource -Path $script:msiLocation -ProductId $script:packageId
 
-                    $getTargetResourceResult.Version | Should Be '1.2.3.4'
-                    $getTargetResourceResult.InstalledOn | Should Be ('{0:d}' -f [DateTime]::Now.Date)
-                    $getTargetResourceResult.ProductId | Should Be $script:packageId
+                    $getTargetResourceResult.Version | Should -Be '1.2.3.4'
+                    $getTargetResourceResult.InstalledOn | Should -Be ('{0:d}' -f [DateTime]::Now.Date)
+                    $getTargetResourceResult.ProductId | Should -Be $script:packageId
 
-                    [Math]::Round($getTargetResourceResult.Size, 2) | Should Be 0.03
+                    [Math]::Round($getTargetResourceResult.Size, 2) | Should -Be 0.03
 
                     Set-TargetResource -Ensure 'Absent' -Path $script:msiLocation -ProductId $script:packageId
 
-                    Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+                    Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
                 }
 
                 It 'Should throw with incorrect product id' {
                     $wrongPackageId = '{deadbeef-80c6-41e6-a1b9-8bdb8a050272}'
 
-                    { Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId $wrongPackageId } | Should Throw
+                    { Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId $wrongPackageId } | Should -Throw
                 }
 
                 It 'Should correctly install and remove a package from a HTTP URL' {
@@ -184,13 +184,13 @@ try
                         # Wait for the file server to be ready to receive requests
                         $fileServerStarted.WaitOne(30000)
 
-                        { Set-TargetResource -Ensure 'Present' -Path $baseUrl -ProductId $script:packageId } | Should Throw
+                        { Set-TargetResource -Ensure 'Present' -Path $baseUrl -ProductId $script:packageId } | Should -Throw
 
                         Set-TargetResource -Ensure 'Present' -Path $msiUrl -ProductId $script:packageId
-                        Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+                        Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
 
                         Set-TargetResource -Ensure 'Absent' -Path $msiUrl -ProductId $script:packageId
-                        Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+                        Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
                     }
                     finally
                     {
@@ -221,13 +221,13 @@ try
                         # Wait for the file server to be ready to receive requests
                         $fileServerStarted.WaitOne(30000)
 
-                        { Set-TargetResource -Ensure 'Present' -Path $baseUrl -ProductId $script:packageId } | Should Throw
+                        { Set-TargetResource -Ensure 'Present' -Path $baseUrl -ProductId $script:packageId } | Should -Throw
 
                         Set-TargetResource -Ensure 'Present' -Path $msiUrl -ProductId $script:packageId
-                        Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+                        Test-PackageInstalledById -ProductId $script:packageId | Should -Be $true
 
                         Set-TargetResource -Ensure 'Absent' -Path $msiUrl -ProductId $script:packageId
-                        Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+                        Test-PackageInstalledById -ProductId $script:packageId | Should -Be $false
                     }
                     finally
                     {
@@ -249,8 +249,8 @@ try
 
                     Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -LogPath $logPath -ProductId $script:packageId
 
-                    Test-Path -Path $logPath | Should Be $true
-                    Get-Content -Path $logPath | Should Not Be $null
+                    Test-Path -Path $logPath | Should -Be $true
+                    Get-Content -Path $logPath | Should -Not -Be $null
                 }
 
                 It 'Should add space after .MSI installation arguments' {
@@ -277,7 +277,7 @@ try
                         ProductId = $script:packageId
                     }
 
-                    { Set-TargetResource -Ensure 'Present' @packageParameters } | Should Not Throw
+                    { Set-TargetResource -Ensure 'Present' @packageParameters } | Should -Not -Throw
                 }
 
                 It 'Should install package using user credentials when specified' {

--- a/Tests/Integration/MSFT_xPackageResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xPackageResource.Integration.Tests.ps1
@@ -98,7 +98,7 @@ try
 
                 Start-DscConfiguration -Path $configurationPath -Wait -Force -Verbose
 
-                Test-PackageInstalledByName -Name $script:packageName | Should Be $true
+                Test-PackageInstalledByName -Name $script:packageName | Should -Be $true
             }
             finally
             {

--- a/Tests/Integration/MSFT_xRegistryResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_xRegistryResource.EndToEnd.Tests.ps1
@@ -56,21 +56,21 @@ try
                     . $script:confgurationFilePathKeyAndNameOnly -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             $registryKey = Get-Item -Path $registryParameters.Key -ErrorAction 'SilentlyContinue'
 
             It 'Should have created the registry key' {
-                $registryKey | Should Not Be $null
+                $registryKey | Should -Not -Be $null
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
             }
         }
 
@@ -88,25 +88,25 @@ try
                     . $script:confgurationFilePathKeyAndNameOnly -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have created the registry key value' {
-                $registryKeyValue | Should Not Be $null
+                $registryKeyValue | Should -Not -Be $null
             }
 
             It 'Should not have set the registry key value' {
-                $registryKeyValue.($registryParameters.ValueName) | Should Be ''
+                $registryKeyValue.($registryParameters.ValueName) | Should -Be ''
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
             }
         }
 
@@ -126,25 +126,25 @@ try
                     . $script:confgurationFilePathWithDataAndType -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have created the registry key value' {
-                $registryKeyValue | Should Not Be $null
+                $registryKeyValue | Should -Not -Be $null
             }
 
             It 'Should have set the registry key value to the specified String value' {
-                $registryKeyValue.($registryParameters.ValueName) | Should Be $registryParameters.ValueData
+                $registryKeyValue.($registryParameters.ValueName) | Should -Be $registryParameters.ValueData
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
             }
         }
 
@@ -186,25 +186,25 @@ try
                         . $script:confgurationFilePathWithDataAndType -ConfigurationName $configurationName
                         & $configurationName -OutputPath $TestDrive @registryParameters
                         Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
                 }
 
                 $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
                 It 'Should be able to retrieve the registry key value' {
-                    $registryKeyValue | Should Not Be $null
+                    $registryKeyValue | Should -Not -Be $null
                 }
 
                 It 'Should have set the registry key value to the specified value' {
-                    Compare-Object -ReferenceObject $expectedRegistryKeyValue -DifferenceObject $registryKeyValue.($registryParameters.ValueName) | Should Be $null
+                    Compare-Object -ReferenceObject $expectedRegistryKeyValue -DifferenceObject $registryKeyValue.($registryParameters.ValueName) | Should -Be $null
                 }
 
                 It 'Should return true from Test-TargetResource with the same parameters' {
-                    MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                    MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
                 }
             }
         }
@@ -227,25 +227,25 @@ try
                     . $script:confgurationFilePathWithDataAndType -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should be able to retrieve the registry key value' {
-                $registryKeyValue | Should Not Be $null
+                $registryKeyValue | Should -Not -Be $null
             }
 
             It 'Should have set the registry key value to the specified Binary value' {
-                Compare-Object -ReferenceObject $expectedRegistryKeyValue -DifferenceObject $registryKeyValue.'(default)' | Should Be $null
+                Compare-Object -ReferenceObject $expectedRegistryKeyValue -DifferenceObject $registryKeyValue.'(default)' | Should -Be $null
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
             }
         }
 
@@ -263,21 +263,21 @@ try
                     . $script:confgurationFilePathKeyAndNameOnly -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
-                $registryKeyValue | Should Be $null
+                $registryKeyValue | Should -Be $null
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
             }
         }
 
@@ -297,21 +297,21 @@ try
                     . $script:confgurationFilePathWithDataAndType -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
-                $registryKeyValue | Should Be $null
+                $registryKeyValue | Should -Be $null
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
             }
         }
 
@@ -329,21 +329,21 @@ try
                     . $script:confgurationFilePathKeyAndNameOnly -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             $registryKey = Get-Item -Path $registryParameters.Key -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
-                $registryKey | Should Be $null
+                $registryKey | Should -Be $null
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should Be $true
+                MSFT_xRegistryResource\Test-TargetResource @registryParameters | Should -Be $true
             }
         }
     }

--- a/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRegistryResource.Integration.Tests.ps1
@@ -83,27 +83,27 @@ try
             It 'Should return Present when retrieving a blank value from an existing registry key' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
                 $getTargetResourceResult = Get-TargetResource -Key $registryKeyPath -ValueName ''
-                $getTargetResourceResult.Ensure | Should Be 'Present'
+                $getTargetResourceResult.Ensure | Should -Be 'Present'
             }
 
             It 'Should return Absent when retrieving a blank value from a registry key that does not exist' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environmental'
                 $getTargetResourceResult = Get-TargetResource -Key $registryKeyPath -ValueName ''
-                $getTargetResourceResult.Ensure | Should Be 'Absent'
+                $getTargetResourceResult.Ensure | Should -Be 'Absent'
             }
 
             It 'Should return Present when retrieving an existing value from an existing registry key' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
                 $registryValueName = 'Path'
                 $getTargetResourceResult = Get-TargetResource -Key $registryKeyPath -ValueName $registryValueName
-                $getTargetResourceResult.Ensure | Should Be 'Present'
+                $getTargetResourceResult.Ensure | Should -Be 'Present'
             }
 
             It 'Should return Absent when retrieving a nonexistant value from an existing registry key' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
                 $registryValueName = 'PsychoPath'
                 $getTargetResourceResult = Get-TargetResource -Key $registryKeyPath -ValueName $registryValueName
-                $getTargetResourceResult.Ensure | Should Be 'Absent'
+                $getTargetResourceResult.Ensure | Should -Be 'Absent'
             }
 
             $commonRegistryKeys = @( 'HKEY_CURRENT_USER', 'HKEY_CLASSES_ROOT', 'HKEY_USERS', 'HKEY_CURRENT_CONFIG' )
@@ -111,7 +111,7 @@ try
             {
                 It "Should return Present when retrieving a blank value from $commonRegistryKey" {
                     $getTargetResourceResult = Get-TargetResource -Key $commonRegistryKey -ValueName ''
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
             }
 
@@ -121,7 +121,7 @@ try
 
                 # Verify that the registry key has been created
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $script:registryKeyPath
-                $registryKeyExists | Should Be $true
+                $registryKeyExists | Should -Be $true
             }
 
             It 'Should create a new registry key tree' {
@@ -131,7 +131,7 @@ try
 
                 # Verify that the registry key has been created
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath
-                $registryKeyExists | Should Be $true
+                $registryKeyExists | Should -Be $true
             }
 
             It 'Should remove a registry key' {
@@ -140,14 +140,14 @@ try
 
                 # Verify that the registry key exists before removal
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $script:registryKeyPath
-                $registryKeyExists | Should Be $true
+                $registryKeyExists | Should -Be $true
 
                 # Now remove the TestKey
                 Set-TargetResource -Key $script:registryKeyPath -ValueName '' -Ensure 'Absent'
 
                 # Verify that the registry key has been removed
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $script:registryKeyPath
-                $registryKeyExists | Should Be $false
+                $registryKeyExists | Should -Be $false
             }
 
             It 'Should remove a registry key (Common registry path)' {
@@ -158,14 +158,14 @@ try
 
                 # Verify that the registry key exists before removal
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $script:registryKeyPath
-                $registryKeyExists | Should Be $true
+                $registryKeyExists | Should -Be $true
 
                 # Now remove the TestKey
                 Set-TargetResource -Key $commonRegistryKeyPath -ValueName '' -Ensure 'Absent'
 
                 # Verify that the registry key has been removed
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $script:registryKeyPath
-                $registryKeyExists | Should Be $false
+                $registryKeyExists | Should -Be $false
             }
 
             It 'Should remove a registry key tree' {
@@ -176,14 +176,14 @@ try
 
                 # Verify that the registry key tree exists before removal
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath
-                $registryKeyExists | Should Be $true
+                $registryKeyExists | Should -Be $true
 
                 # Remove the test registry key tree
                 Set-TargetResource -Key $registryKeyTreePath -ValueName '' -Ensure 'Absent'
 
                 # Verify that the registry key tree has been removed
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath
-                $registryKeyExists | Should Be $false
+                $registryKeyExists | Should -Be $false
             }
 
             It 'Should remove a registry key tree (Common registry path)' {
@@ -195,14 +195,14 @@ try
 
                 # Verify that the registry key tree exists before removal
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath
-                $registryKeyExists | Should Be $true
+                $registryKeyExists | Should -Be $true
 
                 # Remove the test registry key tree
                 Set-TargetResource -Key $commonRegistryKeyTreePath -ValueName '' -Ensure 'Absent'
 
                 # Verify that the registry key tree has been removed
                 $registryKeyExists = Test-RegistryKeyExists -KeyPath $registryKeyTreePath
-                $registryKeyExists | Should Be $false
+                $registryKeyExists | Should -Be $false
             }
 
             It 'Should create a new string registry key value' {
@@ -215,7 +215,7 @@ try
 
                 # Verify that the registry key value has been created with the correct data and type
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $valueType
-                $registryValueExists | Should Be $true
+                $registryValueExists | Should -Be $true
             }
 
             It 'Should create a new binary registry key value' {
@@ -228,7 +228,7 @@ try
 
                 # Verify that the registry key value has been created with the correct data and type
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $valueType
-                $registryValueExists | Should Be $true
+                $registryValueExists | Should -Be $true
             }
 
             It 'Should set the default value of a registry key' {
@@ -240,7 +240,7 @@ try
 
                 # Verify that the registry key value has been created with the correct data and type
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName '(default)' -ValueData $valueData -ValueType 'String'
-                $registryValueExists | Should Be $true
+                $registryValueExists | Should -Be $true
             }
 
             It 'Should remove a registry key value' {
@@ -253,14 +253,14 @@ try
 
                 # Verify that the registry key value exists before removal
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName
-                $registryValueExists | Should Be $true
+                $registryValueExists | Should -Be $true
 
                 # Remove the registry value
                 Set-TargetResource -Key $script:registryKeyPath -ValueName $valueName -Ensure 'Absent'
 
                 # Verify that the registry key value has been removed
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName
-                $registryValueExists | Should Be $false
+                $registryValueExists | Should -Be $false
             }
 
             It 'Should remove the default value for a registry key' {
@@ -273,14 +273,14 @@ try
 
                 # Verify that the registry key value exists before removal
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName '(default)'
-                $registryValueExists | Should Be $true
+                $registryValueExists | Should -Be $true
 
                 # Remove the registry value
                 Set-TargetResource -Key $script:registryKeyPath -ValueName $valueName -Ensure 'Absent'
 
                 # Verify that the registry key value has been removed
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName '(default)'
-                $registryValueExists | Should Be $false
+                $registryValueExists | Should -Be $false
             }
 
             It 'Should create a new key and value with path containing forward slashes' {
@@ -293,46 +293,46 @@ try
 
                 # Verify that the registry key value has been created with the correct data and type
                 $registryValueExists = Test-RegistryValueExists -KeyPath $registryKeyPathWithForwardSlashes -ValueName $valueName  -ValueData $valueData
-                $registryValueExists | Should Be $true
+                $registryValueExists | Should -Be $true
             }
 
             # Test-TargetResource
             It 'Should return true for an existing registry key' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName ''
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return false for a registry key that does not exist' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environmentally'
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName ''
-                $testTargetResourceResult | Should Be $false
+                $testTargetResourceResult | Should -Be $false
             }
 
             It 'Should return true for an existing registry value' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
                 $valueName = 'path'
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName $valueName
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return false for a registry value that does not exist' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
                 $valueName = 'NonExisting'
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName $valueName
-                $testTargetResourceResult | Should Be $false
+                $testTargetResourceResult | Should -Be $false
             }
 
             It 'Should return true when Ensure is Absent and registry key does not exist' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environmentally'
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName '' -Ensure 'Absent'
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return false when Ensure is Absent and registry key exists' {
                 $registryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName '' -Ensure 'Absent'
-                $testTargetResourceResult | Should Be $false
+                $testTargetResourceResult | Should -Be $false
             }
 
             It 'Should return false when Ensure is Absent and registry value exists with invalid data' {
@@ -341,7 +341,7 @@ try
                 $valueData = 'FakePath'
 
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName $valueName -ValueData $valueData -Ensure 'Absent'
-                $testTargetResourceResult | Should Be $false
+                $testTargetResourceResult | Should -Be $false
             }
 
             It 'Should return true for a multi-string registry value' {
@@ -353,7 +353,7 @@ try
                 New-RegistryValue -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $valueType
 
                 $testTargetResourceResult = Test-TargetResource -Key $registryKeyPath -ValueName $valueName -ValueData $valueData
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return true for a binary registry value' {
@@ -365,7 +365,7 @@ try
                 New-RegistryValue -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $valueType
 
                 $testTargetResourceResult = Test-TargetResource -Key $script:registryKeyPath -ValueName $valueName -ValueData $valueData
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return true for an empty binary registry value' {
@@ -378,10 +378,10 @@ try
 
                 # Verify that the registry key value has been created with the correct data and type
                 $registryValueExists = Test-RegistryValueExists -KeyPath $script:registryKeyPath -ValueName $valueName  -ValueData $valueData -ValueType $valueType
-                $registryValueExists | Should Be $true
+                $registryValueExists | Should -Be $true
 
                 $testTargetResourceResult = Test-TargetResource -Key $script:registryKeyPath -ValueName $valueName -ValueData $valueData
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return true for binary registry value with zeroes' {
@@ -393,7 +393,7 @@ try
                 New-RegistryValue -KeyPath $script:registryKeyPath -ValueName $valueName -ValueData $valueData -ValueType $valueType
 
                 $testTargetResourceResult = Test-TargetResource -Key $script:registryKeyPath -ValueName $valueName -ValueData $valueData
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
         }
     }

--- a/Tests/Integration/MSFT_xRemoteFile.Tests.ps1
+++ b/Tests/Integration/MSFT_xRemoteFile.Tests.ps1
@@ -42,24 +42,24 @@ try
                 Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestDrive"
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
             $Result = Get-DscConfiguration
-            $Result.Ensure          | Should Be 'Present'
-            $Result.Uri             | Should Be $TestURI
-            $Result.DestinationPath | Should Be $TestDestinationPath
+            $Result.Ensure          | Should -Be 'Present'
+            $Result.Uri             | Should -Be $TestURI
+            $Result.DestinationPath | Should -Be $TestDestinationPath
         }
         It 'The Downloaded content should match the source content' {
             $DownloadedContent = Get-Content -Path $TestDestinationPath -Raw
             $ExistingContent = Get-Content -Path $TestConfigPath -Raw
-            $DownloadedContent | Should Be $ExistingContent
+            $DownloadedContent | Should -Be $ExistingContent
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
@@ -61,7 +61,7 @@ try
             }
 
             It 'Should have removed test file before config runs' {
-                Test-Path -Path $resourceParameters.FilePath | Should Be $false
+                Test-Path -Path $resourceParameters.FilePath | Should -Be $false
             }
 
             It 'Should compile and apply the MOF without throwing' {
@@ -69,15 +69,15 @@ try
                     . $script:configurationNoCredentialFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should have created the test file' {
-                Test-Path -Path $resourceParameters.FilePath | Should Be $true
+                Test-Path -Path $resourceParameters.FilePath | Should -Be $true
             }
 
             It 'Should have set file content correctly' {
-                Get-Content -Path $resourceParameters.FilePath -Raw | Should Be "$($resourceParameters.FileContent)`r`n"
+                Get-Content -Path $resourceParameters.FilePath -Raw | Should -Be "$($resourceParameters.FileContent)`r`n"
             }
         }
 
@@ -97,7 +97,7 @@ try
             }
 
             It 'Should have removed test file before config runs' {
-                Test-Path -Path $resourceParameters.FilePath | Should Be $false
+                Test-Path -Path $resourceParameters.FilePath | Should -Be $false
             }
 
             $configData = @{
@@ -115,15 +115,15 @@ try
                     . $script:configurationWithCredentialFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive -ConfigurationData $configData @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should have created the test file' {
-                Test-Path -Path $resourceParameters.FilePath | Should Be $true
+                Test-Path -Path $resourceParameters.FilePath | Should -Be $true
             }
 
             It 'Should have set file content correctly' {
-                Get-Content -Path $resourceParameters.FilePath -Raw | Should Be "$($resourceParameters.FileContent)`r`n"
+                Get-Content -Path $resourceParameters.FilePath -Raw | Should -Be "$($resourceParameters.FileContent)`r`n"
             }
         }
     }

--- a/Tests/Integration/MSFT_xServiceResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xServiceResource.Integration.Tests.ps1
@@ -125,55 +125,55 @@ try
                     . $script:configurationAllExceptCredentialFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $service = Get-Service -Name $resourceParameters.Name -ErrorAction 'SilentlyContinue'
             $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$($resourceParameters.Name)'" -ErrorAction 'SilentlyContinue'
 
             It 'Should have created a new service with the specified name' {
-                 $service | Should Not Be $null
-                 $serviceCimInstance | Should Not Be $null
+                 $service | Should -Not -Be $null
+                 $serviceCimInstance | Should -Not -Be $null
 
-                 $service.Name | Should Be $resourceParameters.Name
-                 $serviceCimInstance.Name | Should Be $resourceParameters.Name
+                 $service.Name | Should -Be $resourceParameters.Name
+                 $serviceCimInstance.Name | Should -Be $resourceParameters.Name
             }
 
             It 'Should have created a new service with the specified path' {
-                $serviceCimInstance.PathName | Should Be $resourceParameters.Path
+                $serviceCimInstance.PathName | Should -Be $resourceParameters.Path
             }
 
             It 'Should have created a new service with the specified display name' {
-                $service.DisplayName | Should Be $resourceParameters.DisplayName
+                $service.DisplayName | Should -Be $resourceParameters.DisplayName
             }
 
             It 'Should have created a new service with the specified description' {
-                $serviceCimInstance.Description | Should Be $resourceParameters.Description
+                $serviceCimInstance.Description | Should -Be $resourceParameters.Description
             }
 
             It 'Should have created a new service with the specified dependencies' {
                 $differentDependencies = Compare-Object -ReferenceObject $resourceParameters.Dependencies -DifferenceObject $service.ServicesDependedOn.Name
-                $differentDependencies | Should Be $null
+                $differentDependencies | Should -Be $null
             }
 
             It 'Should have created a new service with the default state as Running' {
-                $service.Status | Should Be 'Running'
+                $service.Status | Should -Be 'Running'
             }
 
             It 'Should have created a new service with the default startup type as Auto' {
-                $serviceCimInstance.StartMode | Should Be 'Auto'
+                $serviceCimInstance.StartMode | Should -Be 'Auto'
             }
 
             It 'Should have created a new service with the default startup account name as LocalSystem' {
-                $serviceCimInstance.StartName | Should Be 'LocalSystem'
+                $serviceCimInstance.StartName | Should -Be 'LocalSystem'
             }
 
             It 'Should have created a new service with the default desktop interaction setting as False' {
-                $serviceCimInstance.DesktopInteract | Should Be $false
+                $serviceCimInstance.DesktopInteract | Should -Be $false
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should Be $true
+                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should -Be $true
             }
         }
 
@@ -188,55 +188,55 @@ try
                     . $script:configurationAllExceptCredentialFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $service = Get-Service -Name $resourceParameters.Name -ErrorAction 'SilentlyContinue'
             $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$($resourceParameters.Name)'" -ErrorAction 'SilentlyContinue'
 
             It 'Should not have removed service with specified name' {
-                 $service | Should Not Be $null
-                 $serviceCimInstance | Should Not Be $null
+                 $service | Should -Not -Be $null
+                 $serviceCimInstance | Should -Not -Be $null
 
-                 $service.Name | Should Be $resourceParameters.Name
-                 $serviceCimInstance.Name | Should Be $resourceParameters.Name
+                 $service.Name | Should -Be $resourceParameters.Name
+                 $serviceCimInstance.Name | Should -Be $resourceParameters.Name
             }
 
             It 'Should have edited service to have the specified path' {
-                $serviceCimInstance.PathName | Should Be $resourceParameters.Path
+                $serviceCimInstance.PathName | Should -Be $resourceParameters.Path
             }
 
             It 'Should have edited service to have the specified display name' {
-                $service.DisplayName | Should Be $resourceParameters.DisplayName
+                $service.DisplayName | Should -Be $resourceParameters.DisplayName
             }
 
             It 'Should have edited service to have the specified description' {
-                $serviceCimInstance.Description | Should Be $resourceParameters.Description
+                $serviceCimInstance.Description | Should -Be $resourceParameters.Description
             }
 
             It 'Should have edited service to have the specified dependencies' {
                 $differentDependencies = Compare-Object -ReferenceObject $resourceParameters.Dependencies -DifferenceObject $service.ServicesDependedOn.Name
-                $differentDependencies | Should Be $null
+                $differentDependencies | Should -Be $null
             }
 
             It 'Should not have changed the service state from Running' {
-                $service.Status | Should Be 'Running'
+                $service.Status | Should -Be 'Running'
             }
 
             It 'Should not have changed the service startup type from Auto' {
-                $serviceCimInstance.StartMode | Should Be 'Auto'
+                $serviceCimInstance.StartMode | Should -Be 'Auto'
             }
 
             It 'Should not have changed the service startup account name from LocalSystem' {
-                $serviceCimInstance.StartName | Should Be 'LocalSystem'
+                $serviceCimInstance.StartName | Should -Be 'LocalSystem'
             }
 
             It 'Should not have changed the service desktop interaction setting from False' {
-                $serviceCimInstance.DesktopInteract | Should Be $false
+                $serviceCimInstance.DesktopInteract | Should -Be $false
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should Be $true
+                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should -Be $true
             }
         }
 
@@ -256,30 +256,30 @@ try
                     . $script:configurationAllExceptCredentialFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $service = Get-Service -Name $resourceParameters.Name -ErrorAction 'SilentlyContinue'
             $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$($resourceParameters.Name)'" -ErrorAction 'SilentlyContinue'
 
             It 'Should not have removed service with specified name' {
-                 $service | Should Not Be $null
-                 $serviceCimInstance | Should Not Be $null
+                 $service | Should -Not -Be $null
+                 $serviceCimInstance | Should -Not -Be $null
 
-                 $service.Name | Should Be $resourceParameters.Name
-                 $serviceCimInstance.Name | Should Be $resourceParameters.Name
+                 $service.Name | Should -Be $resourceParameters.Name
+                 $serviceCimInstance.Name | Should -Be $resourceParameters.Name
             }
 
             It 'Should have edited the service to have the specified state' {
-                $service.Status | Should Be $resourceParameters.State
+                $service.Status | Should -Be $resourceParameters.State
             }
 
             It 'Should have edited the service to have the specified startup type' {
-                $serviceCimInstance.StartMode | Should Be $resourceParameters.StartupType
+                $serviceCimInstance.StartMode | Should -Be $resourceParameters.StartupType
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should Be $true
+                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should -Be $true
             }
         }
 
@@ -306,18 +306,18 @@ try
                     . $script:configurationCredentialOnlyFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive -ConfigurationData $configData @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $service = Get-Service -Name $resourceParameters.Name -ErrorAction 'SilentlyContinue'
             $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$($resourceParameters.Name)'" -ErrorAction 'SilentlyContinue'
 
             It 'Should not have removed service with specified name' {
-                    $service | Should Not Be $null
-                    $serviceCimInstance | Should Not Be $null
+                    $service | Should -Not -Be $null
+                    $serviceCimInstance | Should -Not -Be $null
 
-                    $service.Name | Should Be $resourceParameters.Name
-                    $serviceCimInstance.Name | Should Be $resourceParameters.Name
+                    $service.Name | Should -Be $resourceParameters.Name
+                    $serviceCimInstance.Name | Should -Be $resourceParameters.Name
             }
 
             It 'Should have edited the service to have the specified startup account name' {
@@ -328,11 +328,11 @@ try
                     $expectedStartName = $expectedStartName.TrimStart("$env:COMPUTERNAME\")
                 }
 
-                $serviceCimInstance.StartName | Should Be ".\$expectedStartName"
+                $serviceCimInstance.StartName | Should -Be ".\$expectedStartName"
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should Be $true
+                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should -Be $true
             }
         }
 
@@ -351,26 +351,26 @@ try
                     . $script:configurationAllExceptCredentialFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $service = Get-Service -Name $resourceParameters.Name -ErrorAction 'SilentlyContinue'
             $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$($resourceParameters.Name)'" -ErrorAction 'SilentlyContinue'
 
             It 'Should not have removed service with specified name' {
-                 $service | Should Not Be $null
-                 $serviceCimInstance | Should Not Be $null
+                 $service | Should -Not -Be $null
+                 $serviceCimInstance | Should -Not -Be $null
 
-                 $service.Name | Should Be $resourceParameters.Name
-                 $serviceCimInstance.Name | Should Be $resourceParameters.Name
+                 $service.Name | Should -Be $resourceParameters.Name
+                 $serviceCimInstance.Name | Should -Be $resourceParameters.Name
             }
 
             It 'Should have edited the service to have the specified startup account name' {
-                $serviceCimInstance.StartName | Should Be 'NT Authority\LocalService'
+                $serviceCimInstance.StartName | Should -Be 'NT Authority\LocalService'
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should Be $true
+                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should -Be $true
             }
         }
 
@@ -389,19 +389,19 @@ try
                     . $script:configurationAllExceptCredentialFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $service = Get-Service -Name $resourceParameters.Name -ErrorAction 'SilentlyContinue'
             $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$($resourceParameters.Name)'" -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the service with specified name' {
-                 $service | Should Be $null
-                 $serviceCimInstance | Should Be $null
+                 $service | Should -Be $null
+                 $serviceCimInstance | Should -Be $null
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {
-                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should Be $true
+                MSFT_xServiceResource\Test-TargetResource @resourceParameters | Should -Be $true
             }
         }
     }

--- a/Tests/Integration/MSFT_xUserResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xUserResource.Integration.Tests.ps1
@@ -63,20 +63,20 @@ try {
                                              -ConfigurationData $ConfigData `
                                              -ErrorAction Stop
                         Start-DscConfiguration -Path $configurationPath -Wait -Force
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
                     $currentConfig = Get-DscConfiguration -Verbose -ErrorAction Stop
-                    $currentConfig.UserName | Should Be $testUserName
-                    $currentConfig.Ensure | Should Be 'Present'
-                    $currentConfig.Description | Should Be $TestDescription
-                    $currentConfig.Disabled | Should Be $false
-                    $currentConfig.PasswordChangeRequired | Should Be $null
+                    $currentConfig.UserName | Should -Be $testUserName
+                    $currentConfig.Ensure | Should -Be 'Present'
+                    $currentConfig.Description | Should -Be $TestDescription
+                    $currentConfig.Disabled | Should -Be $false
+                    $currentConfig.PasswordChangeRequired | Should -Be $null
                 }
             }
             finally
@@ -116,20 +116,20 @@ try {
                                              -ConfigurationData $ConfigData `
                                              -ErrorAction Stop
                         Start-DscConfiguration -Path $configurationPath -Wait -Force
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
                     $currentConfig = Get-DscConfiguration -Verbose -ErrorAction Stop
-                    $currentConfig.UserName | Should Be $testUserName
-                    $currentConfig.Ensure | Should Be 'Present'
-                    $currentConfig.Description | Should Be $TestDescription
-                    $currentConfig.Disabled | Should Be $false
-                    $currentConfig.PasswordChangeRequired | Should Be $null
+                    $currentConfig.UserName | Should -Be $testUserName
+                    $currentConfig.Ensure | Should -Be 'Present'
+                    $currentConfig.Description | Should -Be $TestDescription
+                    $currentConfig.Disabled | Should -Be $false
+                    $currentConfig.PasswordChangeRequired | Should -Be $null
                 }
             }
             finally
@@ -168,17 +168,17 @@ try {
                                              -Ensure 'Absent' `
                                              -ErrorAction Stop
                         Start-DscConfiguration -Path $configurationPath -Wait -Force
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
                     $currentConfig = Get-DscConfiguration -Verbose -ErrorAction Stop
-                    $currentConfig.UserName | Should Be $testUserName
-                    $currentConfig.Ensure | Should Be 'Absent'
+                    $currentConfig.UserName | Should -Be $testUserName
+                    $currentConfig.Ensure | Should -Be 'Absent'
                 }
             }
             finally

--- a/Tests/Integration/MSFT_xWindowsFeature.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsFeature.Integration.Tests.ps1
@@ -92,23 +92,23 @@ try {
                                              -OutputPath $configurationPath `
                                              -ErrorAction 'Stop'
                         Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
                    $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                   $currentConfig.Name | Should Be $script:testFeatureName
-                   $currentConfig.IncludeAllSubFeature | Should Be $false
-                   $currentConfig.Ensure | Should Be 'Present'
+                   $currentConfig.Name | Should -Be $script:testFeatureName
+                   $currentConfig.IncludeAllSubFeature | Should -Be $false
+                   $currentConfig.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should be Installed' {
                     $feature = Get-WindowsFeature -Name $script:testFeatureName
-                    $feature.Installed | Should Be $true
+                    $feature.Installed | Should -Be $true
                 }
             }
             finally
@@ -141,23 +141,23 @@ try {
                                              -OutputPath $configurationPath `
                                              -ErrorAction 'Stop'
                         Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
                    $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                   $currentConfig.Name | Should Be $script:testFeatureName
-                   $currentConfig.IncludeAllSubFeature | Should Be $false
-                   $currentConfig.Ensure | Should Be 'Absent'
+                   $currentConfig.Name | Should -Be $script:testFeatureName
+                   $currentConfig.IncludeAllSubFeature | Should -Be $false
+                   $currentConfig.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should not be installed' {
                     $feature = Get-WindowsFeature -Name $script:testFeatureName
-                    $feature.Installed | Should Be $false
+                    $feature.Installed | Should -Be $false
                 }
             }
             finally
@@ -194,28 +194,28 @@ try {
                                             -OutputPath $configurationPath `
                                             -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' -Skip:$script:skipLongTests {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' -Skip:$script:skipLongTests {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Name | Should Be $script:testFeatureWithSubFeaturesName
-                $currentConfig.IncludeAllSubFeature | Should Be $true
-                $currentConfig.Ensure | Should Be 'Present'
+                $currentConfig.Name | Should -Be $script:testFeatureWithSubFeaturesName
+                $currentConfig.IncludeAllSubFeature | Should -Be $true
+                $currentConfig.Ensure | Should -Be 'Present'
             }
 
             It 'Should be Installed (includes check for subFeatures)' -Skip:$script:skipLongTests {
                 $feature = Get-WindowsFeature -Name $script:testFeatureWithSubFeaturesName
-                $feature.Installed | Should Be $true
+                $feature.Installed | Should -Be $true
 
                 foreach ($subFeatureName in $feature.SubFeatures)
                 {
                     $subFeature = Get-WindowsFeature -Name $subFeatureName
-                    $subFeature.Installed | Should Be $true
+                    $subFeature.Installed | Should -Be $true
                 }
             }
         }
@@ -235,28 +235,28 @@ try {
                                             -OutputPath $configurationPath `
                                             -ErrorAction 'Stop'
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' -Skip:$script:skipLongTests {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' -Skip:$script:skipLongTests  {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Name | Should Be $script:testFeatureWithSubFeaturesName
-                $currentConfig.IncludeAllSubFeature | Should Be $false
-                $currentConfig.Ensure | Should Be 'Absent'
+                $currentConfig.Name | Should -Be $script:testFeatureWithSubFeaturesName
+                $currentConfig.IncludeAllSubFeature | Should -Be $false
+                $currentConfig.Ensure | Should -Be 'Absent'
             }
 
             It 'Should not be installed (includes check for subFeatures)' -Skip:$script:skipLongTests {
                 $feature = Get-WindowsFeature -Name $script:testFeatureWithSubFeaturesName
-                $feature.Installed | Should Be $false
+                $feature.Installed | Should -Be $false
 
                 foreach ($subFeatureName in $feature.SubFeatures)
                 {
                     $subFeature = Get-WindowsFeature -Name $subFeatureName
-                    $subFeature.Installed | Should Be $false
+                    $subFeature.Installed | Should -Be $false
                 }
             }
         }

--- a/Tests/Integration/MSFT_xWindowsOptionalFeature.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsOptionalFeature.Integration.Tests.ps1
@@ -43,12 +43,12 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 $windowsOptionalFeature = Dism\Get-WindowsOptionalFeature -FeatureName $resourceParameters.Name -Online
 
-                $windowsOptionalFeature | Should Not Be $null
-                $windowsOptionalFeature.State -in $script:enabledStates | Should Be $true
+                $windowsOptionalFeature | Should -Not -Be $null
+                $windowsOptionalFeature.State -in $script:enabledStates | Should -Be $true
             }
             finally
             {
@@ -92,12 +92,12 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 $windowsOptionalFeature = Dism\Get-WindowsOptionalFeature -FeatureName $resourceParameters.Name -Online
 
-                $windowsOptionalFeature | Should Not Be $null
-                $windowsOptionalFeature.State -in $script:disabledStates | Should Be $true
+                $windowsOptionalFeature | Should -Not -Be $null
+                $windowsOptionalFeature.State -in $script:disabledStates | Should -Be $true
             }
             finally
             {
@@ -127,7 +127,7 @@ try
                 NoWindowsUpdateCheck = $true
             }
 
-            Dism\Get-WindowsOptionalFeature -FeatureName $resourceParameters.Name -Online | Should Be $null
+            Dism\Get-WindowsOptionalFeature -FeatureName $resourceParameters.Name -Online | Should -Be $null
 
             try
             {
@@ -135,11 +135,11 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Throw "Feature name $($resourceParameters.Name) is unknown."
+                } | Should -Throw "Feature name $($resourceParameters.Name) is unknown."
 
-                Test-Path -Path $resourceParameters.LogPath | Should Be $true
+                Test-Path -Path $resourceParameters.LogPath | Should -Be $true
 
-                Dism\Get-WindowsOptionalFeature -FeatureName $resourceParameters.Name -Online | Should Be $null
+                Dism\Get-WindowsOptionalFeature -FeatureName $resourceParameters.Name -Online | Should -Be $null
             }
             finally
             {

--- a/Tests/Integration/MSFT_xWindowsPackageCab.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsPackageCab.Integration.Tests.ps1
@@ -78,13 +78,13 @@ try
                 . $script:confgurationFilePath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @resourceParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
 
-            { $windowsPackage = Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should Not Throw
+            { $windowsPackage = Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should -Not -Throw
 
             $windowsPackage = Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online
-            $windowsPackage | Should Not Be $null
-            $windowsPackage.PackageState -in $script:installedStates | Should Be $true
+            $windowsPackage | Should -Not -Be $null
+            $windowsPackage.PackageState -in $script:installedStates | Should -Be $true
         }
 
         It 'Should uninstall a Windows package through a cab file' -Skip:$script:cabPackageNotProvided {
@@ -98,15 +98,15 @@ try
 
             Dism\Add-WindowsPackage -PackagePath $resourceParameters.SourcePath -Online -NoRestart
 
-            { $windowsPackage = Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should Not Throw
+            { $windowsPackage = Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should -Not -Throw
 
             {
                 . $script:confgurationFilePath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @resourceParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
 
-            { $windowsPackage = Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should Throw
+            { $windowsPackage = Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should -Throw
         }
 
         It 'Should not install an invalid Windows package through a cab file' {
@@ -119,17 +119,17 @@ try
                 LogPath = (Join-Path -Path $TestDrive -ChildPath 'InvalidWindowsPackageCab.log')
             }
 
-            { Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should Throw
+            { Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should -Throw
 
             {
                 . $script:confgurationFilePath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @resourceParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Throw
+            } | Should -Throw
 
-            Test-Path -Path $resourceParameters.LogPath | Should Be $true
+            Test-Path -Path $resourceParameters.LogPath | Should -Be $true
 
-            { Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should Throw
+            { Dism\Get-WindowsPackage -PackageName $resourceParameters.Name -Online } | Should -Throw
         }
     }
 }

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -53,26 +53,26 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Absent'
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Absent'
             }
 
             It 'Should not create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
         }
 
@@ -82,7 +82,7 @@ try
 
             It 'Should not have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
 
             It 'Should compile without throwing' {
@@ -94,27 +94,27 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Present'
-                $currentConfig.ProcessCount | Should Be 1
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Present'
+                $currentConfig.ProcessCount | Should -Be 1
             }
 
             It 'Should create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
         }
 
@@ -124,11 +124,11 @@ try
 
             It 'Should have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
 
             It 'Should not throw when removing the log file' {
-                { Remove-Item -Path $logFilePath } | Should not Throw
+                { Remove-Item -Path $logFilePath } | Should -Not -Throw
             }
 
             It 'Should compile without throwing' {
@@ -140,27 +140,27 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Present'
-                $currentConfig.ProcessCount | Should Be 1
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Present'
+                $currentConfig.ProcessCount | Should -Be 1
             }
 
             It 'Should not create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
         }
 
@@ -170,7 +170,7 @@ try
 
             It 'Should not have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
 
             It 'Should compile without throwing' {
@@ -182,26 +182,26 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Absent'
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Absent'
             }
 
             It 'Should not create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
         }
 
@@ -211,7 +211,7 @@ try
 
             It 'Should not have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
 
             It 'Should compile without throwing' {
@@ -223,7 +223,7 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
@@ -234,20 +234,20 @@ try
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Present'
-                $currentConfig.ProcessCount | Should Be 2
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Present'
+                $currentConfig.ProcessCount | Should -Be 2
             }
 
             It 'Should create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
         }
 
@@ -257,11 +257,11 @@ try
 
             It 'Should have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
 
             It 'Should not throw when removing the log file' {
-                { Remove-Item -Path $logFilePath } | Should not Throw
+                { Remove-Item -Path $logFilePath } | Should -Not -Throw
             }
 
             It 'Should compile without throwing' {
@@ -273,26 +273,26 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Absent'
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Absent'
             }
 
             It 'Should not create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
         }
     }
@@ -340,26 +340,26 @@ try
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Absent'
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Absent'
             }
 
             It 'Should not create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
         }
 
@@ -369,7 +369,7 @@ try
 
             It 'Should not have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
 
             It 'Should compile without throwing' {
@@ -383,27 +383,27 @@ try
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Present'
-                $currentConfig.ProcessCount | Should Be 1
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Present'
+                $currentConfig.ProcessCount | Should -Be 1
             }
 
             It 'Should create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
         }
 
@@ -413,11 +413,11 @@ try
 
             It 'Should have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
 
             It 'Should not throw when removing the log file' {
-                { Remove-Item -Path $logFilePath } | Should not Throw
+                { Remove-Item -Path $logFilePath } | Should -Not -Throw
             }
 
             It 'Should compile without throwing' {
@@ -431,27 +431,27 @@ try
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Present'
-                $currentConfig.ProcessCount | Should Be 1
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Present'
+                $currentConfig.ProcessCount | Should -Be 1
             }
 
             It 'Should not create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
         }
 
@@ -461,7 +461,7 @@ try
 
             It 'Should not have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
 
             It 'Should compile without throwing' {
@@ -475,26 +475,26 @@ try
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Absent'
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Absent'
             }
 
             It 'Should not create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
         }
 
@@ -504,7 +504,7 @@ try
 
             It 'Should not have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $false
+                $pathResult | Should -Be $false
             }
 
             It 'Should compile without throwing' {
@@ -518,7 +518,7 @@ try
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
@@ -529,20 +529,20 @@ try
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Present'
-                $currentConfig.ProcessCount | Should Be 2
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Present'
+                $currentConfig.ProcessCount | Should -Be 2
             }
 
             It 'Should create a logfile' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
         }
 
@@ -552,11 +552,11 @@ try
 
             It 'Should have a logfile already present' {
                 $pathResult = Test-Path $logFilePath
-                $pathResult | Should Be $true
+                $pathResult | Should -Be $true
             }
 
             It 'Should not throw when removing the log file' {
-                { Remove-Item -Path $logFilePath } | Should not Throw
+                { Remove-Item -Path $logFilePath } | Should -Not -Throw
             }
 
             It 'Should compile without throwing' {
@@ -575,21 +575,21 @@ try
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
                     Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
             It 'Should be able to call Get-DscConfiguration without throwing' {
-                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should -Not -Throw
             }
 
             It 'Should return the correct configuration' {
                 $currentConfig = Get-DscConfiguration -ErrorAction 'Stop'
-                $currentConfig.Path | Should Be $testProcessPath
-                $currentConfig.Arguments | Should Be $logFilePath
-                $currentConfig.Ensure | Should Be 'Absent'
+                $currentConfig.Path | Should -Be $testProcessPath
+                $currentConfig.Arguments | Should -Be $logFilePath
+                $currentConfig.Ensure | Should -Be 'Absent'
             }
         }
     }

--- a/Tests/Integration/xGroupSet.Integration.Tests.ps1
+++ b/Tests/Integration/xGroupSet.Integration.Tests.ps1
@@ -64,8 +64,8 @@ try
                 Ensure = 'Present'
             }
 
-            Test-GroupExists -GroupName $testGroupName1 | Should Be $false
-            Test-GroupExists -GroupName $testGroupName2 | Should Be $false
+            Test-GroupExists -GroupName $testGroupName1 | Should -Be $false
+            Test-GroupExists -GroupName $testGroupName2 | Should -Be $false
 
             try
             {
@@ -73,10 +73,10 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName1 -Members @() | Should Be $true
-                Test-GroupExists -GroupName $testGroupName2 -Members @() | Should Be $true
+                Test-GroupExists -GroupName $testGroupName1 -Members @() | Should -Be $true
+                Test-GroupExists -GroupName $testGroupName2 -Members @() | Should -Be $true
             }
             finally
             {
@@ -104,7 +104,7 @@ try
                 MembersToInclude = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName1 | Should Be $false
+            Test-GroupExists -GroupName $testGroupName1 | Should -Be $false
 
             try
             {
@@ -112,9 +112,9 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName1 -MembersToInclude $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName1 -MembersToInclude $groupMembers | Should -Be $true
             }
             finally
             {
@@ -139,8 +139,8 @@ try
                 MembersToInclude = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
-            Test-GroupExists -GroupName $administratorsGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
+            Test-GroupExists -GroupName $administratorsGroupName | Should -Be $true
 
             try
             {
@@ -148,10 +148,10 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should Be $true
-                Test-GroupExists -GroupName $administratorsGroupName -MembersToInclude $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should -Be $true
+                Test-GroupExists -GroupName $administratorsGroupName -MembersToInclude $groupMembers | Should -Be $true
             }
             finally
             {
@@ -177,11 +177,11 @@ try
 
             foreach ($testGroupName in $testGroupNames)
             {
-                Test-GroupExists -GroupName $testGroupName | Should Be $false
+                Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
                 New-Group -GroupName $testGroupName -Members $testUsernames
 
-                Test-GroupExists -GroupName $testGroupName | Should Be $true
+                Test-GroupExists -GroupName $testGroupName | Should -Be $true
             }
 
             try
@@ -190,11 +190,11 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 foreach ($testGroupName in $testGroupNames)
                 {
-                    Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should Be $true
+                    Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should -Be $true
                 }
             }
             finally
@@ -222,11 +222,11 @@ try
 
             foreach ($testGroupName in $testGroupNames)
             {
-                Test-GroupExists -GroupName $testGroupName | Should Be $false
+                Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
                 New-Group -GroupName $testGroupName
 
-                Test-GroupExists -GroupName $testGroupName | Should Be $true
+                Test-GroupExists -GroupName $testGroupName | Should -Be $true
             }
 
             try
@@ -235,11 +235,11 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 foreach ($testGroupName in $testGroupNames)
                 {
-                    Test-GroupExists -GroupName $testGroupName | Should Be $false
+                    Test-GroupExists -GroupName $testGroupName | Should -Be $false
                 }
             }
             finally

--- a/Tests/Integration/xProcessSet.Integration.Tests.ps1
+++ b/Tests/Integration/xProcessSet.Integration.Tests.ps1
@@ -71,7 +71,7 @@ try
                 }
 
                 It "Should not have started process $processName before configuration" {
-                    $process | Should Be $null
+                    $process | Should -Be $null
                 }
             }
 
@@ -80,7 +80,7 @@ try
                     . $script:configurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @processSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             foreach ($processPath in $processSetParameters.ProcessPaths)
@@ -89,7 +89,7 @@ try
                 $process = Get-Process -Name $processName -ErrorAction 'SilentlyContinue'
 
                 It "Should have started process $processName after configuration" {
-                    $process | Should Not Be $null
+                    $process | Should -Not -Be $null
                 }
             }
         }
@@ -122,7 +122,7 @@ try
                 }
 
                 It "Should have started process $processName before configuration" {
-                    $process | Should Not Be $null
+                    $process | Should -Not -Be $null
                 }
             }
 
@@ -131,7 +131,7 @@ try
                     . $script:configurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @processSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             foreach ($processPath in $processSetParameters.ProcessPaths)
@@ -140,7 +140,7 @@ try
                 $process = Get-Process -Name $processName -ErrorAction 'SilentlyContinue'
 
                 It "Should have stopped process $processName after configuration" {
-                    $process | Should Be $null
+                    $process | Should -Be $null
                 }
             }
         }

--- a/Tests/Integration/xServiceSet.Integration.Tests.ps1
+++ b/Tests/Integration/xServiceSet.Integration.Tests.ps1
@@ -147,30 +147,30 @@ try
                     . $script:confgurationFilePathAllExceptBuiltInAccount -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive -ConfigurationData $configData @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $service = Get-Service -Name $resourceParameters.Name[0] -ErrorAction 'SilentlyContinue'
             $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$($resourceParameters.Name[0])'" -ErrorAction 'SilentlyContinue'
 
             It 'Should not have removed service with the specified name' {
-                 $service | Should Not Be $null
-                 $serviceCimInstance | Should Not Be $null
+                 $service | Should -Not -Be $null
+                 $serviceCimInstance | Should -Not -Be $null
 
-                 $service.Name | Should Be $resourceParameters.Name[0]
-                 $serviceCimInstance.Name | Should Be $resourceParameters.Name[0]
+                 $service.Name | Should -Be $resourceParameters.Name[0]
+                 $serviceCimInstance.Name | Should -Be $resourceParameters.Name[0]
             }
 
             It 'Should have set the service state to the specified state' {
-                $service.Status | Should Be $resourceParameters.State
+                $service.Status | Should -Be $resourceParameters.State
             }
 
             It 'Should have set the service startup type to the specified startup type' {
-                $serviceCimInstance.StartMode | Should Be $resourceParameters.StartupType
+                $serviceCimInstance.StartMode | Should -Be $resourceParameters.StartupType
             }
 
             It 'Should have set the service start name to the appveyor account name' {
-                $serviceCimInstance.StartName | Should Be '.\appveyor'
+                $serviceCimInstance.StartName | Should -Be '.\appveyor'
             }
         }
 
@@ -189,7 +189,7 @@ try
                     . $script:confgurationFilePathBuiltInAccountOnly -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $serviceCount = 1
@@ -200,19 +200,19 @@ try
                 $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$serviceName'" -ErrorAction 'SilentlyContinue'
 
                 It "Should not have removed service $serviceCount" {
-                     $service | Should Not Be $null
-                     $serviceCimInstance | Should Not Be $null
+                     $service | Should -Not -Be $null
+                     $serviceCimInstance | Should -Not -Be $null
 
-                     $service.Name | Should Be $serviceName
-                     $serviceCimInstance.Name | Should Be $serviceName
+                     $service.Name | Should -Be $serviceName
+                     $serviceCimInstance.Name | Should -Be $serviceName
                 }
 
                 It "Should have set the state  of service $serviceCount to Running (default action of xService)" {
-                    $service.Status | Should Be 'Running'
+                    $service.Status | Should -Be 'Running'
                 }
 
                 It "Should have set the start name of service $serviceCount to the specified built-in account name" {
-                    $serviceCimInstance.StartName | Should Be $resourceParameters.BuiltInAccount
+                    $serviceCimInstance.StartName | Should -Be $resourceParameters.BuiltInAccount
                 }
 
                 $serviceCount += 1
@@ -234,7 +234,7 @@ try
                     . $script:confgurationFilePathBuiltInAccountOnly -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             $serviceCount = 1
@@ -245,8 +245,8 @@ try
                 $serviceCimInstance = Get-CimInstance -ClassName 'Win32_Service' -Filter "Name='$serviceName'" -ErrorAction 'SilentlyContinue'
 
                 It "Should have removed service $serviceCount" {
-                     $service | Should Be $null
-                     $serviceCimInstance | Should Be $null
+                     $service | Should -Be $null
+                     $serviceCimInstance | Should -Be $null
                 }
 
                 $serviceCount += 1

--- a/Tests/Integration/xWindowsFeatureSet.Integration.Tests.ps1
+++ b/Tests/Integration/xWindowsFeatureSet.Integration.Tests.ps1
@@ -61,7 +61,7 @@ try {
                 $windowsFeature = Get-WindowsFeature -Name $windowsFeatureName
 
                 It "Should be able to retrieve Windows feature $windowsFeatureName before the configuration" {
-                    $windowsFeature | Should Not Be $null
+                    $windowsFeature | Should -Not -Be $null
                 }
 
                 if ($windowsFeature.Installed)
@@ -80,7 +80,7 @@ try {
                 }
 
                 It "Should have uninstalled Windows feature $windowsFeatureName before the configuration" {
-                    $windowsFeature.Installed | Should Be $false
+                    $windowsFeature.Installed | Should -Be $false
                 }
             }
 
@@ -89,7 +89,7 @@ try {
                     . $script:configurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @windowsFeatureSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             foreach ($windowsFeatureName in $windowsFeatureSetParameters.WindowsFeatureNames)
@@ -97,7 +97,7 @@ try {
                 $windowsFeature = Get-WindowsFeature -Name $windowsFeatureName
 
                 It "Should be able to retrieve Windows feature $windowsFeatureName after the configuration" {
-                    $windowsFeature | Should Not Be $null
+                    $windowsFeature | Should -Not -Be $null
                 }
 
                 if (-not $windowsFeature.Installed)
@@ -113,16 +113,16 @@ try {
                 }
 
                 It "Should have installed Windows feature $windowsFeatureName after the configuration" {
-                    $windowsFeature.Installed | Should Be $true
+                    $windowsFeature.Installed | Should -Be $true
                 }
             }
 
             It 'Should have created the log file' {
-                Test-Path -Path $windowsFeatureSetParameters.LogPath | Should Be $true
+                Test-Path -Path $windowsFeatureSetParameters.LogPath | Should -Be $true
             }
 
             It 'Should have created content in the log file' {
-                Get-Content -Path $windowsFeatureSetParameters.LogPath -Raw | Should Not Be $null
+                Get-Content -Path $windowsFeatureSetParameters.LogPath -Raw | Should -Not -Be $null
             }
         }
 
@@ -140,7 +140,7 @@ try {
                 $windowsFeature = Get-WindowsFeature -Name $windowsFeatureName
 
                 It "Should be able to retrieve Windows feature $windowsFeatureName before the configuration" {
-                    $windowsFeature | Should Not Be $null
+                    $windowsFeature | Should -Not -Be $null
                 }
 
                 if (-not $windowsFeature.Installed)
@@ -159,7 +159,7 @@ try {
                 }
 
                 It "Should have installed Windows feature $windowsFeatureName before the configuration" {
-                    $windowsFeature.Installed | Should Be $true
+                    $windowsFeature.Installed | Should -Be $true
                 }
             }
 
@@ -168,7 +168,7 @@ try {
                     . $script:configurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @windowsFeatureSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             foreach ($windowsFeatureName in $windowsFeatureSetParameters.WindowsFeatureNames)
@@ -176,7 +176,7 @@ try {
                 $windowsFeature = Get-WindowsFeature -Name $windowsFeatureName
 
                 It "Should be able to retrieve Windows feature $windowsFeatureName after the configuration" {
-                    $windowsFeature | Should Not Be $null
+                    $windowsFeature | Should -Not -Be $null
                 }
 
                 if ($windowsFeature.Installed)
@@ -192,16 +192,16 @@ try {
                 }
 
                 It "Should have uninstalled Windows feature $windowsFeatureName after the configuration" {
-                    $windowsFeature.Installed | Should Be $false
+                    $windowsFeature.Installed | Should -Be $false
                 }
             }
 
             It 'Should have created the log file' {
-                Test-Path -Path $windowsFeatureSetParameters.LogPath | Should Be $true
+                Test-Path -Path $windowsFeatureSetParameters.LogPath | Should -Be $true
             }
 
             It 'Should have created content in the log file' {
-                Get-Content -Path $windowsFeatureSetParameters.LogPath -Raw | Should Not Be $null
+                Get-Content -Path $windowsFeatureSetParameters.LogPath -Raw | Should -Not -Be $null
             }
         }
     }

--- a/Tests/Integration/xWindowsOptionalFeatureSet.Integration.Tests.ps1
+++ b/Tests/Integration/xWindowsOptionalFeatureSet.Integration.Tests.ps1
@@ -68,7 +68,7 @@ try
                 $windowsOptionalFeature = Dism\Get-WindowsOptionalFeature -Online -FeatureName $windowsOptionalFeatureName
 
                 It "Should be able to retrieve Windows optional feature $windowsOptionalFeatureName before the configuration" {
-                    $windowsOptionalFeature | Should Not Be $null
+                    $windowsOptionalFeature | Should -Not -Be $null
                 }
 
                 if ($windowsOptionalFeature.State -in $script:enabledStates)
@@ -87,7 +87,7 @@ try
                 }
 
                 It "Should have disabled Windows optional feature $windowsOptionalFeatureName before the configuration" {
-                    $windowsOptionalFeature.State -in $script:disabledStates | Should Be $true
+                    $windowsOptionalFeature.State -in $script:disabledStates | Should -Be $true
                 }
             }
 
@@ -96,7 +96,7 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @wofSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             foreach ($windowsOptionalFeatureName in $wofSetParameters.WindowsOptionalFeatureNames)
@@ -104,7 +104,7 @@ try
                 $windowsOptionalFeature = Dism\Get-WindowsOptionalFeature -Online -FeatureName $windowsOptionalFeatureName
 
                 It "Should be able to retrieve Windows optional feature $windowsOptionalFeatureName after the configuration" {
-                    $windowsOptionalFeature | Should Not Be $null
+                    $windowsOptionalFeature | Should -Not -Be $null
                 }
 
                 # May need to wait a moment for the correct state to populate
@@ -117,16 +117,16 @@ try
                 }
 
                 It "Should have enabled Windows optional feature $windowsOptionalFeatureName after the configuration" {
-                    $windowsOptionalFeature.State -in $script:enabledStates | Should Be $true
+                    $windowsOptionalFeature.State -in $script:enabledStates | Should -Be $true
                 }
             }
 
             It 'Should have created the log file' {
-                Test-Path -Path $wofSetParameters.LogPath | Should Be $true
+                Test-Path -Path $wofSetParameters.LogPath | Should -Be $true
             }
 
             It 'Should have created content in the log file' {
-                Get-Content -Path $wofSetParameters.LogPath -Raw | Should Not Be $null
+                Get-Content -Path $wofSetParameters.LogPath -Raw | Should -Not -Be $null
             }
         }
 
@@ -144,7 +144,7 @@ try
                 $windowsOptionalFeature = Dism\Get-WindowsOptionalFeature -Online -FeatureName $windowsOptionalFeatureName
 
                 It "Should be able to retrieve Windows optional feature $windowsOptionalFeatureName before the configuration" {
-                    $windowsOptionalFeature | Should Not Be $null
+                    $windowsOptionalFeature | Should -Not -Be $null
                 }
 
                 if ($windowsOptionalFeature.State -in $script:disabledStates)
@@ -163,7 +163,7 @@ try
                 }
 
                 It "Should have enabled Windows optional feature $windowsOptionalFeatureName before the configuration" {
-                    $windowsOptionalFeature.State -in $script:enabledStates | Should Be $true
+                    $windowsOptionalFeature.State -in $script:enabledStates | Should -Be $true
                 }
             }
 
@@ -172,7 +172,7 @@ try
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @wofSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
 
             foreach ($windowsOptionalFeatureName in $wofSetParameters.WindowsOptionalFeatureNames)
@@ -180,7 +180,7 @@ try
                 $windowsOptionalFeature = Dism\Get-WindowsOptionalFeature -Online -FeatureName $windowsOptionalFeatureName
 
                 It "Should be able to retrieve Windows optional feature $windowsOptionalFeatureName after the confguration" {
-                    $windowsOptionalFeature | Should Not Be $null
+                    $windowsOptionalFeature | Should -Not -Be $null
                 }
 
                 # May need to wait a moment for the correct state to populate
@@ -193,16 +193,16 @@ try
                 }
 
                 It "Should have disabled Windows optional feature $windowsOptionalFeatureName after the confguration" {
-                    $windowsOptionalFeature.State -in $script:disabledStates | Should Be $true
+                    $windowsOptionalFeature.State -in $script:disabledStates | Should -Be $true
                 }
             }
 
             It 'Should have created the log file' {
-                Test-Path -Path $wofSetParameters.LogPath | Should Be $true
+                Test-Path -Path $wofSetParameters.LogPath | Should -Be $true
             }
 
             It 'Should have created content in the log file' {
-                Get-Content -Path $wofSetParameters.LogPath -Raw | Should Not Be $null
+                Get-Content -Path $wofSetParameters.LogPath -Raw | Should -Not -Be $null
             }
         }
     }

--- a/Tests/Unit/MSFT_xArchive.Tests.ps1
+++ b/Tests/Unit/MSFT_xArchive.Tests.ps1
@@ -63,7 +63,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for Checksum specified while Validate is false' {
                     $errorMessage = $script:localizedData.ChecksumSpecifiedAndValidateFalse -f $getTargetResourceParameters.Checksum, $getTargetResourceParameters.Path, $getTargetResourceParameters.Destination
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $errorMessage
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -74,7 +74,7 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should throw an error for invalid archive path' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $testInvalidArchivePathErrorMessage
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw -ExpectedMessage $testInvalidArchivePathErrorMessage
                 }
             }
 
@@ -87,7 +87,7 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should throw an error for invalid destination' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $testInvalidDestinationErrorMessage
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw -ExpectedMessage $testInvalidDestinationErrorMessage
                 }
             }
 
@@ -687,7 +687,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for Checksum specified while Validate is false' {
                     $errorMessage = $script:localizedData.ChecksumSpecifiedAndValidateFalse -f $setTargetResourceParameters.Checksum, $setTargetResourceParameters.Path, $setTargetResourceParameters.Destination
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $errorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -698,7 +698,7 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should throw an error for invalid archive path' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $testInvalidArchivePathErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $testInvalidArchivePathErrorMessage
                 }
             }
 
@@ -711,7 +711,7 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should throw an error for invalid destination' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $testInvalidDestinationErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $testInvalidDestinationErrorMessage
                 }
             }
 
@@ -1604,7 +1604,7 @@ Describe 'xArchive Unit Tests' {
                 It 'Should throw an error for failed PSDrive creation' {
                     $expectedPath = $mountPSDriveWithCredentialParameters.Path.Substring(0, $mountPSDriveWithCredentialParameters.Path.IndexOf('\'))
                     $expectedErrorMessage = $script:localizedData.ErrorCreatingPSDrive -f $expectedPath, $mountPSDriveWithCredentialParameters.Credential.UserName
-                    { $null = Mount-PSDriveWithCredential @mountPSDriveWithCredentialParameters } | Should -Throw $expectedErrorMessage
+                    { $null = Mount-PSDriveWithCredential @mountPSDriveWithCredentialParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -1709,7 +1709,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for an invalid path' {
                     $expectedErrorMessage = $script:localizedData.PathDoesNotContainValidPSDriveRoot -f $mountPSDriveWithCredentialParameters.Path
-                    { $null = Mount-PSDriveWithCredential @mountPSDriveWithCredentialParameters } | Should -Throw $expectedErrorMessage
+                    { $null = Mount-PSDriveWithCredential @mountPSDriveWithCredentialParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -1747,7 +1747,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for non-existent path' {
                     $expectedErrorMessage = $script:localizedData.PathDoesNotExistAsLeaf -f $assertPathExistsAsLeafParameters.Path
-                    { Assert-PathExistsAsLeaf @assertPathExistsAsLeafParameters } | Should -Throw $expectedErrorMessage
+                    { Assert-PathExistsAsLeaf @assertPathExistsAsLeafParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -1807,7 +1807,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw error for file at destination' {
                     $expectedErrorMessage = $script:localizedData.DestinationExistsAsFile -f $assertDestinationDoesNotExistAsFileParameters.Destination
-                    { Assert-DestinationDoesNotExistAsFile @assertDestinationDoesNotExistAsFileParameters } | Should -Throw $expectedErrorMessage
+                    { Assert-DestinationDoesNotExistAsFile @assertDestinationDoesNotExistAsFileParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -1901,7 +1901,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw error for failure while opening archive entry' {
                     $expectedErrorMessage = $script:localizedData.ErrorComparingHashes -f $testFileHashMatchesArchiveEntryHashParameters.FilePath, $testArchiveEntryFullName, $testFileHashMatchesArchiveEntryHashParameters.HashAlgorithmName
-                    { $null = Test-FileHashMatchesArchiveEntryHash @testFileHashMatchesArchiveEntryHashParameters } | Should -Throw $expectedErrorMessage
+                    { $null = Test-FileHashMatchesArchiveEntryHash @testFileHashMatchesArchiveEntryHashParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -1916,7 +1916,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw error for failure while opening a stream to the file' {
                     $expectedErrorMessage = $script:localizedData.ErrorComparingHashes -f $testFileHashMatchesArchiveEntryHashParameters.FilePath, $testArchiveEntryFullName, $testFileHashMatchesArchiveEntryHashParameters.HashAlgorithmName
-                    { $null = Test-FileHashMatchesArchiveEntryHash @testFileHashMatchesArchiveEntryHashParameters } | Should -Throw $expectedErrorMessage
+                    { $null = Test-FileHashMatchesArchiveEntryHash @testFileHashMatchesArchiveEntryHashParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -1931,7 +1931,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw error for failure to retrieve the file hash or archive entry hash' {
                     $expectedErrorMessage = $script:localizedData.ErrorComparingHashes -f $testFileHashMatchesArchiveEntryHashParameters.FilePath, $testArchiveEntryFullName, $testFileHashMatchesArchiveEntryHashParameters.HashAlgorithmName
-                    { $null = Test-FileHashMatchesArchiveEntryHash @testFileHashMatchesArchiveEntryHashParameters } | Should -Throw $expectedErrorMessage
+                    { $null = Test-FileHashMatchesArchiveEntryHash @testFileHashMatchesArchiveEntryHashParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -3575,7 +3575,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for failed copy from the file stream to the archive entry stream' {
                     $expectedErrorMessage = $script:localizedData.ErrorCopyingFromArchiveToDestination -f $copyArchiveEntryToDestinationParameters.DestinationPath
-                    { Copy-ArchiveEntryToDestination @copyArchiveEntryToDestinationParameters } | Should -Throw $expectedErrorMessage
+                    { Copy-ArchiveEntryToDestination @copyArchiveEntryToDestinationParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -3864,7 +3864,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for attempting to overwrite an existing item without specifying the Force parameter' {
                     $errorMessage = $script:localizedData.ForceNotSpecifiedToOverwriteItem -f $testItemPathAtDestination, $testArchiveEntryFullName
-                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw $errorMessage
+                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -3995,7 +3995,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for attempting to overwrite an existing item without specifying the Force parameter' {
                     $errorMessage = $script:localizedData.ForceNotSpecifiedToOverwriteItem -f $testItemPathAtDestination, $testArchiveEntryFullName
-                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw $errorMessage
+                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -4490,7 +4490,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for attempting to overwrite an existing item without specifying the Force parameter' {
                     $errorMessage = $script:localizedData.ForceNotSpecifiedToOverwriteItem -f $testItemPathAtDestination, $testArchiveEntryFullName
-                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw $errorMessage
+                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -4621,7 +4621,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for attempting to overwrite an existing item without specifying the Force parameter' {
                     $errorMessage = $script:localizedData.ForceNotSpecifiedToOverwriteItem -f $testItemPathAtDestination, $testArchiveEntryFullName
-                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw $errorMessage
+                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -4857,7 +4857,7 @@ Describe 'xArchive Unit Tests' {
 
                 It 'Should throw an error for attempting to overwrite an existing item without specifying the Force parameter' {
                     $errorMessage = $script:localizedData.ForceNotSpecifiedToOverwriteItem -f $testItemPathAtDestination, $testArchiveEntryFullName
-                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw $errorMessage
+                    { Expand-ArchiveToDestination @expandArchiveToDestinationParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 

--- a/Tests/Unit/MSFT_xArchive.Tests.ps1
+++ b/Tests/Unit/MSFT_xArchive.Tests.ps1
@@ -2478,11 +2478,11 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should Not Throw
+                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should Be $false
+                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should -Be $false
                 }
             }
 
@@ -2492,11 +2492,11 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should Not Throw
+                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should Be $false
+                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should -Be $false
                 }
             }
 
@@ -2506,11 +2506,11 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should Not Throw
+                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should Be $false
+                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should -Be $false
                 }
             }
 
@@ -2520,11 +2520,11 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should Not Throw
+                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should Be $true
+                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should -Be $true
                 }
             }
 
@@ -2534,11 +2534,11 @@ Describe 'xArchive Unit Tests' {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should Not Throw
+                    { $null = Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should Be $true
+                    Test-ArchiveEntryIsDirectory @testArchiveEntryNameIsDirectoryPathParameters | Should -Be $true
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDSCWebService.Tests.ps1
+++ b/Tests/Unit/MSFT_xDSCWebService.Tests.ps1
@@ -664,7 +664,7 @@ try
 
                 It 'Should throw an error because no certificate specified' {
                     $message = "Error: Cannot use best practice security settings with unencrypted traffic. Please set UseSecurityBestPractices to `$false or use a certificate to encrypt pull server traffic."
-                    {Set-TargetResource @altTestParameters -Ensure Present} | Should -Throw $message
+                    {Set-TargetResource @altTestParameters -Ensure Present} | Should -Throw -ExpectedMessage $message
                 }
             }
 
@@ -1137,14 +1137,14 @@ try
                 $templateName = 'Invalid Template Name'
 
                 $errorMessage = 'Certificate not found with subject containing {0} and using template "{1}".' -f $subject, $templateName
-                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -Throw $errorMessage
+                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -Throw -ExpectedMessage $errorMessage
             }
             It 'Should throw an error when the more than one certificate is found' {
                 $subject      = $certificateData[1].Subject
                 $templateName = 'WebServer'
 
                 $errorMessage = 'More than one certificate found with subject containing {0} and using template "{1}".' -f $subject, $templateName
-                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -Throw $errorMessage
+                {Find-CertificateThumbprintWithSubjectAndTemplateName -Subject $subject -TemplateName $templateName} | Should -Throw -ExpectedMessage $errorMessage
             }
         }
         Describe -Name "$dscResourceName\Get-OSVersion" -Fixture {

--- a/Tests/Unit/MSFT_xEnvironmentResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xEnvironmentResource.Tests.ps1
@@ -62,19 +62,19 @@ try
                 }
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the environment variable name' {
-                    $getTargetResourceResult.Name | Should Be $script:mockEnvironmentVarName
+                    $getTargetResourceResult.Name | Should -Be $script:mockEnvironmentVarName
                 }
 
                 It 'Should return the environment variable Ensure state as Present' {
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return the value of the environment variable' {
-                    $getTargetResourceResult.Value | Should Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
+                    $getTargetResourceResult.Value | Should -Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
                 }
             }
 
@@ -86,19 +86,19 @@ try
                 }
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the environment variable name' {
-                    $getTargetResourceResult.Name | Should Be $script:mockEnvironmentVarInvalidName
+                    $getTargetResourceResult.Name | Should -Be $script:mockEnvironmentVarInvalidName
                 }
 
                 It 'Should return the environment variable Ensure state as Absent' {
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return Value as null' {
-                    $getTargetResourceResult.Value | Should Be $null
+                    $getTargetResourceResult.Value | Should -Be $null
                 }
             }
 
@@ -110,19 +110,19 @@ try
                 }
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the environment variable name' {
-                    $getTargetResourceResult.Name | Should Be $script:mockEnvironmentVarName
+                    $getTargetResourceResult.Name | Should -Be $script:mockEnvironmentVarName
                 }
 
                 It 'Should return the environment variable Ensure state as Present' {
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return the value of the environment variable' {
-                    $getTargetResourceResult.Value | Should Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
+                    $getTargetResourceResult.Value | Should -Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
                 }
             }
 
@@ -134,19 +134,19 @@ try
                 }
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the environment variable name' {
-                    $getTargetResourceResult.Name | Should Be $script:mockEnvironmentVarInvalidName
+                    $getTargetResourceResult.Name | Should -Be $script:mockEnvironmentVarInvalidName
                 }
 
                 It 'Should return the environment variable Ensure state as Absent' {
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return Value as null' {
-                    $getTargetResourceResult.Value | Should Be $null
+                    $getTargetResourceResult.Value | Should -Be $null
                 }
             }
 
@@ -158,19 +158,19 @@ try
                 }
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the environment variable name' {
-                    $getTargetResourceResult.Name | Should Be $script:mockEnvironmentVarName
+                    $getTargetResourceResult.Name | Should -Be $script:mockEnvironmentVarName
                 }
 
                 It 'Should return the environment variable Ensure state as Present' {
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return the value of the environment variable' {
-                    $getTargetResourceResult.Value | Should Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
+                    $getTargetResourceResult.Value | Should -Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
                 }
             }
 
@@ -182,19 +182,19 @@ try
                 }
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the environment variable name' {
-                    $getTargetResourceResult.Name | Should Be $script:mockEnvironmentVarInvalidName
+                    $getTargetResourceResult.Name | Should -Be $script:mockEnvironmentVarInvalidName
                 }
 
                 It 'Should return the environment variable Ensure state as Absent' {
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return Value as null' {
-                    $getTargetResourceResult.Value | Should Be $null
+                    $getTargetResourceResult.Value | Should -Be $null
                 }
             }
         }
@@ -212,11 +212,11 @@ try
 
             Context 'Add new environment variable without Path and item properties not present' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue } | Should -Not -Throw
                 }
 
                 It 'Should have set the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -230,11 +230,11 @@ try
                 $newPathValue = 'new path value2'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should -Not -Throw
                 }
 
                 It 'Should have set the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -250,7 +250,7 @@ try
                 It 'Should throw an exception' {
                     {
                         Set-TargetResource -Name $script:mockEnvironmentVarName -Path $true -Ensure 'Present'
-                    } | Should Throw ($script:localizedData.CannotSetValueToEmpty -f $script:mockEnvironmentVarName)
+                    } | Should -Throw ($script:localizedData.CannotSetValueToEmpty -f $script:mockEnvironmentVarName)
                 }
             }
 
@@ -260,7 +260,7 @@ try
 
             Context 'Update environment variable but no Value specified' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -275,11 +275,11 @@ try
                 $script:mockEnvironmentVar.PATH = $newPathValue
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -293,11 +293,11 @@ try
                 $newPathValue = 'new path value3'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue } | Should -Not -Throw
                 }
 
                 It 'Should have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -311,11 +311,11 @@ try
                 $newPathValue = ';'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Not Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Not -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -331,11 +331,11 @@ try
                 $newPathValue = '    '
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Not Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Not -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -353,11 +353,11 @@ try
 
             Context 'Update environment variable with new Path and valid Value passed in' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true } | Should -Not -Throw
                 }
 
                 It 'Should have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newFullPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newFullPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -377,11 +377,11 @@ try
                 $newFullPathValue = ($script:mockEnvironmentVar.PATH +';' + $newPathValue)
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $oldPathValue -Path $true } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $oldPathValue -Path $true } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $oldPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $oldPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -399,7 +399,7 @@ try
 
             Context 'Remove environment variable that is already removed' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -415,7 +415,7 @@ try
 
             Context 'Remove environment variable with no Value specified' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Path $true } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Path $true } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -432,7 +432,7 @@ try
                                          -Value 'mockNewValue' `
                                          -Ensure 'Absent' `
                                          -Path $false
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -449,7 +449,7 @@ try
                                          -Value ';' `
                                          -Ensure 'Absent' `
                                          -Path $true
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -466,7 +466,7 @@ try
                                          -Value 'nonExistentPath' `
                                          -Ensure 'Absent' `
                                          -Path $true
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -488,7 +488,7 @@ try
                                          -Value $pathToRemove `
                                          -Ensure 'Absent' `
                                          -Path $true
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -511,7 +511,7 @@ try
                                          -Value $pathToRemove `
                                          -Ensure 'Absent' `
                                          -Path $true
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -536,11 +536,11 @@ try
 
             Context 'Add new environment variable without Path and item properties not present' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should have set the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -554,11 +554,11 @@ try
                 $newPathValue = 'new path value2'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should have set the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -573,7 +573,7 @@ try
                 It 'Should throw an exception' {
                     {
                         Set-TargetResource -Name $script:mockEnvironmentVarName -Path $true -Ensure 'Present' -Target @('Process')
-                    } | Should Throw ($script:localizedData.CannotSetValueToEmpty -f $script:mockEnvironmentVarName)
+                    } | Should -Throw ($script:localizedData.CannotSetValueToEmpty -f $script:mockEnvironmentVarName)
                 }
             }
 
@@ -581,7 +581,7 @@ try
 
             Context 'Update environment variable but no Value specified' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -596,11 +596,11 @@ try
                 $script:mockEnvironmentVar.PATH = $newPathValue
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -614,11 +614,11 @@ try
                 $newPathValue = 'new path value3'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -632,11 +632,11 @@ try
                 $newPathValue = ';'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Not Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Not -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -651,11 +651,11 @@ try
                 $newPathValue = '    '
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Not Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Not -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -672,11 +672,11 @@ try
 
             Context 'Update environment variable with new Path and valid Value passed in' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newFullPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newFullPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -695,11 +695,11 @@ try
                 $newFullPathValue = ($script:mockEnvironmentVar.PATH +';' + $newPathValue)
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $oldPathValue -Path $true -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $oldPathValue -Path $true -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $oldPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $oldPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -714,7 +714,7 @@ try
 
             Context 'Remove environment variable that is already removed' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -729,7 +729,7 @@ try
 
             Context 'Remove environment variable with no Value specified' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Path $true -Target @('Process') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Path $true -Target @('Process') } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -746,7 +746,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $false `
                                          -Target @('Process')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -764,7 +764,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Process')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -781,7 +781,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Process')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -803,7 +803,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Process')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -826,7 +826,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Process')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -852,11 +852,11 @@ try
             Context 'Add new environment variable without Path and item properties not present' {
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should have set the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -870,11 +870,11 @@ try
                 $newPathValue = 'new path value2'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should have set the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -890,7 +890,7 @@ try
                 It 'Should throw an exception' {
                     {
                         Set-TargetResource -Name $script:mockEnvironmentVarName -Path $true -Ensure 'Present' -Target @('Machine')
-                    } | Should Throw ($script:localizedData.CannotSetValueToEmpty -f $script:mockEnvironmentVarName)
+                    } | Should -Throw ($script:localizedData.CannotSetValueToEmpty -f $script:mockEnvironmentVarName)
                 }
             }
 
@@ -900,7 +900,7 @@ try
 
             Context 'Update environment variable but no Value specified' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -917,11 +917,11 @@ try
                 $script:mockEnvironmentVar.PATH = $newPathValue
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -935,11 +935,11 @@ try
                 $newPathValue = 'new path value3'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -953,11 +953,11 @@ try
                 $newPathValue = ';'
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Not Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Not -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -973,11 +973,11 @@ try
                 $newPathValue = '    '
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Not Be $newPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Not -Be $newPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -995,11 +995,11 @@ try
 
             Context 'Update environment variable with new Path and valid Value passed in' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $newPathValue -Path $true -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $newFullPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $newFullPathValue
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -1019,11 +1019,11 @@ try
                 $newFullPathValue = ($script:mockEnvironmentVar.PATH +';' + $newPathValue)
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $oldPathValue -Path $true -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Value $oldPathValue -Path $true -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should not have updated the mock variable value' {
-                    $script:mockEnvironmentVar.PATH | Should Be $oldPathValue
+                    $script:mockEnvironmentVar.PATH | Should -Be $oldPathValue
                 }
 
                 It 'Should have called the correct mocks to not set the environment variable' {
@@ -1040,7 +1040,7 @@ try
 
             Context 'Remove environment variable that is already removed' {
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -1057,7 +1057,7 @@ try
                 Mock -CommandName Remove-EnvironmentVariable -MockWith {}
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Path $true -Target @('Machine') } | Should Not Throw
+                    { Set-TargetResource -Name $script:mockEnvironmentVarName -Ensure 'Absent' -Path $true -Target @('Machine') } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -1078,7 +1078,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $false `
                                          -Target @('Machine')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -1096,7 +1096,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Machine')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -1114,7 +1114,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Machine')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to not remove the environment variable' {
@@ -1137,7 +1137,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Machine')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to remove the environment variable' {
@@ -1161,7 +1161,7 @@ try
                                          -Ensure 'Absent' `
                                          -Path $true `
                                          -Target @('Machine')
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should have called the correct mocks to set the environment variable' {
@@ -1185,7 +1185,7 @@ try
                     $testTargetResourceResult = Test-TargetResource -Name $script:mockEnvironmentVarName `
                                                                     -Ensure 'Present' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1203,7 +1203,7 @@ try
                     $testTargetResourceResult = Test-TargetResource -Name $script:mockEnvironmentVarName `
                                                                     -Ensure 'Present' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1221,7 +1221,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Present' `
                                                                     -Path $false
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1239,7 +1239,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Present' `
                                                                     -Path $false
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1257,7 +1257,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Present' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1276,7 +1276,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Present' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1307,7 +1307,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Present' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1329,7 +1329,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Present' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1347,7 +1347,7 @@ try
                     $testTargetResourceResult = Test-TargetResource -Name $script:mockEnvironmentVarName `
                                                                     -Ensure 'Absent' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1365,7 +1365,7 @@ try
                     $testTargetResourceResult = Test-TargetResource -Name $script:mockEnvironmentVarName `
                                                                     -Ensure 'Absent' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1383,7 +1383,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Absent' `
                                                                     -Path $false
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1401,7 +1401,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Absent' `
                                                                     -Path $false
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1433,7 +1433,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Absent' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1455,7 +1455,7 @@ try
                                                                     -Value $expectedValue `
                                                                     -Ensure 'Absent' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1473,7 +1473,7 @@ try
                                                                     -Value 'nonExistentValue' `
                                                                     -Ensure 'Absent' `
                                                                     -Path $true
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1495,7 +1495,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1512,7 +1512,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1532,7 +1532,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $false `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1551,7 +1551,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $false `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1570,7 +1570,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1589,7 +1589,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1620,7 +1620,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1638,7 +1638,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1655,7 +1655,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1672,7 +1672,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1690,7 +1690,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $false `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1709,7 +1709,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $false `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1740,7 +1740,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1761,7 +1761,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1781,7 +1781,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Process')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1803,7 +1803,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1822,7 +1822,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1841,7 +1841,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $false `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1860,7 +1860,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $false `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1879,7 +1879,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1901,7 +1901,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1933,7 +1933,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1956,7 +1956,7 @@ try
                                                                     -Ensure 'Present' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1974,7 +1974,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -1992,7 +1992,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -2011,7 +2011,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $false `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -2030,7 +2030,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $false `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -2063,7 +2063,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 It 'Should have called the correct mocks' {
@@ -2086,7 +2086,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -2105,7 +2105,7 @@ try
                                                                     -Ensure 'Absent' `
                                                                     -Path $true `
                                                                     -Target @('Machine')
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should have called the correct mocks' {
@@ -2134,7 +2134,7 @@ try
                 It 'Should return the correct value' {
                     $getEnvironmentVariableResult = Get-EnvironmentVariable -Name 'VariableName' `
                                                             -Target 'Process'
-                    $getEnvironmentVariableResult | Should Be $desiredValue
+                    $getEnvironmentVariableResult | Should -Be $desiredValue
                 }
             }
 
@@ -2142,13 +2142,13 @@ try
                 It 'Should return the correct value' {
                     $getEnvironmentVariableResult = Get-EnvironmentVariable -Name $script:mockEnvironmentVarName `
                                                             -Target 'Machine'
-                    $getEnvironmentVariableResult | Should Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
+                    $getEnvironmentVariableResult | Should -Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
                 }
 
                 It 'Should return the null when Name does not exist' {
                     $getEnvironmentVariableResult = Get-EnvironmentVariable -Name 'nonExistentName' `
                                                             -Target 'Machine'
-                    $getEnvironmentVariableResult | Should Be $null
+                    $getEnvironmentVariableResult | Should -Be $null
                 }
             }
         }
@@ -2158,13 +2158,13 @@ try
                 It 'Should return the updated path value with the new path' {
                     $getPathValueWithAddedPathsResult = Add-PathsToValue -CurrentValue 'path1;path2;path4' `
                                                                                     -NewValue 'path3'
-                    $getPathValueWithAddedPathsResult | Should Be 'path1;path2;path4;path3'
+                    $getPathValueWithAddedPathsResult | Should -Be 'path1;path2;path4;path3'
                 }
 
                 It 'Should return the updated path value with all of the new paths' {
                     $getPathValueWithAddedPathsResult = Add-PathsToValue -CurrentValue 'path1;path2;path4' `
                                                                                     -NewValue 'path3;path4;path5;path6;path1'
-                    $getPathValueWithAddedPathsResult | Should Be 'path1;path2;path4;path3;path5;path6'
+                    $getPathValueWithAddedPathsResult | Should -Be 'path1;path2;path4;path3;path5;path6'
                 }
             }
 
@@ -2174,13 +2174,13 @@ try
                 It 'Should return the original value if one path is passed in and it is already in the current value' {
                     $getPathValueWithAddedPathsResult = Add-PathsToValue -CurrentValue $currentValue `
                                                                          -NewValue 'path3'
-                    $getPathValueWithAddedPathsResult | Should Be $currentValue
+                    $getPathValueWithAddedPathsResult | Should -Be $currentValue
                 }
 
                 It 'Should return $currentValue if multiple paths are passed in that are already contained in current value' {
                     $getPathValueWithAddedPathsResult = Add-PathsToValue -CurrentValue $currentValue `
                                                                          -NewValue 'path3;path4;path2'
-                    $getPathValueWithAddedPathsResult | Should Be $currentValue
+                    $getPathValueWithAddedPathsResult | Should -Be $currentValue
                 }
             }
         }
@@ -2190,19 +2190,19 @@ try
                 It 'Should return the updated path value with the specified path removed' {
                     $getPathValueWithRemovedPathsResult = Remove-PathsFromValue -CurrentValue 'path1;path2;path4' `
                                                                                     -PathsToRemove 'path2'
-                    $getPathValueWithRemovedPathsResult | Should Be 'path1;path4'
+                    $getPathValueWithRemovedPathsResult | Should -Be 'path1;path4'
                 }
 
                 It 'Should return the updated path value with all of the specified paths removed if they were present' {
                     $getPathValueWithRemovedPathsResult = Remove-PathsFromValue -CurrentValue 'path1;path2;path4' `
                                                                                     -PathsToRemove 'path3;path4;path5;path6;path1'
-                    $getPathValueWithRemovedPathsResult | Should Be 'path2'
+                    $getPathValueWithRemovedPathsResult | Should -Be 'path2'
                 }
 
                 It 'Should return an empty string if all paths are removed' {
                     $getPathValueWithRemovedPathsResult = Remove-PathsFromValue -CurrentValue 'path1;path2;path4' `
                                                                                     -PathsToRemove 'path2;path1;path4'
-                    $getPathValueWithRemovedPathsResult | Should Be ''
+                    $getPathValueWithRemovedPathsResult | Should -Be ''
                 }
             }
 
@@ -2210,7 +2210,7 @@ try
                 It 'Should return the original path if no paths were removed' {
                     $getPathValueWithRemovedPathsResult = Remove-PathsFromValue -CurrentValue 'path1;path2;path3;path4' `
                                                                                     -PathsToRemove 'path5;path6;path0'
-                    $getPathValueWithRemovedPathsResult | Should Be 'path1;path2;path3;path4'
+                    $getPathValueWithRemovedPathsResult | Should -Be 'path1;path2;path3;path4'
                 }
             }
         }
@@ -2266,7 +2266,7 @@ try
                             really really really long name that will not be accepted by the machine. `
                             really really really long name that will not be accepted by the machine.' `
                             -Target @('Machine')
-                    } | Should Throw $script:localizedData.ArgumentTooLong
+                    } | Should -Throw $script:localizedData.ArgumentTooLong
                 }
 
 
@@ -2275,14 +2275,14 @@ try
                     $invalidName = 'invalidName'
                     {
                         Set-EnvironmentVariable -Name $invalidName -Target @('Machine')
-                    } | Should Throw ($script:localizedData.RemoveNonExistentVarError -f $invalidName)
+                    } | Should -Throw ($script:localizedData.RemoveNonExistentVarError -f $invalidName)
                 }
 
                 It 'Should throw exception when environment variable cannot be found to set' {
                     $invalidName = 'invalidName'
                     {
                         Set-EnvironmentVariable -Name $invalidName -Value 'testValue' -Target @('Machine')
-                    } | Should Throw ($script:localizedData.GetItemPropertyFailure -f $invalidName, $script:envVarRegPathMachine)
+                    } | Should -Throw ($script:localizedData.GetItemPropertyFailure -f $invalidName, $script:envVarRegPathMachine)
                 }
 
                 It 'Should set the environment variable if a value is passed in' {
@@ -2309,7 +2309,7 @@ try
                     $value = 'mockValue'
                     {
                         Set-EnvironmentVariable -Name $name -Value $value -Target @('Process')
-                    } | Should Throw $errorRecord
+                    } | Should -Throw $errorRecord
                 }
             }
         }
@@ -2322,21 +2322,21 @@ try
                     $testPathInPathListWithCriteriaResult = Test-PathsInValue -ExistingPaths $existingPaths `
                                                                                             -QueryPaths 'path3' `
                                                                                             -FindCriteria 'Any'
-                    $testPathInPathListWithCriteriaResult | Should Be $true
+                    $testPathInPathListWithCriteriaResult | Should -Be $true
                 }
 
                 It 'Should return true when one of many paths is contained in path list' {
                     $testPathInPathListWithCriteriaResult = Test-PathsInValue -ExistingPaths $existingPaths `
                                                                                             -QueryPaths 'path0;path7;path3;path8'`
                                                                                             -FindCriteria 'Any'
-                    $testPathInPathListWithCriteriaResult | Should Be $true
+                    $testPathInPathListWithCriteriaResult | Should -Be $true
                 }
 
                 It 'Should return false when no path is contained in path list' {
                     $testPathInPathListWithCriteriaResult = Test-PathsInValue -ExistingPaths $existingPaths `
                                                                                             -QueryPaths 'path0;path7;path8;path9' `
                                                                                             -FindCriteria 'Any'
-                    $testPathInPathListWithCriteriaResult | Should Be $false
+                    $testPathInPathListWithCriteriaResult | Should -Be $false
                 }
             }
 
@@ -2345,21 +2345,21 @@ try
                     $testPathInPathListWithCriteriaResult = Test-PathsInValue -ExistingPaths $existingPaths `
                                                                                             -QueryPaths 'path3' `
                                                                                             -FindCriteria 'All'
-                    $testPathInPathListWithCriteriaResult | Should Be $true
+                    $testPathInPathListWithCriteriaResult | Should -Be $true
                 }
 
                 It 'Should return false when path is not contained in path list' {
                     $testPathInPathListWithCriteriaResult = Test-PathsInValue -ExistingPaths $existingPaths `
                                                                                             -QueryPaths 'path4' `
                                                                                             -FindCriteria 'All'
-                    $testPathInPathListWithCriteriaResult | Should Be $false
+                    $testPathInPathListWithCriteriaResult | Should -Be $false
                 }
 
                 It 'Should return false when one of many paths is not contained in path list' {
                     $testPathInPathListWithCriteriaResult = Test-PathsInValue -ExistingPaths $existingPaths `
                                                                                             -QueryPaths 'path1;path2;path3;path4' `
                                                                                             -FindCriteria 'All'
-                    $testPathInPathListWithCriteriaResult | Should Be $false
+                    $testPathInPathListWithCriteriaResult | Should -Be $false
                 }
             }
         }
@@ -2369,13 +2369,13 @@ try
 
             It 'Should return the correct value when the environment variable exists' {
                 $getItemPropertyExpandedResult = Get-EnvironmentVariableWithoutExpanding -Name $script:mockEnvironmentVarName
-                $getItemPropertyExpandedResult.$script:mockEnvironmentVarName | Should Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
+                $getItemPropertyExpandedResult.$script:mockEnvironmentVarName | Should -Be $script:mockEnvironmentVar.$script:mockEnvironmentVarName
                 Assert-MockCalled -CommandName Get-KeyValue -Exactly 1 -Scope It
             }
 
             It 'Should return $null when the environment variable does not exist' {
                 $getItemPropertyExpandedResult = Get-EnvironmentVariableWithoutExpanding -Name 'non-existentEnvironmentVariableName'
-                $getItemPropertyExpandedResult | Should Be $null
+                $getItemPropertyExpandedResult | Should -Be $null
                 Assert-MockCalled -CommandName Get-KeyValue -Exactly 0 -Scope It
             }
         }

--- a/Tests/Unit/MSFT_xEnvironmentResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xEnvironmentResource.Tests.ps1
@@ -2266,7 +2266,7 @@ try
                             really really really long name that will not be accepted by the machine. `
                             really really really long name that will not be accepted by the machine.' `
                             -Target @('Machine')
-                    } | Should -Throw $script:localizedData.ArgumentTooLong
+                    } | Should -Throw -ExpectedMessage $script:localizedData.ArgumentTooLong
                 }
 
 
@@ -2309,7 +2309,7 @@ try
                     $value = 'mockValue'
                     {
                         Set-EnvironmentVariable -Name $name -Value $value -Target @('Process')
-                    } | Should -Throw $errorRecord
+                    } | Should -Throw -ExpectedMessage $errorRecord
                 }
             }
         }

--- a/Tests/Unit/MSFT_xGroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xGroupResource.Tests.ps1
@@ -122,7 +122,7 @@ try
 
                     Assert-MockCalled -CommandName 'Test-IsNanoServer'
                     Assert-MockCalled -CommandName 'Get-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    $getTargetResourceResult.TestResult | Should Be 'OnFullSKU'
+                    $getTargetResourceResult.TestResult | Should -Be 'OnFullSKU'
                 }
 
                 It 'Should call Get-TargetResourceOnNanoServer with all parameters when on Nano Server' {
@@ -132,7 +132,7 @@ try
 
                     Assert-MockCalled -CommandName 'Test-IsNanoServer'
                     Assert-MockCalled -CommandName 'Get-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    $getTargetResourceResult.TestResult | Should Be 'OnNanoServer'
+                    $getTargetResourceResult.TestResult | Should -Be 'OnNanoServer'
                 }
             }
 
@@ -199,28 +199,28 @@ try
                 {
                     It "Should throw error if name contains invalid character '$invalidCharacter'" {
                         $invalidGroupName = ('Invalid' + $invalidCharacter + 'Group')
-                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
+                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
                     }
                 }
 
                 It 'Should throw if name contains only whitespace' {
                     $invalidGroupName = '    '
-                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
+                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
                 }
 
                 It 'Should throw if name contains only dots' {
                     $invalidGroupName = '....'
-                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
+                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
                 }
 
                 It 'Should throw if name contains only whitespace and dots' {
                     $invalidGroupName = '..    ..'
-                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
+                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
                 }
 
                 It 'Should not throw if name contains whitespace and dots' {
                     $invalidGroupName = '..  MyGroup  ..'
-                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should Not Throw
+                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Not -Throw
                 }
             }
 
@@ -232,26 +232,26 @@ try
                 foreach ($localMachineScope in $localMachineScopes)
                 {
                     It "Should return true for local machine scope $localMachineScope" {
-                        Test-IsLocalMachine -Scope $localMachineScope | Should Be $true
+                        Test-IsLocalMachine -Scope $localMachineScope | Should -Be $true
                     }
                 }
 
                 $customLocalIPAddress = '123.4.5.6'
 
                 It 'Should return false if custom local IP address provided and Get-CimInstance returns null' {
-                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should Be $false
+                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
                 }
 
                 It 'Should return true if custom local IP address provided and Get-CimInstance contains matching IP address' {
                     Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @($customLocalIPAddress, '789.1.2.3')} }
 
-                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should Be $true
+                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $true
                 }
 
                 It 'Should return false if custom local IP address provided and Get-CimInstance do not contain matching IP addresses' {
                     Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @('789.1.2.3')} }
 
-                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should Be $false
+                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
                 }
             }
 
@@ -264,7 +264,7 @@ try
 
                     Assert-MockCalled -CommandName 'Test-IsLocalMachine'
 
-                    $splitMemberNameResult | Should Be @( $script:localDomain, 'username' )
+                    $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
                 }
 
                 Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
@@ -275,35 +275,35 @@ try
 
                     Assert-MockCalled -CommandName 'Test-IsLocalMachine'
 
-                    $splitMemberNameResult | Should Be @( 'domain', 'username' )
+                    $splitMemberNameResult | Should -Be @( 'domain', 'username' )
                 }
 
                 It 'Should split a member name in the username@domain format' {
                     $testMemberName = 'username@domain'
                     $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
-                    $splitMemberNameResult | Should Be @( 'domain', 'username' )
+                    $splitMemberNameResult | Should -Be @( 'domain', 'username' )
                 }
 
                 It 'Should split a member name in the CN=username,DC=domain format with local domain' {
                     $testMemberName = 'CN=username,DC=domain'
                     $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
-                    $splitMemberNameResult | Should Be @( $script:localDomain, $testMemberName )
+                    $splitMemberNameResult | Should -Be @( $script:localDomain, $testMemberName )
                 }
 
                 It 'Should split a member name in the CN=username,DC=domain format with outisde domain' {
                     $testMemberName = 'CN=username,DC=domain,DC=com'
                     $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
-                    $splitMemberNameResult | Should Be @( 'domain', $testMemberName )
+                    $splitMemberNameResult | Should -Be @( 'domain', $testMemberName )
                 }
 
                 It 'Should split a member name in the local username format' {
                     $testMemberName = 'username'
                     $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
-                    $splitMemberNameResult | Should Be @( $script:localDomain, 'username' )
+                    $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
                 }
             }
 
@@ -321,16 +321,16 @@ try
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
 
-                        $getTargetResourceResult -is [Hashtable] | Should Be $true
-                        $getTargetResourceResult.Keys.Count | Should Be 2
-                        $getTargetResourceResult.GroupName | Should Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should Be 'Absent'
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 2
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
                     }
 
                     It 'Should throw an error when Get-LocalGroup throws an exception other than GroupNotFound' {
                         Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
-                        { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should Throw $script:testErrorMessage
+                        { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should -Throw $script:testErrorMessage
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
@@ -345,12 +345,12 @@ try
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
 
-                        $getTargetResourceResult -is [Hashtable] | Should Be $true
-                        $getTargetResourceResult.Keys.Count | Should Be 4
-                        $getTargetResourceResult.GroupName | Should Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should Be 'Present'
-                        $getTargetResourceResult.Description | Should Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should Be $null
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $null
                     }
 
                     It 'Should return correct hashtable values when Get-LocalGroup returns a valid, existing group with members' {
@@ -364,12 +364,12 @@ try
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
 
-                        $getTargetResourceResult -is [Hashtable] | Should Be $true
-                        $getTargetResourceResult.Keys.Count | Should Be 4
-                        $getTargetResourceResult.GroupName | Should Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should Be 'Present'
-                        $getTargetResourceResult.Description | Should Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should Be $testMembers
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $testMembers
                     }
                 }
 
@@ -453,7 +453,7 @@ try
                     Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
                     It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should Throw $script:testErrorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
                     }
 
                     Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
@@ -571,7 +571,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -580,7 +580,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -589,7 +589,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should not modify group if member specified by MembersToInclude is already in group' {
@@ -667,13 +667,13 @@ try
                     Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { }
 
                     It 'Should return true for an absent group when Ensure is Absent' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should Be $true
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
 
                     It 'Should return false for an absent group when Ensure is Present' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
@@ -681,19 +681,19 @@ try
                     Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
                     It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should Throw $script:testErrorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
                     }
 
                     Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
 
                     It 'Should return true for an existing group when Ensure is Present' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
 
                     It 'Should return false for an existing group when Ensure is Absent' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should Be $false
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
@@ -701,7 +701,7 @@ try
                     It 'Should return true for an existing group with a matching description' {
                         $script:testLocalGroup.Description = $script:testGroupDescription
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
@@ -709,7 +709,7 @@ try
                     It 'Should return false for an existing  group with a mismatching description' {
                         $script:testLocalGroup.Description = $script:testGroupDescription
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
@@ -717,7 +717,7 @@ try
                     It 'Should return true with matching empty members when using Members' {
                         $testMembers = @( )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -726,7 +726,7 @@ try
                     It 'Should return false with mismatching number of members when using Members' {
                         $testMembers = @( $script:testMemberName1 )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -735,7 +735,7 @@ try
                     It 'Should return false with missing member when using MembersToInclude' {
                         $testMembers = @( $script:testMemberName1 )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -744,7 +744,7 @@ try
                     It 'Should return true with missing member when using MembersToExclude' {
                         $testMembers = @( $script:testMemberName1 )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -755,7 +755,7 @@ try
                     It 'Should return false when group contains member specified by MemberstoExclude' {
                         $testMembers = @( $script:testMemberName1 )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -764,7 +764,7 @@ try
                     It 'Should return true when group contains member specified by MembersToInclude' {
                         $testMembers = @( $script:testMemberName1 )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -773,7 +773,7 @@ try
                     It 'Should return true when group members match Members' {
                         $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -782,7 +782,7 @@ try
                     It 'Should return false when group members do not match Members' {
                         $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
@@ -794,7 +794,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -803,7 +803,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -812,7 +812,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
                 }
 
@@ -820,7 +820,7 @@ try
                     Mock -CommandName 'Get-LocalGroupMember' -MockWith { }
 
                     It 'Should return nothing if group does not have members' {
-                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should Be $null
+                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be $null
 
                         Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
@@ -838,7 +838,7 @@ try
                     Mock -CommandName 'Get-LocalGroupMember' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
 
                     It 'Should return all local members and ignore non-local members' {
-                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should Be @( $testDomainUser2.Name )
+                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be @( $testDomainUser2.Name )
 
                         Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
@@ -859,10 +859,10 @@ try
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'Remove-DisposableObject'
 
-                        $getTargetResourceResult -is [Hashtable] | Should Be $true
-                        $getTargetResourceResult.Keys.Count | Should Be 2
-                        $getTargetResourceResult.GroupName | Should Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should Be 'Absent'
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 2
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
                     }
 
                     It 'Should return correct hashtable values when Get-Group returns a valid, existing group without members' {
@@ -876,12 +876,12 @@ try
                         Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
                         Assert-MockCalled -CommandName 'Remove-DisposableObject'
 
-                        $getTargetResourceResult -is [Hashtable] | Should Be $true
-                        $getTargetResourceResult.Keys.Count | Should Be 4
-                        $getTargetResourceResult.GroupName | Should Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should Be 'Present'
-                        $getTargetResourceResult.Description | Should Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should Be $null
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $null
                     }
 
                     It 'Should return correct hashtable values when Get-Group returns a valid, existing group with members' {
@@ -896,12 +896,12 @@ try
                         Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
                         Assert-MockCalled -CommandName 'Remove-DisposableObject'
 
-                        $getTargetResourceResult -is [Hashtable] | Should Be $true
-                        $getTargetResourceResult.Keys.Count | Should Be 4
-                        $getTargetResourceResult.GroupName | Should Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should Be 'Present'
-                        $getTargetResourceResult.Description | Should Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should Be $testMembers
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $testMembers
                     }
                 }
 
@@ -1188,7 +1188,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -1197,7 +1197,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -1206,7 +1206,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
 
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should not modify group if member specified by MembersToInclude is already in group' {
@@ -1378,7 +1378,7 @@ try
                     Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
 
                     It 'Should return true for an absent group when Ensure is Absent' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
@@ -1386,7 +1386,7 @@ try
                     }
 
                     It 'Should return false for an absent group when Ensure is Present' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1396,7 +1396,7 @@ try
                     Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
 
                     It 'Should return true for an existing group when Ensure is Present' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1404,7 +1404,7 @@ try
                     }
 
                     It 'Should return false for an existing group when Ensure is Absent' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should Be $false
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
@@ -1414,7 +1414,7 @@ try
                     It 'Should return true for an existing group with a matching description' {
                         $script:testGroup.Description = $script:testGroupDescription
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1424,7 +1424,7 @@ try
                     It 'Should return false for an existing  group with a mismatching description' {
                         $script:testGroup.Description = $script:testGroupDescription
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1434,7 +1434,7 @@ try
                     It 'Should return true with matching empty members when using Members' {
                         $testMembers = @( )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1445,7 +1445,7 @@ try
                     It 'Should return false with mismatching number of members when using Members' {
                         $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1456,7 +1456,7 @@ try
                     It 'Should return false with missing member when using MembersToInclude' {
                         $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1467,7 +1467,7 @@ try
                     It 'Should return true with missing member when using MembersToExclude' {
                         $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1480,7 +1480,7 @@ try
                     It 'Should return false when group contains member specified by MemberstoExclude' {
                         $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1491,7 +1491,7 @@ try
                     It 'Should return true when group contains member specified by MembersToInclude' {
                         $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1502,7 +1502,7 @@ try
                     It 'Should return true when group members match Members' {
                         $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1513,7 +1513,7 @@ try
                     It 'Should return false when group members do not match Members' {
                         $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal3 )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should Be $false
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
 
                         Assert-MockCalled -CommandName 'Get-PrincipalContext'
                         Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
@@ -1545,7 +1545,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -1554,7 +1554,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -1563,7 +1563,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should Throw $errorMessage
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
                     }
                 }
 
@@ -1574,7 +1574,7 @@ try
                     Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
 
                     It 'Should return nothing if group does not have members' {
-                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should Be $null
+                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
 
                         Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
@@ -1582,7 +1582,7 @@ try
                     Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
                     It 'Should return principal names for members without domains' {
-                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should Be @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
 
                         Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
@@ -1619,7 +1619,7 @@ try
 
                         $getMembersResult = Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        (Compare-Object -ReferenceObject $expectedGetMembersResult -DifferenceObject $getMembersResult) | Should Be $null
+                        (Compare-Object -ReferenceObject $expectedGetMembersResult -DifferenceObject $getMembersResult) | Should -Be $null
 
                         Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
@@ -1645,7 +1645,7 @@ try
                     Mock -CommandName 'Resolve-SidToPrincipal' -MockWith { return 'FakeSidValue' }
 
                     It 'Should return empty list when there are no group members' {
-                        Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should Be $null
+                        Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
                         Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
 
@@ -1675,7 +1675,7 @@ try
 
                     It 'Should ignore stale members' {
                         $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables -WarningAction 'SilentlyContinue'
-                        $getMembersResult | Should Be $null
+                        $getMembersResult | Should -Be $null
 
                         Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' }
@@ -1685,7 +1685,7 @@ try
 
                     It 'Should return current members' {
                         $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $getMembersResult.Count | Should Be 2
+                        $getMembersResult.Count | Should -Be 2
 
                         Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
@@ -1703,7 +1703,7 @@ try
 
                     It 'Should return current members with custom domain when prinicpal can be found' {
                         $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $getMembersResult.Count | Should Be 2
+                        $getMembersResult.Count | Should -Be 2
 
                         Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
@@ -1729,7 +1729,7 @@ try
                     It 'Should throw when prinicpal context for custom domain cannot be found' {
                         $errorMessage = ($script:localizedData.DomainCredentialsRequired -f 'accountname')
 
-                        { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should Throw $errorMessage
+                        { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should -Throw $errorMessage
                     }
                 }
 
@@ -1762,7 +1762,7 @@ try
                         $memberNames = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
 
                         $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $uniquePrincipalsList | Should Be @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
+                        $uniquePrincipalsList | Should -Be @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
 
                         foreach ($passedInMemberName in $memberNames)
                         {
@@ -1774,7 +1774,7 @@ try
                         $memberNames = @( $testDomainUser1.Name, $testDomainUser1.Name )
 
                         $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $uniquePrincipalsList | Should Be @( $testDomainUser1 )
+                        $uniquePrincipalsList | Should -Be @( $testDomainUser1 )
 
                         foreach ($passedInMemberName in $memberNames)
                         {
@@ -1811,7 +1811,7 @@ try
                             -PrincipalContextCache $principalContextCache `
                             -Disposables $disposables
 
-                        $convertToPrincipalResult | Should Be $script:testUserPrincipal1
+                        $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
 
                         Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
                         Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
@@ -1827,7 +1827,7 @@ try
                             -PrincipalContextCache $principalContextCache `
                             -Disposables $disposables
 
-                        $convertToPrincipalResult | Should Be $script:testUserPrincipal1
+                        $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
 
                         Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
                         Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
@@ -1849,7 +1849,7 @@ try
                         { $convertToPrincipalResult = ConvertTo-Principal `
                             -MemberName $script:testUserPrincipal1.Name `
                             -PrincipalContextCache $principalContextCache `
-                            -Disposables $disposables } | Should Throw $errorMessage
+                            -Disposables $disposables } | Should -Throw $errorMessage
                     }
                 }
 
@@ -1863,7 +1863,7 @@ try
                     $sidIdentityType = [System.DirectoryServices.AccountManagement.IdentityType]::Sid
 
                     It 'Should throw when principal not found and scope is local' {
-                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain } | Should Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
+                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
 
                         Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
                         Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
@@ -1874,7 +1874,7 @@ try
                     It 'Should throw when principal not found and scope is custom' {
                         $customDomain = 'CustomDomain'
 
-                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $customDomain } | Should Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
+                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $customDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
 
                         Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
                         Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
@@ -1884,7 +1884,7 @@ try
                     Mock -CommandName 'Find-Principal' -MockWith { return $fakePrincipal }
 
                     It 'Should return found principal' {
-                        Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain | Should Be $fakePrincipal
+                        Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain | Should -Be $fakePrincipal
                         Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
                     }
                 }
@@ -1909,9 +1909,9 @@ try
                         Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $localScope }
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and $ArgumentList.Contains($localMachineContext) }
 
-                        $principalContextCache.ContainsKey($localScope) | Should Be $false
-                        $principalContextCache.$script:localDomain | Should Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should Be $true
+                        $principalContextCache.ContainsKey($localScope) | Should -Be $false
+                        $principalContextCache.$script:localDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
 
                     It 'Should return the local principal context from the cache' {
@@ -1923,8 +1923,8 @@ try
                         Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
 
-                        $principalContextCache.$script:localDomain | Should Not Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should Be $false
+                        $principalContextCache.$script:localDomain | Should -Not -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $false
                     }
 
                     Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
@@ -1944,8 +1944,8 @@ try
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
                             (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                        $principalContextCache.$customDomain | Should Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should Be $true
+                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
 
                     It 'Should create a new custom principal context with a Credential without a domain' {
@@ -1963,8 +1963,8 @@ try
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
                             (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                        $principalContextCache.$customDomain | Should Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should Be $true
+                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
 
                     It 'Should create a new custom principal context with a Credential with a domain' {
@@ -1988,8 +1988,8 @@ try
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
                             (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                        $principalContextCache.$customDomain | Should Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should Be $true
+                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
 
                     It 'Should return a custom principal context from the cache' {
@@ -2003,8 +2003,8 @@ try
                         Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
                         Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
 
-                        $principalContextCache.$customDomain | Should Not Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should Be $false
+                        $principalContextCache.$customDomain | Should -Not -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $false
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xGroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xGroupResource.Tests.ps1
@@ -330,7 +330,7 @@ try
                     It 'Should throw an error when Get-LocalGroup throws an exception other than GroupNotFound' {
                         Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
-                        { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should -Throw $script:testErrorMessage
+                        { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should -Throw -ExpectedMessage $script:testErrorMessage
 
                         Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
@@ -453,7 +453,7 @@ try
                     Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
                     It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw -ExpectedMessage $script:testErrorMessage
                     }
 
                     Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
@@ -571,7 +571,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -580,7 +580,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -589,7 +589,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should not modify group if member specified by MembersToInclude is already in group' {
@@ -681,7 +681,7 @@ try
                     Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
                     It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw -ExpectedMessage $script:testErrorMessage
                     }
 
                     Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
@@ -794,7 +794,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -803,7 +803,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -812,7 +812,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
 
@@ -1188,7 +1188,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -1197,7 +1197,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -1206,7 +1206,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
 
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should not modify group if member specified by MembersToInclude is already in group' {
@@ -1545,7 +1545,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if Members and MembersToExclude are both specified' {
@@ -1554,7 +1554,7 @@ try
 
                         $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
 
                     It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
@@ -1563,7 +1563,7 @@ try
 
                         $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
 
@@ -1729,7 +1729,7 @@ try
                     It 'Should throw when prinicpal context for custom domain cannot be found' {
                         $errorMessage = ($script:localizedData.DomainCredentialsRequired -f 'accountname')
 
-                        { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should -Throw $errorMessage
+                        { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
 
@@ -1849,7 +1849,7 @@ try
                         { $convertToPrincipalResult = ConvertTo-Principal `
                             -MemberName $script:testUserPrincipal1.Name `
                             -PrincipalContextCache $principalContextCache `
-                            -Disposables $disposables } | Should -Throw $errorMessage
+                            -Disposables $disposables } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
 

--- a/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
@@ -472,7 +472,7 @@ Describe 'xMsiPackage Unit Tests' {
         Describe 'Assert-PathExtensionValid' {
             Context 'Path is a valid .msi path' {
                 It 'Should not throw' {
-                    { Assert-PathExtensionValid -Path 'testMsiFile.msi' } | Should Not Throw
+                    { Assert-PathExtensionValid -Path 'testMsiFile.msi' } | Should -Not -Throw
                 }
             }
 
@@ -481,14 +481,14 @@ Describe 'xMsiPackage Unit Tests' {
                     $invalidPath = 'testMsiFile.exe'
                     $expectedErrorMessage = ($script:localizedData.InvalidBinaryType -f $invalidPath)
 
-                    { Assert-PathExtensionValid -Path $invalidPath } | Should Throw $expectedErrorMessage
+                    { Assert-PathExtensionValid -Path $invalidPath } | Should -Throw $expectedErrorMessage
                 }
 
                 It 'Should throw an invalid argument exception when an invalid file type is passed in' {
                     $invalidPath = 'testMsiFilemsi'
                     $expectedErrorMessage = ($script:localizedData.InvalidBinaryType -f $invalidPath)
 
-                    { Assert-PathExtensionValid -Path $invalidPath } | Should Throw $expectedErrorMessage
+                    { Assert-PathExtensionValid -Path $invalidPath } | Should -Throw $expectedErrorMessage
                 }
             }
         }
@@ -499,21 +499,21 @@ Describe 'xMsiPackage Unit Tests' {
                     $filePath = (Join-Path -Path $PSScriptRoot -ChildPath 'testMsi.msi')
                     $expectedReturnValue = [Uri] $filePath
 
-                    Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
+                    Convert-PathToUri -Path $filePath | Should -Be $expectedReturnValue
                 }
 
                 It 'Should return the expected URI when scheme is http' {
                     $filePath = 'http://localhost:1242/testMsi.msi'
                     $expectedReturnValue = [Uri] $filePath
 
-                    Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
+                    Convert-PathToUri -Path $filePath | Should -Be $expectedReturnValue
                 }
 
                 It 'Should return the expected URI when scheme is https' {
                     $filePath = 'https://localhost:1243/testMsi.msi'
                     $expectedReturnValue = [Uri] $filePath
 
-                    Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
+                    Convert-PathToUri -Path $filePath | Should -Be $expectedReturnValue
                 }
             }
 
@@ -522,14 +522,14 @@ Describe 'xMsiPackage Unit Tests' {
                     $filePath = 'ht://localhost:1243/testMsi.msi'
                     $expectedErrorMessage = ($script:localizedData.InvalidPath -f $filePath)
 
-                    { Convert-PathToUri -Path $filePath } | Should Throw $expectedErrorMessage
+                    { Convert-PathToUri -Path $filePath } | Should -Throw $expectedErrorMessage
                 }
 
                 It 'Should throw an error when path is not in valid format' {
                     $filePath = 'mri'
                     $expectedErrorMessage = ($script:localizedData.InvalidPath -f $filePath)
 
-                    { Convert-PathToUri -Path $filePath } | Should Throw $expectedErrorMessage
+                    { Convert-PathToUri -Path $filePath } | Should -Throw $expectedErrorMessage
                 }
             }
         }
@@ -537,18 +537,18 @@ Describe 'xMsiPackage Unit Tests' {
         Describe 'Convert-ProductIdToIdentifyingNumber' {
             Context 'Valid Product ID is passed in' {
                 It 'Should return the same value that is passed in when the Product ID is already in the correct format' {
-                    Convert-ProductIdToIdentifyingNumber -ProductId $script:testIdentifyingNumber | Should Be $script:testIdentifyingNumber
+                    Convert-ProductIdToIdentifyingNumber -ProductId $script:testIdentifyingNumber | Should -Be $script:testIdentifyingNumber
                 }
 
                 It 'Should convert a valid poduct ID to the identifying number format' {
-                    Convert-ProductIdToIdentifyingNumber -ProductId $script:testProductId | Should Be $script:testIdentifyingNumber
+                    Convert-ProductIdToIdentifyingNumber -ProductId $script:testProductId | Should -Be $script:testIdentifyingNumber
                 }
             }
 
             Context 'Invalid Product ID is passed in' {
                 It 'Should throw an exception when an invalid product ID is passed in' {
                     $expectedErrorMessage = ($script:localizedData.InvalidIdentifyingNumber -f $script:testWrongProductId)
-                    { Convert-ProductIdToIdentifyingNumber -ProductId $script:testWrongProductId } | Should Throw $expectedErrorMessage
+                    { Convert-ProductIdToIdentifyingNumber -ProductId $script:testWrongProductId } | Should -Throw $expectedErrorMessage
                 }
             }
         }
@@ -562,7 +562,7 @@ Describe 'xMsiPackage Unit Tests' {
 
             Context 'Product entry is found in the expected location' {
                 It 'Should return the expected product entry' {
-                    Get-ProductEntry -IdentifyingNumber $script:testIdentifyingNumber | Should Be $script:mockProductEntry
+                    Get-ProductEntry -IdentifyingNumber $script:testIdentifyingNumber | Should -Be $script:mockProductEntry
                 }
 
                 It 'Should retrieve the item' {
@@ -574,7 +574,7 @@ Describe 'xMsiPackage Unit Tests' {
 
             Context 'Product entry is found under Wow6432Node' {
                 It 'Should return the expected product entry' {
-                    Get-ProductEntry -IdentifyingNumber $script:testIdentifyingNumber | Should Be $script:mockProductEntry
+                    Get-ProductEntry -IdentifyingNumber $script:testIdentifyingNumber | Should -Be $script:mockProductEntry
                 }
 
                 It 'Should attempt to retrieve the item twice' {
@@ -586,7 +586,7 @@ Describe 'xMsiPackage Unit Tests' {
 
             Context 'Product entry is not found' {
                 It 'Should return $null' {
-                    Get-ProductEntry -IdentifyingNumber $script:testIdentifyingNumber | Should Be $null
+                    Get-ProductEntry -IdentifyingNumber $script:testIdentifyingNumber | Should -Be $null
                 }
 
                 It 'Should attempt to retrieve the item twice' {
@@ -609,31 +609,31 @@ Describe 'xMsiPackage Unit Tests' {
                 $getProductEntryInfoResult = Get-ProductEntryInfo -ProductEntry $script:mockProductEntry
 
                 It 'Should return the expected installed date' {
-                     $getProductEntryInfoResult.InstalledOn | Should Be $script:mockProductEntryInfo.InstalledOn
+                     $getProductEntryInfoResult.InstalledOn | Should -Be $script:mockProductEntryInfo.InstalledOn
                 }
 
                 It 'Should return the expected publisher' {
-                     $getProductEntryInfoResult.Publisher | Should Be $script:mockProductEntryInfo.Publisher
+                     $getProductEntryInfoResult.Publisher | Should -Be $script:mockProductEntryInfo.Publisher
                 }
 
                 It 'Should return the expected size' {
-                     $getProductEntryInfoResult.Size | Should Be ($script:mockProductEntryInfo.Size / 1024)
+                     $getProductEntryInfoResult.Size | Should -Be ($script:mockProductEntryInfo.Size / 1024)
                 }
 
                 It 'Should return the expected Version' {
-                     $getProductEntryInfoResult.Version | Should Be $script:mockProductEntryInfo.Version
+                     $getProductEntryInfoResult.Version | Should -Be $script:mockProductEntryInfo.Version
                 }
 
                 It 'Should return the expected package description' {
-                     $getProductEntryInfoResult.PackageDescription | Should Be $script:mockProductEntryInfo.PackageDescription
+                     $getProductEntryInfoResult.PackageDescription | Should -Be $script:mockProductEntryInfo.PackageDescription
                 }
 
                 It 'Should return the expected name' {
-                     $getProductEntryInfoResult.Name | Should Be $script:mockProductEntryInfo.Name
+                     $getProductEntryInfoResult.Name | Should -Be $script:mockProductEntryInfo.Name
                 }
 
                 It 'Should return the expected install source' {
-                     $getProductEntryInfoResult.InstallSource | Should Be $script:mockProductEntryInfo.InstallSource
+                     $getProductEntryInfoResult.InstallSource | Should -Be $script:mockProductEntryInfo.InstallSource
                 }
 
                 It 'Should retrieve 7 product entry values' {
@@ -648,7 +648,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $getProductEntryInfoResult = Get-ProductEntryInfo -ProductEntry $script:mockProductEntry
 
                 It 'Should return $null for InstalledOn' {
-                    $getProductEntryInfoResult.InstalledOn | Should Be $null
+                    $getProductEntryInfoResult.InstalledOn | Should -Be $null
                 }
             }
         }
@@ -710,7 +710,7 @@ Describe 'xMsiPackage Unit Tests' {
                 )
 
                 It 'Should return the expected response stream' {
-                    Get-WebRequestResponse -Uri $script:testUriHttp | Should Be $script:mockStream
+                    Get-WebRequestResponse -Uri $script:testUriHttp | Should -Be $script:mockStream
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -724,7 +724,7 @@ Describe 'xMsiPackage Unit Tests' {
                 )
 
                 It 'Should return the expected response stream' {
-                    Get-WebRequestResponse -Uri $script:testUriHttps | Should Be $script:mockStream
+                    Get-WebRequestResponse -Uri $script:testUriHttps | Should -Be $script:mockStream
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -738,7 +738,7 @@ Describe 'xMsiPackage Unit Tests' {
                 )
 
                 It 'Should return the expected response stream' {
-                    Get-WebRequestResponse -Uri $script:testUriHttps -ServerCertificateValidationCallback 'TestCallbackFunction' | Should Be $script:mockStream
+                    Get-WebRequestResponse -Uri $script:testUriHttps -ServerCertificateValidationCallback 'TestCallbackFunction' | Should -Be $script:mockStream
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -749,7 +749,7 @@ Describe 'xMsiPackage Unit Tests' {
             Context 'Error occurred during while retrieving the response' {
                 It 'Should throw the expected exception' {
                     $expectedErrorMessage = ($script:localizedData.CouldNotGetResponseFromWebRequest -f $script:testUriHttp.Scheme, $script:testUriHttp.OriginalString)
-                    { Get-WebRequestResponse -Uri $script:testUriHttp } | Should Throw $expectedErrorMessage
+                    { Get-WebRequestResponse -Uri $script:testUriHttp } | Should -Throw $expectedErrorMessage
                 }
             }
         }
@@ -765,7 +765,7 @@ Describe 'xMsiPackage Unit Tests' {
                 )
 
                 It 'Should not throw' {
-                    { Assert-FileValid -Path $script:testPath -FileHash 'mockFileHash' } | Should Not Throw
+                    { Assert-FileValid -Path $script:testPath -FileHash 'mockFileHash' } | Should -Not -Throw
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -778,7 +778,7 @@ Describe 'xMsiPackage Unit Tests' {
                 )
 
                 It 'Should not throw' {
-                    { Assert-FileValid -Path $script:testPath -FileHash 'mockFileHash' -SignerThumbprint 'mockSignerThumbprint' } | Should Not Throw
+                    { Assert-FileValid -Path $script:testPath -FileHash 'mockFileHash' -SignerThumbprint 'mockSignerThumbprint' } | Should -Not -Throw
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -791,7 +791,7 @@ Describe 'xMsiPackage Unit Tests' {
                 )
 
                 It 'Should not throw' {
-                    { Assert-FileValid -Path $script:testPath -SignerSubject 'mockSignerSubject' } | Should Not Throw
+                    { Assert-FileValid -Path $script:testPath -SignerSubject 'mockSignerSubject' } | Should -Not -Throw
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -807,7 +807,7 @@ Describe 'xMsiPackage Unit Tests' {
                     { Assert-FileValid -Path $script:testPath -FileHash 'mockFileHash' `
                                                               -SignerThumbprint 'mockSignerThumbprint' `
                                                               -SignerSubject 'mockSignerSubject'
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -822,7 +822,7 @@ Describe 'xMsiPackage Unit Tests' {
                 It 'Should not throw' {
                     { Assert-FileValid -Path $script:testPath -SignerThumbprint 'mockSignerThumbprint' `
                                                               -SignerSubject 'mockSignerSubject'
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -835,7 +835,7 @@ Describe 'xMsiPackage Unit Tests' {
                 )
 
                 It 'Should not throw' {
-                    { Assert-FileValid -Path $script:testPath } | Should Not Throw
+                    { Assert-FileValid -Path $script:testPath } | Should -Not -Throw
                 }
 
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
@@ -848,7 +848,7 @@ Describe 'xMsiPackage Unit Tests' {
 
             Context 'File hash is valid' {
                 It 'Should not throw when hashes match' {
-                    { Assert-FileHashValid -Path $script:testPath -Hash $mockHash.Hash -Algorithm 'SHA256' } | Should Not Throw
+                    { Assert-FileHashValid -Path $script:testPath -Hash $mockHash.Hash -Algorithm 'SHA256' } | Should -Not -Throw
                 }
 
                 It 'Should fetch the file hash' {
@@ -861,7 +861,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.InvalidFileHash -f $script:testPath, $badHash, 'SHA256')
 
                 It 'Should throw when hashes do not match' {
-                    { Assert-FileHashValid -Path $script:testPath -Hash $badHash -Algorithm 'SHA256' } | Should Throw $expectedErrorMessage
+                    { Assert-FileHashValid -Path $script:testPath -Hash $badHash -Algorithm 'SHA256' } | Should -Throw $expectedErrorMessage
                 }
             }
         }
@@ -878,25 +878,25 @@ Describe 'xMsiPackage Unit Tests' {
 
             Context 'File signature status, thumbprint and subject are valid' {
                 It 'Should not throw' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $mockSubject } | Should Not Throw
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $mockSubject } | Should -Not -Throw
                 }
             }
 
             Context 'File signature status and thumbprint are valid and Subject not passed in' {
                 It 'Should not throw' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint } | Should Not Throw
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint } | Should -Not -Throw
                 }
             }
 
             Context 'File signature status and subject are valid and Thumbprint not passed in' {
                 It 'Should not throw' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Subject $mockSubject } | Should Not Throw
+                    { Assert-FileSignatureValid -Path $script:testPath -Subject $mockSubject } | Should -Not -Throw
                 }
             }
 
             Context 'Only Path is passed in' {
                 It 'Should not throw' {
-                    { Assert-FileSignatureValid -Path $script:testPath } | Should Not Throw
+                    { Assert-FileSignatureValid -Path $script:testPath } | Should -Not -Throw
                 }
             }
 
@@ -905,7 +905,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.WrongSignerSubject -f $script:testPath, $badSubject)
 
                 It 'Should throw expected error message' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $badSubject } | Should Throw $expectedErrorMessage
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $badSubject } | Should -Throw $expectedErrorMessage
                 }
             }
 
@@ -914,7 +914,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.WrongSignerThumbprint -f $script:testPath, $badThumbprint)
 
                 It 'Should throw expected error message' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $badThumbprint -Subject $mockSubject } | Should Throw $expectedErrorMessage
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $badThumbprint -Subject $mockSubject } | Should -Throw $expectedErrorMessage
                 }
             }
 
@@ -923,7 +923,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.InvalidFileSignature -f $script:testPath, $mockSignature.Status)
 
                 It 'Should throw expected error message' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $mockSubject } | Should Throw $expectedErrorMessage
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $mockSubject } | Should -Throw $expectedErrorMessage
                 }
             }
         }

--- a/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
@@ -481,14 +481,14 @@ Describe 'xMsiPackage Unit Tests' {
                     $invalidPath = 'testMsiFile.exe'
                     $expectedErrorMessage = ($script:localizedData.InvalidBinaryType -f $invalidPath)
 
-                    { Assert-PathExtensionValid -Path $invalidPath } | Should -Throw $expectedErrorMessage
+                    { Assert-PathExtensionValid -Path $invalidPath } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
 
                 It 'Should throw an invalid argument exception when an invalid file type is passed in' {
                     $invalidPath = 'testMsiFilemsi'
                     $expectedErrorMessage = ($script:localizedData.InvalidBinaryType -f $invalidPath)
 
-                    { Assert-PathExtensionValid -Path $invalidPath } | Should -Throw $expectedErrorMessage
+                    { Assert-PathExtensionValid -Path $invalidPath } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -522,14 +522,14 @@ Describe 'xMsiPackage Unit Tests' {
                     $filePath = 'ht://localhost:1243/testMsi.msi'
                     $expectedErrorMessage = ($script:localizedData.InvalidPath -f $filePath)
 
-                    { Convert-PathToUri -Path $filePath } | Should -Throw $expectedErrorMessage
+                    { Convert-PathToUri -Path $filePath } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
 
                 It 'Should throw an error when path is not in valid format' {
                     $filePath = 'mri'
                     $expectedErrorMessage = ($script:localizedData.InvalidPath -f $filePath)
 
-                    { Convert-PathToUri -Path $filePath } | Should -Throw $expectedErrorMessage
+                    { Convert-PathToUri -Path $filePath } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -548,7 +548,7 @@ Describe 'xMsiPackage Unit Tests' {
             Context 'Invalid Product ID is passed in' {
                 It 'Should throw an exception when an invalid product ID is passed in' {
                     $expectedErrorMessage = ($script:localizedData.InvalidIdentifyingNumber -f $script:testWrongProductId)
-                    { Convert-ProductIdToIdentifyingNumber -ProductId $script:testWrongProductId } | Should -Throw $expectedErrorMessage
+                    { Convert-ProductIdToIdentifyingNumber -ProductId $script:testWrongProductId } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -749,7 +749,7 @@ Describe 'xMsiPackage Unit Tests' {
             Context 'Error occurred during while retrieving the response' {
                 It 'Should throw the expected exception' {
                     $expectedErrorMessage = ($script:localizedData.CouldNotGetResponseFromWebRequest -f $script:testUriHttp.Scheme, $script:testUriHttp.OriginalString)
-                    { Get-WebRequestResponse -Uri $script:testUriHttp } | Should -Throw $expectedErrorMessage
+                    { Get-WebRequestResponse -Uri $script:testUriHttp } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -861,7 +861,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.InvalidFileHash -f $script:testPath, $badHash, 'SHA256')
 
                 It 'Should throw when hashes do not match' {
-                    { Assert-FileHashValid -Path $script:testPath -Hash $badHash -Algorithm 'SHA256' } | Should -Throw $expectedErrorMessage
+                    { Assert-FileHashValid -Path $script:testPath -Hash $badHash -Algorithm 'SHA256' } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }
@@ -905,7 +905,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.WrongSignerSubject -f $script:testPath, $badSubject)
 
                 It 'Should throw expected error message' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $badSubject } | Should -Throw $expectedErrorMessage
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $badSubject } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -914,7 +914,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.WrongSignerThumbprint -f $script:testPath, $badThumbprint)
 
                 It 'Should throw expected error message' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $badThumbprint -Subject $mockSubject } | Should -Throw $expectedErrorMessage
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $badThumbprint -Subject $mockSubject } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -923,7 +923,7 @@ Describe 'xMsiPackage Unit Tests' {
                 $expectedErrorMessage = ($script:localizedData.InvalidFileSignature -f $script:testPath, $mockSignature.Status)
 
                 It 'Should throw expected error message' {
-                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $mockSubject } | Should -Throw $expectedErrorMessage
+                    { Assert-FileSignatureValid -Path $script:testPath -Thumbprint $mockThumbprint -Subject $mockSubject } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
         }

--- a/Tests/Unit/MSFT_xPackageResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xPackageResource.Tests.ps1
@@ -179,7 +179,7 @@ try
                         -ProductId $script:packageId `
                         -Name ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Present' `
@@ -187,7 +187,7 @@ try
                         -Name $script:packageName `
                         -ProductId ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Absent' `
@@ -195,7 +195,7 @@ try
                         -ProductId $script:packageId `
                         -Name ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Absent' `
@@ -203,7 +203,7 @@ try
                         -Name $script:packageName `
                         -ProductId ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
 
                 It 'Should return correct value when package is present without registry parameters' {
@@ -211,7 +211,7 @@ try
 
                     Clear-PackageCache
 
-                    Test-PackageInstalledByName -Name $script:packageName | Should Be $true
+                    Test-PackageInstalledByName -Name $script:packageName | Should -Be $true
 
                     $testTargetResourceResult = Test-TargetResource `
                             -Ensure 'Present' `
@@ -219,7 +219,7 @@ try
                             -ProductId $script:packageId `
                             -Name ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Present' `
@@ -227,7 +227,7 @@ try
                         -Name $script:packageName `
                         -ProductId ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Absent' `
@@ -235,7 +235,7 @@ try
                         -ProductId $script:packageId `
                         -Name ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
 
                     $testTargetResourceResult = Test-TargetResource `
                         -Ensure 'Absent' `
@@ -243,7 +243,7 @@ try
                         -Name $script:packageName `
                         -ProductId ([String]::Empty)
 
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
 
                 $existingPackageParameters = @{
@@ -263,10 +263,10 @@ try
                     try
                     {
                         $testTargetResourceResult = Test-TargetResource -Ensure 'Present' @existingPackageParameters
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
 
                         $testTargetResourceResult = Test-TargetResource -Ensure 'Absent' @existingPackageParameters
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                     finally
                     {
@@ -290,10 +290,10 @@ try
                             Write-Verbose -Message "Test target resource parameters: $( Out-String -InputObject $mismatchingParameters)"
 
                             $testTargetResourceResult = Test-TargetResource -Ensure 'Present' @mismatchingParameters
-                            $testTargetResourceResult | Should Be $false
+                            $testTargetResourceResult | Should -Be $false
 
                             $testTargetResourceResult = Test-TargetResource -Ensure 'Absent' @mismatchingParameters
-                            $testTargetResourceResult | Should Be $true
+                            $testTargetResourceResult | Should -Be $true
                         }
                         finally
                         {
@@ -308,24 +308,24 @@ try
                 It 'Should correctly install and remove a .msi package without registry parameters' {
                     Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId $script:packageId -Name ([String]::Empty)
 
-                    Test-PackageInstalledByName -Name $script:packageName | Should Be $true
+                    Test-PackageInstalledByName -Name $script:packageName | Should -Be $true
 
                     $getTargetResourceResult = Get-TargetResource -Path $script:msiLocation -ProductId $script:packageId -Name ([String]::Empty)
 
-                    $getTargetResourceResult.Version | Should Be '1.2.3.4'
-                    $getTargetResourceResult.InstalledOn | Should Be ('{0:d}' -f [DateTime]::Now.Date)
-                    $getTargetResourceResult.Installed | Should Be $true
-                    $getTargetResourceResult.ProductId | Should Be $script:packageId
-                    $getTargetResourceResult.Path | Should Be $script:msiLocation
+                    $getTargetResourceResult.Version | Should -Be '1.2.3.4'
+                    $getTargetResourceResult.InstalledOn | Should -Be ('{0:d}' -f [DateTime]::Now.Date)
+                    $getTargetResourceResult.Installed | Should -Be $true
+                    $getTargetResourceResult.ProductId | Should -Be $script:packageId
+                    $getTargetResourceResult.Path | Should -Be $script:msiLocation
 
                     # Can't figure out how to set this within the MSI.
-                    # $getTargetResourceResult.PackageDescription | Should Be 'A package for unit testing'
+                    # $getTargetResourceResult.PackageDescription | Should -Be 'A package for unit testing'
 
-                    [Math]::Round($getTargetResourceResult.Size, 2) | Should Be 0.03
+                    [Math]::Round($getTargetResourceResult.Size, 2) | Should -Be 0.03
 
                     Set-TargetResource -Ensure 'Absent' -Path $script:msiLocation -ProductId $script:packageId -Name ([String]::Empty)
 
-                    Test-PackageInstalledByName -Name $script:packageName | Should Be $false
+                    Test-PackageInstalledByName -Name $script:packageName | Should -Be $false
                 }
 
                 It 'Should correctly install and remove a .msi package with registry parameters' {
@@ -344,23 +344,23 @@ try
 
                     try
                     {
-                        Test-PackageInstalledByName -Name $script:packageName | Should Be $true
+                        Test-PackageInstalledByName -Name $script:packageName | Should -Be $true
 
                         $getTargetResourceResult = Get-TargetResource @packageParameters
 
-                        $getTargetResourceResult.Installed | Should Be $true
-                        $getTargetResourceResult.ProductId | Should Be $packageParameters.ProductId
-                        $getTargetResourceResult.Path | Should Be $packageParameters.Path
-                        $getTargetResourceResult.Name | Should Be $packageParameters.Name
-                        $getTargetResourceResult.CreateCheckRegValue | Should Be $packageParameters.CreateCheckRegValue
-                        $getTargetResourceResult.InstalledCheckRegHive | Should Be $packageParameters.InstalledCheckRegHive
-                        $getTargetResourceResult.InstalledCheckRegKey | Should Be $packageParameters.InstalledCheckRegKey
-                        $getTargetResourceResult.InstalledCheckRegValueName | Should Be $packageParameters.InstalledCheckRegValueName
-                        $getTargetResourceResult.InstalledCheckRegValueData | Should Be $packageParameters.InstalledCheckRegValueData
+                        $getTargetResourceResult.Installed | Should -Be $true
+                        $getTargetResourceResult.ProductId | Should -Be $packageParameters.ProductId
+                        $getTargetResourceResult.Path | Should -Be $packageParameters.Path
+                        $getTargetResourceResult.Name | Should -Be $packageParameters.Name
+                        $getTargetResourceResult.CreateCheckRegValue | Should -Be $packageParameters.CreateCheckRegValue
+                        $getTargetResourceResult.InstalledCheckRegHive | Should -Be $packageParameters.InstalledCheckRegHive
+                        $getTargetResourceResult.InstalledCheckRegKey | Should -Be $packageParameters.InstalledCheckRegKey
+                        $getTargetResourceResult.InstalledCheckRegValueName | Should -Be $packageParameters.InstalledCheckRegValueName
+                        $getTargetResourceResult.InstalledCheckRegValueData | Should -Be $packageParameters.InstalledCheckRegValueData
 
                         Set-TargetResource -Ensure 'Absent' @packageParameters
 
-                        Test-PackageInstalledByName -Name $script:packageName | Should Be $false
+                        Test-PackageInstalledByName -Name $script:packageName | Should -Be $false
                     }
                     finally
                     {
@@ -385,23 +385,23 @@ try
 
                     try
                     {
-                        Test-TargetResource -Ensure 'Present' @packageParameters | Should Be $true
+                        Test-TargetResource -Ensure 'Present' @packageParameters | Should -Be $true
 
                         $getTargetResourceResult = Get-TargetResource @packageParameters
 
-                        $getTargetResourceResult.Installed | Should Be $true
-                        $getTargetResourceResult.ProductId | Should Be $packageParameters.ProductId
-                        $getTargetResourceResult.Path | Should Be $packageParameters.Path
-                        $getTargetResourceResult.Name | Should Be $packageParameters.Name
-                        $getTargetResourceResult.CreateCheckRegValue | Should Be $packageParameters.CreateCheckRegValue
-                        $getTargetResourceResult.InstalledCheckRegHive | Should Be $packageParameters.InstalledCheckRegHive
-                        $getTargetResourceResult.InstalledCheckRegKey | Should Be $packageParameters.InstalledCheckRegKey
-                        $getTargetResourceResult.InstalledCheckRegValueName | Should Be $packageParameters.InstalledCheckRegValueName
-                        $getTargetResourceResult.InstalledCheckRegValueData | Should Be $packageParameters.InstalledCheckRegValueData
+                        $getTargetResourceResult.Installed | Should -Be $true
+                        $getTargetResourceResult.ProductId | Should -Be $packageParameters.ProductId
+                        $getTargetResourceResult.Path | Should -Be $packageParameters.Path
+                        $getTargetResourceResult.Name | Should -Be $packageParameters.Name
+                        $getTargetResourceResult.CreateCheckRegValue | Should -Be $packageParameters.CreateCheckRegValue
+                        $getTargetResourceResult.InstalledCheckRegHive | Should -Be $packageParameters.InstalledCheckRegHive
+                        $getTargetResourceResult.InstalledCheckRegKey | Should -Be $packageParameters.InstalledCheckRegKey
+                        $getTargetResourceResult.InstalledCheckRegValueName | Should -Be $packageParameters.InstalledCheckRegValueName
+                        $getTargetResourceResult.InstalledCheckRegValueData | Should -Be $packageParameters.InstalledCheckRegValueData
 
                         Set-TargetResource -Ensure 'Absent' @packageParameters
 
-                        Test-TargetResource -Ensure 'Absent' @packageParameters | Should Be $true
+                        Test-TargetResource -Ensure 'Absent' @packageParameters | Should -Be $true
                     }
                     finally
                     {
@@ -413,13 +413,13 @@ try
                 It 'Should throw with incorrect product id' {
                     $wrongPackageId = '{deadbeef-80c6-41e6-a1b9-8bdb8a050272}'
 
-                    { Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId $wrongPackageId -Name ([String]::Empty) } | Should Throw
+                    { Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId $wrongPackageId -Name ([String]::Empty) } | Should -Throw
                 }
 
                 It 'Should throw with incorrect name' {
                     $wrongPackageName = 'WrongPackageName'
 
-                    { Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId ([String]::Empty) -Name $wrongPackageName } | Should Throw
+                    { Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -ProductId ([String]::Empty) -Name $wrongPackageName } | Should -Throw
                 }
 
                 It 'Should correctly install and remove a package from a HTTP URL' {
@@ -432,13 +432,13 @@ try
                     $pipe.WaitForConnection()
                     $pipe.Dispose()
 
-                    { Set-TargetResource -Ensure 'Present' -Path $baseUrl -Name $script:packageName -ProductId $script:packageId } | Should Throw
+                    { Set-TargetResource -Ensure 'Present' -Path $baseUrl -Name $script:packageName -ProductId $script:packageId } | Should -Throw
 
                     Set-TargetResource -Ensure 'Present' -Path $msiUrl -Name $script:packageName -ProductId $script:packageId
-                    Test-PackageInstalledByName -Name $script:packageName | Should Be $true
+                    Test-PackageInstalledByName -Name $script:packageName | Should -Be $true
 
                     Set-TargetResource -Ensure 'Absent' -Path $msiUrl -Name $script:packageName -ProductId $script:packageId
-                    Test-PackageInstalledByName -Name $script:packageName | Should Be $false
+                    Test-PackageInstalledByName -Name $script:packageName | Should -Be $false
 
                     $pipe = New-Object -TypeName 'System.IO.Pipes.NamedPipeClientStream' -ArgumentList @( '\\.\pipe\dsctest2' )
                     $pipe.Connect()
@@ -455,13 +455,13 @@ try
                     $pipe.WaitForConnection()
                     $pipe.Dispose()
 
-                    { Set-TargetResource -Ensure 'Present' -Path $baseUrl -Name $script:packageName -ProductId $script:packageId } | Should Throw
+                    { Set-TargetResource -Ensure 'Present' -Path $baseUrl -Name $script:packageName -ProductId $script:packageId } | Should -Throw
 
                     Set-TargetResource -Ensure 'Present' -Path $msiUrl -Name $script:packageName -ProductId $script:packageId
-                    Test-PackageInstalledByName -Name $script:packageName | Should Be $true
+                    Test-PackageInstalledByName -Name $script:packageName | Should -Be $true
 
                     Set-TargetResource -Ensure 'Absent' -Path $msiUrl -Name $script:packageName -ProductId $script:packageId
-                    Test-PackageInstalledByName -Name $script:packageName | Should Be $false
+                    Test-PackageInstalledByName -Name $script:packageName | Should -Be $false
 
                     $pipe = New-Object -TypeName 'System.IO.Pipes.NamedPipeClientStream' -ArgumentList @( '\\.\pipe\dsctest2' )
                     $pipe.Connect()
@@ -478,8 +478,8 @@ try
 
                     Set-TargetResource -Ensure 'Present' -Path $script:msiLocation -Name $script:packageName -LogPath $logPath -ProductId ([string]::Empty)
 
-                    Test-Path -Path $logPath | Should Be $true
-                    Get-Content -Path $logPath | Should Not Be $null
+                    Test-Path -Path $logPath | Should -Be $true
+                    Get-Content -Path $logPath | Should -Not -Be $null
                 }
 
                 It 'Should add space after .MSI installation arguments (#195)' {
@@ -511,7 +511,7 @@ try
                         ProductId = $script:packageId
                     }
 
-                    { Set-TargetResource -Ensure 'Present' @packageParameters } | Should Not Throw
+                    { Set-TargetResource -Ensure 'Present' @packageParameters } | Should -Not -Throw
 
                     Assert-MockCalled -CommandName Set-DSCMachineRebootRequired -Times 1
                 }
@@ -545,14 +545,14 @@ try
                     {
                         Assert-MockCalled -CommandName 'Add-Type' -Times 0
 
-                        $msiTool | Should Be ([System.Management.Automation.PSTypeName]'Microsoft.Windows.DesiredStateConfiguration.xPackageResource.MsiTools').Type
+                        $msiTool | Should -Be ([System.Management.Automation.PSTypeName]'Microsoft.Windows.DesiredStateConfiguration.xPackageResource.MsiTools').Type
                     }
                     else
                     {
                         Assert-MockCalled -CommandName 'Add-Type' -Times 1
 
-                        $addTypeResult['Namespace'] | Should Be 'Microsoft.Windows.DesiredStateConfiguration.xPackageResource'
-                        $msiTool | Should Be $null
+                        $addTypeResult['Namespace'] | Should -Be 'Microsoft.Windows.DesiredStateConfiguration.xPackageResource'
+                        $msiTool | Should -Be $null
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
@@ -742,7 +742,7 @@ try
                 It 'Should throw error for removal of registry key with subkeys without specifying Force as True' {
                     $errorMessage = $script:localizedData.CannotRemoveExistingRegistryKeyWithSubKeysWithoutForce -f $setTargetResourceParameters.Key
 
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $errorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -1383,7 +1383,7 @@ try
                 It 'Should throw error for trying to overwrite existing registry key value without specifying Force as True' {
                     $errorMessage = $script:localizedData.CannotOverwriteExistingRegistryKeyValueWithoutForce -f $setTargetResourceParameters.Key, $setTargetResourceParameters.ValueName
 
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $errorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -2689,7 +2689,7 @@ try
                 It 'Should throw an error for invalid registry drive' {
                     $errorMessage = $script:localizedData.InvalidRegistryDrive -f $invalidRegistryDriveRoot
 
-                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Throw $errorMessage
+                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -2742,7 +2742,7 @@ try
                 It 'Should throw an error for invalid registry drive' {
                     $errorMessage = $script:localizedData.InvalidRegistryDrive -f $invalidRegistryDriveName
 
-                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Throw $errorMessage
+                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -2792,7 +2792,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -2806,7 +2806,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -2820,7 +2820,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -2874,7 +2874,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -2888,7 +2888,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -3650,7 +3650,7 @@ try
                 It 'Should not throw' {
                     $errorMessage = $script:localizedData.BinaryDataNotInHexFormat -f $invalidBinaryString
 
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Throw $errorMessage
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -3662,7 +3662,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'Binary'
 
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Throw $errorMessage
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
         }
@@ -3744,7 +3744,7 @@ try
                 It 'Should throw an error for the invalid dword string' {
                     $errorMessage = $script:localizedData.DWordDataNotInHexFormat -f $invalidHexDWord
 
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Throw $errorMessage
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -3798,7 +3798,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'Dword'
 
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Throw $errorMessage
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
         }
@@ -3962,7 +3962,7 @@ try
                 It 'Should throw an error for the invalid qword string' {
                     $errorMessage = $script:localizedData.QWordDataNotInHexFormat -f $invalidHexDWord
 
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Throw $errorMessage
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -4016,7 +4016,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'Qword'
 
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Throw $errorMessage
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
         }
@@ -4094,7 +4094,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'String or ExpandString'
 
-                    { $null = ConvertTo-String @convertToStringParameters } | Should -Throw $errorMessage
+                    { $null = ConvertTo-String @convertToStringParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
         }

--- a/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xRegistryResource.Tests.ps1
@@ -44,7 +44,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -75,31 +75,31 @@ try
                 $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return 5 hashtable properties' {
-                    $getTargetResourceResult.Keys.Count | Should Be 5
+                    $getTargetResourceResult.Keys.Count | Should -Be 5
                 }
 
                 It 'Should return the Key property as the given registry key path' {
-                    $getTargetResourceResult.Key | Should Be $getTargetResourceParameters.Key
+                    $getTargetResourceResult.Key | Should -Be $getTargetResourceParameters.Key
                 }
 
                 It 'Should return the Ensure property as Absent' {
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return the ValueName property as null' {
-                    $getTargetResourceResult.ValueName | Should Be $null
+                    $getTargetResourceResult.ValueName | Should -Be $null
                 }
 
                 It 'Should return the ValueType property as null' {
-                    $getTargetResourceResult.ValueType | Should Be $null
+                    $getTargetResourceResult.ValueType | Should -Be $null
                 }
 
                 It 'Should return the ValueData property as null' {
-                    $getTargetResourceResult.ValueData | Should Be $null
+                    $getTargetResourceResult.ValueData | Should -Be $null
                 }
             }
 
@@ -112,7 +112,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -143,31 +143,31 @@ try
                 $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return 5 hashtable properties' {
-                    $getTargetResourceResult.Keys.Count | Should Be 5
+                    $getTargetResourceResult.Keys.Count | Should -Be 5
                 }
 
                 It 'Should return the Key property as the given registry key path' {
-                    $getTargetResourceResult.Key | Should Be $getTargetResourceParameters.Key
+                    $getTargetResourceResult.Key | Should -Be $getTargetResourceParameters.Key
                 }
 
                 It 'Should return the Ensure property as Present' {
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return the ValueName property as null' {
-                    $getTargetResourceResult.ValueName | Should Be $null
+                    $getTargetResourceResult.ValueName | Should -Be $null
                 }
 
                 It 'Should return the ValueType property as null' {
-                    $getTargetResourceResult.ValueType | Should Be $null
+                    $getTargetResourceResult.ValueType | Should -Be $null
                 }
 
                 It 'Should return the ValueData property as null' {
-                    $getTargetResourceResult.ValueData | Should Be $null
+                    $getTargetResourceResult.ValueData | Should -Be $null
                 }
             }
 
@@ -178,7 +178,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -221,31 +221,31 @@ try
                 $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return 5 hashtable properties' {
-                    $getTargetResourceResult.Keys.Count | Should Be 5
+                    $getTargetResourceResult.Keys.Count | Should -Be 5
                 }
 
                 It 'Should return the Key property as the given registry key path' {
-                    $getTargetResourceResult.Key | Should Be $getTargetResourceParameters.Key
+                    $getTargetResourceResult.Key | Should -Be $getTargetResourceParameters.Key
                 }
 
                 It 'Should return the Ensure property as Absent' {
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return the ValueName property as the specified value name' {
-                    $getTargetResourceResult.ValueName | Should Be $getTargetResourceParameters.ValueName
+                    $getTargetResourceResult.ValueName | Should -Be $getTargetResourceParameters.ValueName
                 }
 
                 It 'Should return the ValueType property as null' {
-                    $getTargetResourceResult.ValueType | Should Be $null
+                    $getTargetResourceResult.ValueType | Should -Be $null
                 }
 
                 It 'Should return the ValueData property as null' {
-                    $getTargetResourceResult.ValueData | Should Be $null
+                    $getTargetResourceResult.ValueData | Should -Be $null
                 }
             }
 
@@ -261,7 +261,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -317,31 +317,31 @@ try
                 $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return 5 hashtable properties' {
-                    $getTargetResourceResult.Keys.Count | Should Be 5
+                    $getTargetResourceResult.Keys.Count | Should -Be 5
                 }
 
                 It 'Should return the Key property as the given registry key path' {
-                    $getTargetResourceResult.Key | Should Be $getTargetResourceParameters.Key
+                    $getTargetResourceResult.Key | Should -Be $getTargetResourceParameters.Key
                 }
 
                 It 'Should return the Ensure property as Present' {
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return the ValueName property as specified value display name' {
-                    $getTargetResourceResult.ValueName | Should Be $getTargetResourceParameters.ValueName
+                    $getTargetResourceResult.ValueName | Should -Be $getTargetResourceParameters.ValueName
                 }
 
                 It 'Should return the ValueType property as the retrieved value type' {
-                    $getTargetResourceResult.ValueType | Should Be $testRegistryValueType
+                    $getTargetResourceResult.ValueType | Should -Be $testRegistryValueType
                 }
 
                 It 'Should return the ValueData property as the retrieved value' {
-                    $getTargetResourceResult.ValueData | Should Be $testRegistryKeyValue
+                    $getTargetResourceResult.ValueData | Should -Be $testRegistryKeyValue
                 }
             }
 
@@ -354,7 +354,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -410,31 +410,31 @@ try
                 $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return 5 hashtable properties' {
-                    $getTargetResourceResult.Keys.Count | Should Be 5
+                    $getTargetResourceResult.Keys.Count | Should -Be 5
                 }
 
                 It 'Should return the Key property as the given registry key path' {
-                    $getTargetResourceResult.Key | Should Be $getTargetResourceParameters.Key
+                    $getTargetResourceResult.Key | Should -Be $getTargetResourceParameters.Key
                 }
 
                 It 'Should return the Ensure property as Present' {
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return the ValueName property as specified value display name' {
-                    $getTargetResourceResult.ValueName | Should Be $getTargetResourceParameters.ValueName
+                    $getTargetResourceResult.ValueName | Should -Be $getTargetResourceParameters.ValueName
                 }
 
                 It 'Should return the ValueType property as the retrieved value type' {
-                    $getTargetResourceResult.ValueType | Should Be $testRegistryValueType
+                    $getTargetResourceResult.ValueType | Should -Be $testRegistryValueType
                 }
 
                 It 'Should return the ValueData property as the retrieved value' {
-                    $getTargetResourceResult.ValueData | Should Be $testRegistryKeyValue
+                    $getTargetResourceResult.ValueData | Should -Be $testRegistryKeyValue
                 }
             }
         }
@@ -466,7 +466,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -539,7 +539,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -551,7 +551,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -629,7 +629,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -643,7 +643,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -726,7 +726,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -742,7 +742,7 @@ try
                 It 'Should throw error for removal of registry key with subkeys without specifying Force as True' {
                     $errorMessage = $script:localizedData.CannotRemoveExistingRegistryKeyWithSubKeysWithoutForce -f $setTargetResourceParameters.Key
 
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw $errorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -755,7 +755,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -838,7 +838,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -850,7 +850,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -933,7 +933,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -945,7 +945,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1018,7 +1018,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -1030,7 +1030,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1132,7 +1132,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -1146,7 +1146,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1248,7 +1248,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -1264,7 +1264,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1365,7 +1365,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -1383,7 +1383,7 @@ try
                 It 'Should throw error for trying to overwrite existing registry key value without specifying Force as True' {
                     $errorMessage = $script:localizedData.CannotOverwriteExistingRegistryKeyValueWithoutForce -f $setTargetResourceParameters.Key, $setTargetResourceParameters.ValueName
 
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw $errorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -1399,7 +1399,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1511,7 +1511,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -1527,7 +1527,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1639,7 +1639,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -1654,7 +1654,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1744,7 +1744,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
 
@@ -1759,7 +1759,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key' {
@@ -1847,7 +1847,7 @@ try
                 }
 
                 It 'Should not return' {
-                    Set-TargetResource @setTargetResourceParameters | Should Be $null
+                    Set-TargetResource @setTargetResourceParameters | Should -Be $null
                 }
             }
         }
@@ -1875,7 +1875,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -1900,11 +1900,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return True' {
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
             }
 
@@ -1916,7 +1916,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -1941,11 +1941,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -1972,7 +1972,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry key value display name' {
@@ -2002,11 +2002,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return True' {
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
             }
 
@@ -2018,7 +2018,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -2048,11 +2048,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -2070,7 +2070,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -2095,11 +2095,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -2111,7 +2111,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -2136,11 +2136,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return True' {
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
             }
 
@@ -2152,7 +2152,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -2182,11 +2182,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -2199,7 +2199,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -2229,11 +2229,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -2246,7 +2246,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -2276,11 +2276,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -2292,7 +2292,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key and value name' {
@@ -2322,11 +2322,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return True' {
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
             }
 
@@ -2346,7 +2346,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key, value name, and value type' {
@@ -2377,11 +2377,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return True' {
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
             }
 
@@ -2402,7 +2402,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key, value name, and value data' {
@@ -2441,11 +2441,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return True' {
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                 }
             }
 
@@ -2465,7 +2465,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key, value name, and value type' {
@@ -2496,11 +2496,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
 
@@ -2525,7 +2525,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry resource with the specified reigstry key, value name, and value data' {
@@ -2564,11 +2564,11 @@ try
                 $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
 
                 It 'Should return a boolean' {
-                    $testTargetResourceResult -is [Boolean] | Should Be $true
+                    $testTargetResourceResult -is [Boolean] | Should -Be $true
                 }
 
                 It 'Should return False' {
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                 }
             }
         }
@@ -2580,13 +2580,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-PathRoot @getPathRootParameters } | Should Not Throw
+                    { $null = Get-PathRoot @getPathRootParameters } | Should -Not -Throw
                 }
 
                 $getPathRootResult = Get-PathRoot @getPathRootParameters
 
                 It 'Should return given path' {
-                    $getPathRootResult | Should Be $getPathRootParameters.Path
+                    $getPathRootResult | Should -Be $getPathRootParameters.Path
                 }
             }
 
@@ -2598,13 +2598,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-PathRoot @getPathRootParameters } | Should Not Throw
+                    { $null = Get-PathRoot @getPathRootParameters } | Should -Not -Throw
                 }
 
                 $getPathRootResult = Get-PathRoot @getPathRootParameters
 
                 It 'Should return the root of the given path' {
-                    $getPathRootResult | Should Be $pathRoot
+                    $getPathRootResult | Should -Be $pathRoot
                 }
             }
 
@@ -2618,13 +2618,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-PathRoot @getPathRootParameters } | Should Not Throw
+                    { $null = Get-PathRoot @getPathRootParameters } | Should -Not -Throw
                 }
 
                 $getPathRootResult = Get-PathRoot @getPathRootParameters
 
                 It 'Should return the root of the given path' {
-                    $getPathRootResult | Should Be $pathRoot
+                    $getPathRootResult | Should -Be $pathRoot
                 }
             }
         }
@@ -2638,7 +2638,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters } | Should Not Throw
+                        { $null = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters } | Should -Not -Throw
                     }
 
                     $expcetedRegistryDriveName = switch ($validRegistryDriveRoot)
@@ -2653,7 +2653,7 @@ try
                     $convertToRegistryDriveNameResult = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters
 
                     It "Should return correct registry drive name $expcetedRegistryDriveName" {
-                        $convertToRegistryDriveNameResult | Should Be $expcetedRegistryDriveName
+                        $convertToRegistryDriveNameResult | Should -Be $expcetedRegistryDriveName
                     }
                 }
             }
@@ -2664,13 +2664,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters } | Should Not Throw
+                    { $null = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters } | Should -Not -Throw
                 }
 
                 $convertToRegistryDriveNameResult = ConvertTo-RegistryDriveName @convertToRegistryDriveNameParameters
 
                 It 'Should return null' {
-                    $convertToRegistryDriveNameResult | Should Be $null
+                    $convertToRegistryDriveNameResult | Should -Be $null
                 }
             }
         }
@@ -2689,7 +2689,7 @@ try
                 It 'Should throw an error for invalid registry drive' {
                     $errorMessage = $script:localizedData.InvalidRegistryDrive -f $invalidRegistryDriveRoot
 
-                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should Throw $errorMessage
+                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -2703,7 +2703,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should Not Throw
+                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the path root' {
@@ -2727,7 +2727,7 @@ try
                 $getDriveNameResult = Get-RegistryDriveName @getRegistryDriveNameParameters
 
                 It 'Should return the retrieved registry drive name' {
-                    $getDriveNameResult | Should Be $script:validRegistryDriveNames[0]
+                    $getDriveNameResult | Should -Be $script:validRegistryDriveNames[0]
                 }
             }
 
@@ -2742,7 +2742,7 @@ try
                 It 'Should throw an error for invalid registry drive' {
                     $errorMessage = $script:localizedData.InvalidRegistryDrive -f $invalidRegistryDriveName
 
-                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should Throw $errorMessage
+                    { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -2755,7 +2755,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should Not Throw
+                        { $null = Get-RegistryDriveName @getRegistryDriveNameParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the path root' {
@@ -2774,7 +2774,7 @@ try
                     $getDriveNameResult = Get-RegistryDriveName @getRegistryDriveNameParameters
 
                     It 'Should return the retrieved registry drive name' {
-                        $getDriveNameResult | Should Be $validRegistryDriveName
+                        $getDriveNameResult | Should -Be $validRegistryDriveName
                     }
                 }
             }
@@ -2792,7 +2792,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -2806,7 +2806,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -2820,7 +2820,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -2834,7 +2834,7 @@ try
                 $expectedRegistryDriveRoot = 'HKEY_CLASSES_ROOT'
 
                 It 'Should not throw' {
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should Not Throw
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry drive with specified name' {
@@ -2860,7 +2860,7 @@ try
                 }
 
                 It 'Should not return anything' {
-                    Mount-RegistryDrive @mountRegistryDriveParameters | Should Be $null
+                    Mount-RegistryDrive @mountRegistryDriveParameters | Should -Be $null
                 }
             }
 
@@ -2874,7 +2874,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -2888,7 +2888,7 @@ try
                 It 'Should throw error for unmountable registry drive' {
                     $errorMessage = $script:localizedData.RegistryDriveCouldNotBeMounted -f $mountRegistryDriveParameters.RegistryDriveName
 
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should Throw $errorMessage
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -2902,7 +2902,7 @@ try
                 $expectedRegistryDriveRoot = 'HKEY_CLASSES_ROOT'
 
                 It 'Should not throw' {
-                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should Not Throw
+                    { Mount-RegistryDrive @mountRegistryDriveParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry drive with specified name' {
@@ -2919,7 +2919,7 @@ try
                 }
 
                 It 'Should not return anything' {
-                    Mount-RegistryDrive @mountRegistryDriveParameters | Should Be $null
+                    Mount-RegistryDrive @mountRegistryDriveParameters | Should -Be $null
                 }
             }
         }
@@ -2940,7 +2940,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-RegistryKey @getRegistryKeyParameters } | Should Not Throw
+                    { $null = Get-RegistryKey @getRegistryKeyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry drive name of the specified registry key path' {
@@ -2985,7 +2985,7 @@ try
                 $getRegistryKeyResult = Get-RegistryKey @getRegistryKeyParameters
 
                 It 'Should return the retrieved registry key' {
-                    $getRegistryKeyResult | Should Be $expectedGetRegistryKeyResult
+                    $getRegistryKeyResult | Should -Be $expectedGetRegistryKeyResult
                 }
             }
 
@@ -2997,7 +2997,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-RegistryKey @getRegistryKeyParameters } | Should Not Throw
+                    { $null = Get-RegistryKey @getRegistryKeyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry drive name of the specified registry key path' {
@@ -3042,7 +3042,7 @@ try
                 $getRegistryKeyResult = Get-RegistryKey @getRegistryKeyParameters
 
                 It 'Should return the retrieved registry key' {
-                    $getRegistryKeyResult | Should Be $expectedGetRegistryKeyResult
+                    $getRegistryKeyResult | Should -Be $expectedGetRegistryKeyResult
                 }
             }
 
@@ -3053,7 +3053,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-RegistryKey @getRegistryKeyParameters } | Should Not Throw
+                    { $null = Get-RegistryKey @getRegistryKeyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the registry drive name of the specified registry key path' {
@@ -3098,7 +3098,7 @@ try
                 $getRegistryKeyResult = Get-RegistryKey @getRegistryKeyParameters
 
                 It 'Should return the retrieved registry key' {
-                    $getRegistryKeyResult | Should Be $expectedGetRegistryKeyResult
+                    $getRegistryKeyResult | Should -Be $expectedGetRegistryKeyResult
                 }
             }
         }
@@ -3110,13 +3110,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters } | Should Not Throw
+                    { $null = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters } | Should -Not -Throw
                 }
 
                 $getRegistryKeyValueDisplayNameResult = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters
 
                 It 'Should return default registry key value name' {
-                    $getRegistryKeyValueDisplayNameResult | Should Be $localizedData.DefaultValueDisplayName
+                    $getRegistryKeyValueDisplayNameResult | Should -Be $localizedData.DefaultValueDisplayName
                 }
             }
 
@@ -3126,13 +3126,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters } | Should Not Throw
+                    { $null = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters } | Should -Not -Throw
                 }
 
                 $getRegistryKeyValueDisplayNameResult = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters
 
                 It 'Should return default registry key value name' {
-                    $getRegistryKeyValueDisplayNameResult | Should Be $localizedData.DefaultValueDisplayName
+                    $getRegistryKeyValueDisplayNameResult | Should -Be $localizedData.DefaultValueDisplayName
                 }
             }
 
@@ -3142,13 +3142,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters } | Should Not Throw
+                    { $null = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters } | Should -Not -Throw
                 }
 
                 $getRegistryKeyValueDisplayNameResult = Get-RegistryKeyValueDisplayName @getRegistryKeyValueDisplayNameParameters
 
                 It 'Should return given registry key value name' {
-                    $getRegistryKeyValueDisplayNameResult | Should Be $getRegistryKeyValueDisplayNameParameters.RegistryKeyValue
+                    $getRegistryKeyValueDisplayNameResult | Should -Be $getRegistryKeyValueDisplayNameParameters.RegistryKeyValue
                 }
             }
         }
@@ -3160,13 +3160,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters } | Should Not Throw
+                    { $null = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters } | Should -Not -Throw
                 }
 
                 $convertByteArrayToHexStringResult = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters
 
                 It 'Should return an empty string' {
-                    $convertByteArrayToHexStringResult | Should Be ([String]::Empty)
+                    $convertByteArrayToHexStringResult | Should -Be ([String]::Empty)
                 }
             }
 
@@ -3176,13 +3176,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters } | Should Not Throw
+                    { $null = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters } | Should -Not -Throw
                 }
 
                 $convertByteArrayToHexStringResult = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters
 
                 It 'Should return the byte array as a single hex string' {
-                    $convertByteArrayToHexStringResult | Should Be '01'
+                    $convertByteArrayToHexStringResult | Should -Be '01'
                 }
             }
 
@@ -3192,13 +3192,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters } | Should Not Throw
+                    { $null = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters } | Should -Not -Throw
                 }
 
                 $convertByteArrayToHexStringResult = Convert-ByteArrayToHexString @convertByteArrayToHexStringParameters
 
                 It 'Should return the byte array as a single hex string' {
-                    $convertByteArrayToHexStringResult | Should Be '00ff'
+                    $convertByteArrayToHexStringResult | Should -Be '00ff'
                 }
             }
         }
@@ -3215,7 +3215,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should Not Throw
+                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should -Not -Throw
                     }
 
                     It 'Should not attempt to convert registry key value to a hex string' {
@@ -3225,7 +3225,7 @@ try
                     $convertToReadableStringResult = ConvertTo-ReadableString @convertToReadableStringParameters
 
                     It 'Should return an empty string' {
-                        $convertToReadableStringResult | Should Be ([String]::Empty)
+                        $convertToReadableStringResult | Should -Be ([String]::Empty)
                     }
                 }
 
@@ -3236,7 +3236,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should Not Throw
+                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should -Not -Throw
                     }
 
                     if ($registryKeyValueType -eq 'Binary')
@@ -3260,7 +3260,7 @@ try
                     $convertToReadableStringResult = ConvertTo-ReadableString @convertToReadableStringParameters
 
                     It 'Should return an empty string' {
-                        $convertToReadableStringResult | Should Be ([String]::Empty)
+                        $convertToReadableStringResult | Should -Be ([String]::Empty)
                     }
                 }
 
@@ -3271,7 +3271,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should Not Throw
+                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should -Not -Throw
                     }
 
                     if ($registryKeyValueType -eq 'Binary')
@@ -3295,7 +3295,7 @@ try
                     $convertToReadableStringResult = ConvertTo-ReadableString @convertToReadableStringParameters
 
                     It 'Should return the specified string' {
-                        $convertToReadableStringResult | Should Be $convertToReadableStringParameters.RegistryKeyValue[0]
+                        $convertToReadableStringResult | Should -Be $convertToReadableStringParameters.RegistryKeyValue[0]
                     }
                 }
 
@@ -3306,7 +3306,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should Not Throw
+                        { $null = ConvertTo-ReadableString @convertToReadableStringParameters } | Should -Not -Throw
                     }
 
                     if ($registryKeyValueType -eq 'Binary')
@@ -3331,7 +3331,7 @@ try
                     $convertToReadableStringResult = ConvertTo-ReadableString @convertToReadableStringParameters
 
                     It 'Should return the specified strings inside one string' {
-                        $convertToReadableStringResult | Should Be $expectedReadProperty
+                        $convertToReadableStringResult | Should -Be $expectedReadProperty
                     }
                 }
             }
@@ -3350,7 +3350,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = New-RegistryKey @newRegistryKeyParameters } | Should Not Throw
+                    { $null = New-RegistryKey @newRegistryKeyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the parent registry key' {
@@ -3380,7 +3380,7 @@ try
                 $newRegistryKeyResult = New-RegistryKey @newRegistryKeyParameters
 
                 It 'Should return the created subkey' {
-                    $newRegistryKeyResult | Should Be $script:testRegistryKey
+                    $newRegistryKeyResult | Should -Be $script:testRegistryKey
                 }
             }
 
@@ -3404,7 +3404,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = New-RegistryKey @newRegistryKeyParameters } | Should Not Throw
+                    { $null = New-RegistryKey @newRegistryKeyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the parent registry key' {
@@ -3449,7 +3449,7 @@ try
                 $newRegistryKeyResult = New-RegistryKey @newRegistryKeyParameters
 
                 It 'Should return the created subkey' {
-                    $newRegistryKeyResult | Should Be $script:testRegistryKey
+                    $newRegistryKeyResult | Should -Be $script:testRegistryKey
                 }
             }
         }
@@ -3485,13 +3485,13 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = Test-RegistryKeyValuesMatch @testRegistryKeyValuesMatchParameters } | Should Not Throw
+                        { $null = Test-RegistryKeyValuesMatch @testRegistryKeyValuesMatchParameters } | Should -Not -Throw
                     }
 
                     $testRegistryKeyValuesMatchResult = Test-RegistryKeyValuesMatch @testRegistryKeyValuesMatchParameters
 
                     It 'Should return true' {
-                        $testRegistryKeyValuesMatchResult | Should Be $true
+                        $testRegistryKeyValuesMatchResult | Should -Be $true
                     }
                 }
 
@@ -3503,13 +3503,13 @@ try
                     }
 
                     It 'Should not throw' {
-                        { $null = Test-RegistryKeyValuesMatch @testRegistryKeyValuesMatchParameters } | Should Not Throw
+                        { $null = Test-RegistryKeyValuesMatch @testRegistryKeyValuesMatchParameters } | Should -Not -Throw
                     }
 
                     $testRegistryKeyValuesMatchResult = Test-RegistryKeyValuesMatch @testRegistryKeyValuesMatchParameters
 
                     It 'Should return false' {
-                        $testRegistryKeyValuesMatchResult | Should Be $false
+                        $testRegistryKeyValuesMatchResult | Should -Be $false
                     }
                 }
             }
@@ -3522,13 +3522,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Not Throw
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Not -Throw
                 }
 
                 $convertToBinaryResult = ConvertTo-Binary @convertToBinaryParameters
 
                 It 'Should return null' {
-                    $convertToBinaryResult | Should Be $null
+                    $convertToBinaryResult | Should -Be $null
                 }
             }
 
@@ -3538,13 +3538,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Not Throw
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Not -Throw
                 }
 
                 $convertToBinaryResult = ConvertTo-Binary @convertToBinaryParameters
 
                 It 'Should return null' {
-                    $convertToBinaryResult | Should Be $null
+                    $convertToBinaryResult | Should -Be $null
                 }
             }
 
@@ -3554,13 +3554,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Not Throw
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Not -Throw
                 }
 
                 $convertToBinaryResult = ConvertTo-Binary @convertToBinaryParameters
 
                 It 'Should return null' {
-                    $convertToBinaryResult | Should Be $null
+                    $convertToBinaryResult | Should -Be $null
                 }
             }
 
@@ -3573,13 +3573,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Not Throw
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Not -Throw
                 }
 
                 $convertToBinaryResult = ConvertTo-Binary @convertToBinaryParameters
 
                 It 'Should return the specified single string' {
-                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should Be $null
+                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should -Be $null
                 }
             }
 
@@ -3592,13 +3592,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Not Throw
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Not -Throw
                 }
 
                 $convertToBinaryResult = ConvertTo-Binary @convertToBinaryParameters
 
                 It 'Should return the specified single string' {
-                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should Be $null
+                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should -Be $null
                 }
             }
 
@@ -3611,13 +3611,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Not Throw
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Not -Throw
                 }
 
                 $convertToBinaryResult = ConvertTo-Binary @convertToBinaryParameters
 
                 It 'Should return the specified single string' {
-                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should Be $null
+                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should -Be $null
                 }
             }
 
@@ -3630,13 +3630,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Not Throw
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Not -Throw
                 }
 
                 $convertToBinaryResult = ConvertTo-Binary @convertToBinaryParameters
 
                 It 'Should return the specified single string' {
-                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should Be $null
+                    Compare-Object -ReferenceObject $expectedByteArray -DifferenceObject $convertToBinaryResult | Should -Be $null
                 }
             }
 
@@ -3650,7 +3650,7 @@ try
                 It 'Should not throw' {
                     $errorMessage = $script:localizedData.BinaryDataNotInHexFormat -f $invalidBinaryString
 
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Throw $errorMessage
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -3662,7 +3662,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'Binary'
 
-                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should Throw $errorMessage
+                    { $null = ConvertTo-Binary @convertToBinaryParameters } | Should -Throw $errorMessage
                 }
             }
         }
@@ -3674,13 +3674,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Not Throw
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Not -Throw
                 }
 
                 $convertToDWordResult =  ConvertTo-DWord @convertToDWordParameters
 
                 It 'Should return 0 as an Int32' {
-                    $convertToDWordResult | Should Be ([System.Int32] 0)
+                    $convertToDWordResult | Should -Be ([System.Int32] 0)
                 }
             }
 
@@ -3690,13 +3690,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Not Throw
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Not -Throw
                 }
 
                 $convertToDWordResult = ConvertTo-DWord @convertToDWordParameters
 
                 It 'Should return 0 as an Int32' {
-                    $convertToDWordResult | Should Be ([System.Int32] 0)
+                    $convertToDWordResult | Should -Be ([System.Int32] 0)
                 }
             }
 
@@ -3706,13 +3706,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Not Throw
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Not -Throw
                 }
 
                 $convertToDWordResult = ConvertTo-DWord @convertToDWordParameters
 
                 It 'Should return 0 as an Int32' {
-                    $convertToDWordResult | Should Be ([System.Int32] 0)
+                    $convertToDWordResult | Should -Be ([System.Int32] 0)
                 }
             }
 
@@ -3724,13 +3724,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Not Throw
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Not -Throw
                 }
 
                 $convertToDWordResult = ConvertTo-DWord @convertToDWordParameters
 
                 It 'Should return the specified double word' {
-                    $convertToDWordResult | Should Be $testDWord1
+                    $convertToDWordResult | Should -Be $testDWord1
                 }
             }
 
@@ -3744,7 +3744,7 @@ try
                 It 'Should throw an error for the invalid dword string' {
                     $errorMessage = $script:localizedData.DWordDataNotInHexFormat -f $invalidHexDWord
 
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Throw $errorMessage
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -3758,13 +3758,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Not Throw
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Not -Throw
                 }
 
                 $convertToDWordResult = ConvertTo-DWord @convertToDWordParameters
 
                 It 'Should return the specified double word converted from a Hex value' {
-                    $convertToDWordResult | Should Be $expectedInt32Value
+                    $convertToDWordResult | Should -Be $expectedInt32Value
                 }
             }
 
@@ -3778,13 +3778,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Not Throw
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Not -Throw
                 }
 
                 $convertToDWordResult = ConvertTo-DWord @convertToDWordParameters
 
                 It 'Should return the specified double word converted from a Hex value' {
-                    $convertToDWordResult | Should Be $expectedInt32Value
+                    $convertToDWordResult | Should -Be $expectedInt32Value
                 }
             }
 
@@ -3798,7 +3798,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'Dword'
 
-                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should Throw $errorMessage
+                    { $null = ConvertTo-DWord @convertToDWordParameters } | Should -Throw $errorMessage
                 }
             }
         }
@@ -3810,13 +3810,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should Not Throw
+                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should -Not -Throw
                 }
 
                 $convertToMultiStringResult = ConvertTo-MultiString @convertToMultiStringParameters
 
                 It 'Should return null' {
-                    $convertToMultiStringResult | Should Be $null
+                    $convertToMultiStringResult | Should -Be $null
                 }
             }
 
@@ -3826,13 +3826,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should Not Throw
+                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should -Not -Throw
                 }
 
                 $convertToMultiStringResult =  ConvertTo-MultiString @convertToMultiStringParameters
 
                 It 'Should return null' {
-                    $convertToMultiStringResult | Should Be $null
+                    $convertToMultiStringResult | Should -Be $null
                 }
             }
 
@@ -3842,13 +3842,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should Not Throw
+                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should -Not -Throw
                 }
 
                 $convertToMultiStringResult =  ConvertTo-MultiString @convertToMultiStringParameters
 
                 It 'Should return an array containing null' {
-                    Compare-Object -ReferenceObject ([String[]] @($null)) -DifferenceObject $convertToMultiStringResult | Should Be $null
+                    Compare-Object -ReferenceObject ([String[]] @($null)) -DifferenceObject $convertToMultiStringResult | Should -Be $null
                 }
             }
 
@@ -3858,13 +3858,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should Not Throw
+                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should -Not -Throw
                 }
 
                 $convertToMultiStringResult =  ConvertTo-MultiString @convertToMultiStringParameters
 
                 It 'Should return an array containing the specified single string' {
-                    Compare-Object -ReferenceObject $convertToMultiStringParameters.RegistryKeyValue -DifferenceObject $convertToMultiStringResult | Should Be $null
+                    Compare-Object -ReferenceObject $convertToMultiStringParameters.RegistryKeyValue -DifferenceObject $convertToMultiStringResult | Should -Be $null
                 }
             }
 
@@ -3874,13 +3874,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should Not Throw
+                    { $null = ConvertTo-MultiString @convertToMultiStringParameters } | Should -Not -Throw
                 }
 
                 $convertToMultiStringResult =  ConvertTo-MultiString @convertToMultiStringParameters
 
                 It 'Should return an array containing the specified single string' {
-                    Compare-Object -ReferenceObject $convertToMultiStringParameters.RegistryKeyValue -DifferenceObject $convertToMultiStringResult | Should Be $null
+                    Compare-Object -ReferenceObject $convertToMultiStringParameters.RegistryKeyValue -DifferenceObject $convertToMultiStringResult | Should -Be $null
                 }
             }
         }
@@ -3892,13 +3892,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Not Throw
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Not -Throw
                 }
 
                 $convertToQWordResult = ConvertTo-QWord @convertToQWordParameters
 
                 It 'Should return 0 as an Int64' {
-                    $convertToQWordResult | Should Be ([System.Int64] 0)
+                    $convertToQWordResult | Should -Be ([System.Int64] 0)
                 }
             }
 
@@ -3908,13 +3908,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Not Throw
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Not -Throw
                 }
 
                 $convertToQWordResult = ConvertTo-QWord @convertToQWordParameters
 
                 It 'Should return 0 as an Int64' {
-                    $convertToQWordResult | Should Be ([System.Int64] 0)
+                    $convertToQWordResult | Should -Be ([System.Int64] 0)
                 }
             }
 
@@ -3924,13 +3924,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Not Throw
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Not -Throw
                 }
 
                 $convertToQWordResult = ConvertTo-QWord @convertToQWordParameters
 
                 It 'Should return 0 as an Int64' {
-                    $convertToQWordResult | Should Be ([System.Int64] 0)
+                    $convertToQWordResult | Should -Be ([System.Int64] 0)
                 }
             }
 
@@ -3942,13 +3942,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Not Throw
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Not -Throw
                 }
 
                 $convertToQWordResult = ConvertTo-QWord @convertToQWordParameters
 
                 It 'Should return the specified quad word' {
-                    $convertToQWordResult | Should Be $testDWord1
+                    $convertToQWordResult | Should -Be $testDWord1
                 }
             }
 
@@ -3962,7 +3962,7 @@ try
                 It 'Should throw an error for the invalid qword string' {
                     $errorMessage = $script:localizedData.QWordDataNotInHexFormat -f $invalidHexDWord
 
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Throw $errorMessage
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -3976,13 +3976,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Not Throw
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Not -Throw
                 }
 
                 $convertToQWordResult = ConvertTo-QWord @convertToQWordParameters
 
                 It 'Should return the specified quad word converted from a Hex value' {
-                    $convertToQWordResult | Should Be $expectedInt64Value
+                    $convertToQWordResult | Should -Be $expectedInt64Value
                 }
             }
 
@@ -3996,13 +3996,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Not Throw
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Not -Throw
                 }
 
                 $convertToQWordResult = ConvertTo-QWord @convertToQWordParameters
 
                 It 'Should return the specified quad word converted from a Hex value' {
-                    $convertToQWordResult | Should Be $expectedInt64Value
+                    $convertToQWordResult | Should -Be $expectedInt64Value
                 }
             }
 
@@ -4016,7 +4016,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'Qword'
 
-                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should Throw $errorMessage
+                    { $null = ConvertTo-QWord @convertToQWordParameters } | Should -Throw $errorMessage
                 }
             }
         }
@@ -4028,13 +4028,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-String @convertToStringParameters } | Should Not Throw
+                    { $null = ConvertTo-String @convertToStringParameters } | Should -Not -Throw
                 }
 
                 $convertToStringResult = ConvertTo-String @convertToStringParameters
 
                 It 'Should return an empty string' {
-                    $convertToStringResult | Should Be ([String]::Empty)
+                    $convertToStringResult | Should -Be ([String]::Empty)
                 }
             }
 
@@ -4044,13 +4044,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-String @convertToStringParameters } | Should Not Throw
+                    { $null = ConvertTo-String @convertToStringParameters } | Should -Not -Throw
                 }
 
                 $convertToStringResult = ConvertTo-String @convertToStringParameters
 
                 It 'Should return an empty string' {
-                    $convertToStringResult | Should Be ([String]::Empty)
+                    $convertToStringResult | Should -Be ([String]::Empty)
                 }
             }
 
@@ -4060,13 +4060,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-String @convertToStringParameters } | Should Not Throw
+                    { $null = ConvertTo-String @convertToStringParameters } | Should -Not -Throw
                 }
 
                 $convertToStringResult = ConvertTo-String @convertToStringParameters
 
                 It 'Should return an empty string' {
-                    $convertToStringResult | Should Be ([String]::Empty)
+                    $convertToStringResult | Should -Be ([String]::Empty)
                 }
             }
 
@@ -4076,13 +4076,13 @@ try
                 }
 
                 It 'Should not throw' {
-                    { $null = ConvertTo-String @convertToStringParameters } | Should Not Throw
+                    { $null = ConvertTo-String @convertToStringParameters } | Should -Not -Throw
                 }
 
                 $convertToStringResult = ConvertTo-String @convertToStringParameters
 
                 It 'Should return the specified single string' {
-                    $convertToStringResult | Should Be $convertToStringParameters.RegistryKeyValue[0]
+                    $convertToStringResult | Should -Be $convertToStringParameters.RegistryKeyValue[0]
                 }
             }
 
@@ -4094,7 +4094,7 @@ try
                 It 'Should throw an error for unexpected array' {
                     $errorMessage = $script:localizedData.ArrayNotAllowedForExpectedType -f 'String or ExpandString'
 
-                    { $null = ConvertTo-String @convertToStringParameters } | Should Throw $errorMessage
+                    { $null = ConvertTo-String @convertToStringParameters } | Should -Throw $errorMessage
                 }
             }
         }

--- a/Tests/Unit/MSFT_xRemoteFile.Tests.ps1
+++ b/Tests/Unit/MSFT_xRemoteFile.Tests.ps1
@@ -103,23 +103,23 @@ try
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
             $result = Get-TargetResource @testSplatFile
             It 'Returns "Present" when DestinationPath is a File and exists' {
-                $Result.Ensure | Should Be 'Present'
+                $Result.Ensure | Should -Be 'Present'
             }
 
             $result = Get-TargetResource @testSplatFolderFileExists
             It 'Returns "Present" when DestinationPath is a Directory and exists and URI file exists' {
-                $Result.Ensure | Should Be 'Present'
+                $Result.Ensure | Should -Be 'Present'
             }
 
             $result = Get-TargetResource @testSplatFolderFileNotExist
             It 'Returns "Absent" when DestinationPath is a Directory and exists but URI file does not' {
-                $Result.Ensure | Should Be 'Absent'
+                $Result.Ensure | Should -Be 'Absent'
             }
 
             Mock Get-PathItemType -MockWith { return 'Other' }
             $result = Get-TargetResource @testSplatFile
             It 'Returns "Absent" when DestinationPath is Other' {
-                $Result.Ensure | Should Be 'Absent'
+                $Result.Ensure | Should -Be 'Absent'
             }
         } #end Describe "$($Global:DSCResourceName)\Get-TargetResource"
 
@@ -133,7 +133,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "UriValidationFailure" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw $errorRecord
                 }
             }
             Context 'DestinationPath is "bad://.."' {
@@ -145,7 +145,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DestinationPathSchemeValidationFailure" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw $errorRecord
                 }
             }
             Context 'DestinationPath starts with "\\"' {
@@ -157,7 +157,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DestinationPathIsUncFailure" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw $errorRecord
                 }
             }
             Context 'DestinationPath contains invalid characters "*"' {
@@ -169,7 +169,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DestinationPathHasInvalidCharactersError" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw $errorRecord
                 }
             }
             Mock Update-Cache
@@ -182,7 +182,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DownloadException" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw $errorRecord
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Update-Cache -Exactly 0
@@ -191,7 +191,7 @@ try
             Mock Invoke-WebRequest
             Context 'URI is valid, DestinationPath is a file, download successful' {
                 It 'Does not throw' {
-                    { Set-TargetResource @testSplatFile } | Should Not Throw
+                    { Set-TargetResource @testSplatFile } | Should -Not -Throw
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Invoke-WebRequest -Exactly 1
@@ -204,7 +204,7 @@ try
             Mock Get-Cache
             Context 'URI is valid, DestinationPath is a File, file exists' {
                 It 'Returns "False"' {
-                    Test-TargetResource @testSplatFile | Should Be $False
+                    Test-TargetResource @testSplatFile | Should -Be $False
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Get-Cache -Exactly 1
@@ -214,7 +214,7 @@ try
                 It 'Returns "True"' {
                     $splat = $testSplatFile.Clone()
                     $splat.MatchSource = $False
-                    Test-TargetResource @splat | Should Be $True
+                    Test-TargetResource @splat | Should -Be $True
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Get-Cache -Exactly 0
@@ -222,7 +222,7 @@ try
             }
             Context 'URI is valid, DestinationPath is a Folder, file exists' {
                 It 'Returns "False"' {
-                    Test-TargetResource @testSplatFolderFileExists | Should Be $False
+                    Test-TargetResource @testSplatFolderFileExists | Should -Be $False
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Get-Cache -Exactly 1
@@ -232,7 +232,7 @@ try
                 It 'Returns "True"' {
                     $splat = $testSplatFolderFileExists.Clone()
                     $splat.MatchSource = $False
-                    Test-TargetResource @splat | Should Be $True
+                    Test-TargetResource @splat | Should -Be $True
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Get-Cache -Exactly 0
@@ -240,7 +240,7 @@ try
             }
             Context 'URI is valid, DestinationPath is a Folder, file does not exist' {
                 It 'Returns "False"' {
-                    Test-TargetResource @testSplatFolderFileNotExist | Should Be $False
+                    Test-TargetResource @testSplatFolderFileNotExist | Should -Be $False
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Get-Cache -Exactly 0
@@ -250,7 +250,7 @@ try
                 It 'Returns "False"' {
                     $splat = $testSplatFolderFileNotExist.Clone()
                     $splat.MatchSource = $False
-                    Test-TargetResource @splat | Should Be $False
+                    Test-TargetResource @splat | Should -Be $False
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Get-Cache -Exactly 0
@@ -261,31 +261,31 @@ try
 
         Describe "$($Global:DSCResourceName)\Test-UriScheme" {
             It 'Returns "True" when URI is "http://.." and scheme is "http|https|file"' {
-                Test-UriScheme -Uri $testURI -Scheme 'http|https|file' | Should Be $true
+                Test-UriScheme -Uri $testURI -Scheme 'http|https|file' | Should -Be $true
             }
             It 'Returns "True" when URI is "http://.." and scheme is "http"' {
-                Test-UriScheme -Uri $testURI -Scheme 'http' | Should Be $true
+                Test-UriScheme -Uri $testURI -Scheme 'http' | Should -Be $true
             }
             It 'Returns "False" when URI is "http://.." and scheme is "https"' {
-                Test-UriScheme -Uri $testURI -Scheme 'https' | Should Be $false
+                Test-UriScheme -Uri $testURI -Scheme 'https' | Should -Be $false
             }
             It 'Returns "False" when URI is "bad://.." and scheme is "http|https|file"' {
-                Test-UriScheme -Uri 'bad://contoso.com' -Scheme 'http|https|file' | Should Be $false
+                Test-UriScheme -Uri 'bad://contoso.com' -Scheme 'http|https|file' | Should -Be $false
             }
         } #end Describe "$($Global:DSCResourceName)\Test-UriScheme"
 
         Describe "$($Global:DSCResourceName)\Get-PathItemType" {
             It 'Returns "Directory" when Path is a Directory' {
-                Get-PathItemType -Path $testDestinationFolder | Should Be 'Directory'
+                Get-PathItemType -Path $testDestinationFolder | Should -Be 'Directory'
             }
             It 'Returns "File" when Path is a File' {
-                Get-PathItemType -Path $testDestinationFile | Should Be 'File'
+                Get-PathItemType -Path $testDestinationFile | Should -Be 'File'
             }
             It 'Returns "NotExists" when Path does not exist' {
-                Get-PathItemType -Path $testDestinationNotExist | Should Be 'NotExists'
+                Get-PathItemType -Path $testDestinationNotExist | Should -Be 'NotExists'
             }
             It 'Returns "Other" when Path is not in File System' {
-                Get-PathItemType -Path HKLM:\Software | Should Be 'Other'
+                Get-PathItemType -Path HKLM:\Software | Should -Be 'Other'
             }
         } #end Describe "$($Global:DSCResourceName)\Get-PathItemType"
 
@@ -295,7 +295,7 @@ try
             Context "DestinationPath 'c:\' and Uri $testURI and Cached Content exists" {
                 $Result = Get-Cache -DestinationPath 'c:\' -Uri $testURI
                 It "Returns Expected Content" {
-                    $Result | Should Be 'Expected Content'
+                    $Result | Should -Be 'Expected Content'
                 }
                 It "Calls expected mocks" {
                     Assert-MockCalled Import-CliXml -Exactly 1
@@ -306,7 +306,7 @@ try
             Context "DestinationPath 'c:\' and Uri $testURI and Cached Content does not exist" {
                 $Result = Get-Cache -DestinationPath 'c:\' -Uri $testURI
                 It "Returns Null" {
-                    $Result | Should BeNullOrEmpty
+                    $Result | Should -BeNullOrEmpty
                 }
                 It "Calls expected mocks" {
                     Assert-MockCalled Import-CliXml -Exactly 0
@@ -321,7 +321,7 @@ try
             Mock New-Item
             Context "DestinationPath 'c:\' and Uri $testURI and CacheLocation Exists" {
                 It "Does Not Throw" {
-                    { Update-Cache -DestinationPath 'c:\' -Uri $testURI -InputObject @{} } | Should Not Throw
+                    { Update-Cache -DestinationPath 'c:\' -Uri $testURI -InputObject @{} } | Should -Not -Throw
                 }
                 It "Calls expected mocks" {
                     Assert-MockCalled Export-CliXml -Exactly 1
@@ -332,7 +332,7 @@ try
             Mock Test-Path -MockWith { $False }
             Context "DestinationPath 'c:\' and Uri $testURI and CacheLocation does not exist" {
                 It "Does Not Throw" {
-                    { Update-Cache -DestinationPath 'c:\' -Uri $testURI -InputObject @{} } | Should Not Throw
+                    { Update-Cache -DestinationPath 'c:\' -Uri $testURI -InputObject @{} } | Should -Not -Throw
                 }
                 It "Calls expected mocks" {
                     Assert-MockCalled Export-CliXml -Exactly 1
@@ -344,10 +344,10 @@ try
 
         Describe "$($Global:DSCResourceName)\Get-CacheKey" {
             It "Returns -799765921 as Cache Key for DestinationPath 'c:\' and Uri $testURI" {
-                Get-CacheKey -DestinationPath 'c:\' -Uri $testURI | Should Be -799765921
+                Get-CacheKey -DestinationPath 'c:\' -Uri $testURI | Should -Be -799765921
             }
             It "Returns 1266535016 as Cache Key for DestinationPath 'c:\Windows\System32' and Uri $testURINotExist" {
-                Get-CacheKey -DestinationPath 'c:\Windows\System32' -Uri $testURINotExist | Should Be 1266535016
+                Get-CacheKey -DestinationPath 'c:\Windows\System32' -Uri $testURINotExist | Should -Be 1266535016
             }
         } #end Describe "$($Global:DSCResourceName)\Get-CacheKey"
     }

--- a/Tests/Unit/MSFT_xRemoteFile.Tests.ps1
+++ b/Tests/Unit/MSFT_xRemoteFile.Tests.ps1
@@ -133,7 +133,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "UriValidationFailure" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should -Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw -ExpectedMessage $errorRecord
                 }
             }
             Context 'DestinationPath is "bad://.."' {
@@ -145,7 +145,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DestinationPathSchemeValidationFailure" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should -Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw -ExpectedMessage $errorRecord
                 }
             }
             Context 'DestinationPath starts with "\\"' {
@@ -157,7 +157,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DestinationPathIsUncFailure" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should -Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw -ExpectedMessage $errorRecord
                 }
             }
             Context 'DestinationPath contains invalid characters "*"' {
@@ -169,7 +169,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DestinationPathHasInvalidCharactersError" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should -Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw -ExpectedMessage $errorRecord
                 }
             }
             Mock Update-Cache
@@ -182,7 +182,7 @@ try
                     $errorRecord = Get-InvalidDataException `
                         -errorId "DownloadException" `
                         -errorMessage $errorMessage
-                    { Set-TargetResource @splat } | Should -Throw $errorRecord
+                    { Set-TargetResource @splat } | Should -Throw -ExpectedMessage $errorRecord
                 }
                 It 'Calls expected mocks' {
                     Assert-MockCalled Update-Cache -Exactly 0

--- a/Tests/Unit/MSFT_xScriptResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xScriptResource.Tests.ps1
@@ -36,7 +36,7 @@ try {
 
                 It 'Should throw an error for malformed get script' {
                     $errorMessage = $script:localizedData.GetScriptDidNotReturnHashtable
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Throw $errorMessage
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -51,7 +51,7 @@ try {
 
                 It 'Should throw an error for malformed get script' {
                     $errorMessage = $script:localizedData.GetScriptDidNotReturnHashtable
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Throw $errorMessage
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -69,7 +69,7 @@ try {
                 }
 
                 It 'Should throw error from get script' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Throw $testErrorRecord
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $testErrorRecord
                 }
             }
 
@@ -84,7 +84,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should use script execution helper to run script' {
@@ -102,12 +102,12 @@ try {
 
                 It 'Should return a hashtable' {
                     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the output from the specified get script' {
                     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-                    Compare-Object -ReferenceObject $testScriptResult -DifferenceObject $getTargetResourceResult | Should Be $null
+                    Compare-Object -ReferenceObject $testScriptResult -DifferenceObject $getTargetResourceResult | Should -Be $null
                 }
             }
 
@@ -120,7 +120,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should Not Throw
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should use script execution helper to run script with the specified Credential' {
@@ -140,12 +140,12 @@ try {
 
                 It 'Should return a hashtable' {
                     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 It 'Should return the output from the specified get script' {
                     $getTargetResourceResult = Get-TargetResource @getTargetResourceParameters
-                    Compare-Object -ReferenceObject $testScriptResult -DifferenceObject $getTargetResourceResult | Should Be $null
+                    Compare-Object -ReferenceObject $testScriptResult -DifferenceObject $getTargetResourceResult | Should -Be $null
                 }
             }
         }
@@ -161,7 +161,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should use script execution helper to run script' {
@@ -187,7 +187,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should use script execution helper to run script with specified Credential' {
@@ -220,7 +220,7 @@ try {
                 }
 
                 It 'Should throw error from set script' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw $testErrorRecord
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $testErrorRecord
                 }
             }
         }
@@ -237,7 +237,7 @@ try {
 
                 It 'Should throw an error for malformed test script' {
                     $errorMessage = $script:localizedData.TestScriptDidNotReturnBoolean
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Throw $errorMessage
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw $errorMessage
                 }
             }
 
@@ -255,7 +255,7 @@ try {
                 }
 
                 It 'Should throw error from test script' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Throw $testErrorRecord
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw $testErrorRecord
                 }
             }
 
@@ -270,7 +270,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should use script execution helper to run script' {
@@ -288,7 +288,7 @@ try {
 
                 It 'Should return the expected boolean' {
                     $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
-                    $testTargetResourceResult | Should Be $expectedBoolean
+                    $testTargetResourceResult | Should -Be $expectedBoolean
                 }
             }
 
@@ -301,7 +301,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should use script execution helper to run script with specified Credential' {
@@ -321,7 +321,7 @@ try {
 
                 It 'Should return the expected boolean' {
                     $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
-                    $testTargetResourceResult | Should Be $expectedBoolean
+                    $testTargetResourceResult | Should -Be $expectedBoolean
                 }
             }
 
@@ -336,7 +336,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should use script execution helper to run script' {
@@ -354,7 +354,7 @@ try {
 
                 It 'Should return the expected boolean' {
                     $testTargetResourceResult = Test-TargetResource @testTargetResourceParameters
-                    $testTargetResourceResult | Should Be $expectedBoolean
+                    $testTargetResourceResult | Should -Be $expectedBoolean
                 }
             }
 
@@ -369,7 +369,7 @@ try {
 
                 It 'Should throw an error for malformed test script' {
                     $errorMessage = $script:localizedData.TestScriptDidNotReturnBoolean
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should Throw $errorMessage
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw $errorMessage
                 }
             }
         }
@@ -385,22 +385,22 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { $null = Invoke-Script @scriptExecutionHelperParameters } | Should Not Throw
+                    { $null = Invoke-Script @scriptExecutionHelperParameters } | Should -Not -Throw
                 }
 
                 It 'Should return an error record' {
                     $scriptExecutionHelperResult = Invoke-Script @scriptExecutionHelperParameters
-                    $scriptExecutionHelperResult -is [System.Management.Automation.ErrorRecord] | Should Be $true
+                    $scriptExecutionHelperResult -is [System.Management.Automation.ErrorRecord] | Should -Be $true
                 }
 
                 It 'Should return an error record' {
                     $scriptExecutionHelperResult = Invoke-Script @scriptExecutionHelperParameters
-                    $scriptExecutionHelperResult -is [System.Management.Automation.ErrorRecord] | Should Be $true
+                    $scriptExecutionHelperResult -is [System.Management.Automation.ErrorRecord] | Should -Be $true
                 }
 
                 It 'Should return error with expected message from script' {
                     $scriptExecutionHelperResult = Invoke-Script @scriptExecutionHelperParameters
-                    $scriptExecutionHelperResult.Exception.Message | Should Be $testErrorMessage
+                    $scriptExecutionHelperResult.Exception.Message | Should -Be $testErrorMessage
                 }
             }
 
@@ -411,7 +411,7 @@ try {
                 }
 
                 It 'Should not throw' {
-                    { $null = Invoke-Script @scriptExecutionHelperParameters } | Should Not Throw
+                    { $null = Invoke-Script @scriptExecutionHelperParameters } | Should -Not -Throw
                 }
 
                 It 'Should run script through Invoke-Command using the specified Credential' {
@@ -429,7 +429,7 @@ try {
 
                 It 'Should return nothing' {
                     $scriptExecutionHelperResult = Invoke-Script @scriptExecutionHelperParameters
-                    $scriptExecutionHelperResult | Should Be $null
+                    $scriptExecutionHelperResult | Should -Be $null
                 }
             }
 
@@ -447,7 +447,7 @@ try {
 
                 It 'Should return result of script' {
                     $scriptExecutionHelperResult = Invoke-Script @scriptExecutionHelperParameters
-                    $scriptExecutionHelperResult | Should Be $testScriptResult
+                    $scriptExecutionHelperResult | Should -Be $testScriptResult
                 }
             }
         }

--- a/Tests/Unit/MSFT_xScriptResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xScriptResource.Tests.ps1
@@ -36,7 +36,7 @@ try {
 
                 It 'Should throw an error for malformed get script' {
                     $errorMessage = $script:localizedData.GetScriptDidNotReturnHashtable
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $errorMessage
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -51,7 +51,7 @@ try {
 
                 It 'Should throw an error for malformed get script' {
                     $errorMessage = $script:localizedData.GetScriptDidNotReturnHashtable
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $errorMessage
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -69,7 +69,7 @@ try {
                 }
 
                 It 'Should throw error from get script' {
-                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw $testErrorRecord
+                    { $null = Get-TargetResource @getTargetResourceParameters } | Should -Throw -ExpectedMessage $testErrorRecord
                 }
             }
 
@@ -220,7 +220,7 @@ try {
                 }
 
                 It 'Should throw error from set script' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $testErrorRecord
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $testErrorRecord
                 }
             }
         }
@@ -237,7 +237,7 @@ try {
 
                 It 'Should throw an error for malformed test script' {
                     $errorMessage = $script:localizedData.TestScriptDidNotReturnBoolean
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw $errorMessage
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
 
@@ -255,7 +255,7 @@ try {
                 }
 
                 It 'Should throw error from test script' {
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw $testErrorRecord
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw -ExpectedMessage $testErrorRecord
                 }
             }
 
@@ -369,7 +369,7 @@ try {
 
                 It 'Should throw an error for malformed test script' {
                     $errorMessage = $script:localizedData.TestScriptDidNotReturnBoolean
-                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw $errorMessage
+                    { $null = Test-TargetResource @testTargetResourceParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
         }

--- a/Tests/Unit/MSFT_xServiceResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xServiceResource.Tests.ps1
@@ -476,7 +476,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and Credential conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $setTargetResourceParameters.Name
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
 
                 $setTargetResourceParameters = @{
@@ -487,7 +487,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $setTargetResourceParameters.Name
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
 
                 $setTargetResourceParameters = @{
@@ -498,7 +498,7 @@ try
 
                 It 'Should throw an error for Credential and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $setTargetResourceParameters.Name
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -553,7 +553,7 @@ try
 
                 It 'Should throw an error for the missing path' {
                     $expectedErrorMessage = $script:localizedData.ServiceDoesNotExistPathMissingError -f $script:testServiceName
-                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -1113,7 +1113,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and Credential conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $testTargetResourceParameters.Name
-                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
 
                 $testTargetResourceParameters = @{
@@ -1124,7 +1124,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $testTargetResourceParameters.Name
-                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
 
                 $testTargetResourceParameters = @{
@@ -1135,7 +1135,7 @@ try
 
                 It 'Should throw an error for Credential and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $testTargetResourceParameters.Name
-                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw $expectedErrorMessage
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw -ExpectedMessage $expectedErrorMessage
                 }
             }
 
@@ -1797,14 +1797,14 @@ try
                         {
                             It 'Should throw error for conflicting state and startup type' {
                                 $errorMessage = $script:localizedData.StartupTypeStateConflict -f $assertNoStartupTypeStateConflictParameters.ServiceName, $startupTypeValue, $stateValue
-                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should -Throw $errorMessage
+                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should -Throw -ExpectedMessage $errorMessage
                             }
                         }
                         elseif ($stateValue -eq 'Stopped' -and $startupTypeValue -eq 'Automatic')
                         {
                             It 'Should throw error for conflicting state and startup type' {
                                 $errorMessage = $script:localizedData.StartupTypeStateConflict -f $assertNoStartupTypeStateConflictParameters.ServiceName, $startupTypeValue, $stateValue
-                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should -Throw $errorMessage
+                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should -Throw -ExpectedMessage $errorMessage
                             }
                         }
                         else
@@ -1967,7 +1967,7 @@ try
                     It 'Should throw error for failed service path change' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServicePathParameters.ServiceName, 'PathName', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServicePath @setServicePathParameters } | Should -Throw $errorMessage
+                        { Set-ServicePath @setServicePathParameters } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
             }
@@ -2133,7 +2133,7 @@ try
                     It 'Should throw error for failed service path change' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceDependenciesParameters.ServiceName, 'ServiceDependencies', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Throw $errorMessage
+                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
             }
@@ -2420,7 +2420,7 @@ try
                     It 'Should throw an error for service change failure' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceAccountPropertyParameters.ServiceName, 'DesktopInteract', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw $errorMessage
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
 
@@ -2433,7 +2433,7 @@ try
                     It 'Should throw an error for service change failure' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceAccountPropertyParameters.ServiceName, 'StartName, StartPassword', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw $errorMessage
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
 
@@ -2446,7 +2446,7 @@ try
                     It 'Should throw an error for service change failure' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceAccountPropertyParameters.ServiceName, 'StartName, StartPassword', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw $errorMessage
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
             }
@@ -2525,7 +2525,7 @@ try
                     It 'Should throw error for failed service change' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceStartupTypeParameters.ServiceName, 'StartMode', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should -Throw $errorMessage
+                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should -Throw -ExpectedMessage $errorMessage
                     }
                 }
             }
@@ -2908,7 +2908,7 @@ try
 
                 It 'Should throw error for service removal timeout' {
                     $errorMessage = $script:localizedData.ServiceDeletionFailed -f $removeServiceWithTimeoutParameters.Name
-                    { Remove-ServiceWithTimeout @removeServiceWithTimeoutParameters } | Should -Throw $errorMessage
+                    { Remove-ServiceWithTimeout @removeServiceWithTimeoutParameters } | Should -Throw -ExpectedMessage $errorMessage
                 }
             }
         }

--- a/Tests/Unit/MSFT_xServiceResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xServiceResource.Tests.ps1
@@ -129,7 +129,7 @@ try
                 $getTargetResourceResult = Get-TargetResource @GetTargetResourceParameters
 
                 It 'Should return a hashtable' {
-                    $getTargetResourceResult -is [Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [Hashtable] | Should -Be $true
                 }
 
                 if ($ExpectedValues.ContainsKey('Name'))
@@ -476,7 +476,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and Credential conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $setTargetResourceParameters.Name
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
                 }
 
                 $setTargetResourceParameters = @{
@@ -487,7 +487,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $setTargetResourceParameters.Name
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
                 }
 
                 $setTargetResourceParameters = @{
@@ -498,7 +498,7 @@ try
 
                 It 'Should throw an error for Credential and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $setTargetResourceParameters.Name
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
                 }
             }
 
@@ -509,7 +509,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -553,7 +553,7 @@ try
 
                 It 'Should throw an error for the missing path' {
                     $expectedErrorMessage = $script:localizedData.ServiceDoesNotExistPathMissingError -f $script:testServiceName
-                    { Set-TargetResource @setTargetResourceParameters } | Should Throw $expectedErrorMessage
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Throw $expectedErrorMessage
                 }
             }
 
@@ -565,7 +565,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -616,7 +616,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should check for a startup type and state conflict' {
@@ -667,7 +667,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should check for a startup type and state conflict' {
@@ -718,7 +718,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should check for a startup type and state conflict' {
@@ -778,7 +778,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -821,7 +821,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -865,7 +865,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -916,7 +916,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should check for a startup type and state conflict' {
@@ -966,7 +966,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should check for a startup type and state conflict' {
@@ -1010,7 +1010,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1056,7 +1056,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1113,7 +1113,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and Credential conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $testTargetResourceParameters.Name
-                    { Test-TargetResource @testTargetResourceParameters } | Should Throw $expectedErrorMessage
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw $expectedErrorMessage
                 }
 
                 $testTargetResourceParameters = @{
@@ -1124,7 +1124,7 @@ try
 
                 It 'Should throw an error for BuiltInAccount and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $testTargetResourceParameters.Name
-                    { Test-TargetResource @testTargetResourceParameters } | Should Throw $expectedErrorMessage
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw $expectedErrorMessage
                 }
 
                 $testTargetResourceParameters = @{
@@ -1135,7 +1135,7 @@ try
 
                 It 'Should throw an error for Credential and GroupManagedServiceAccount conflict' {
                     $expectedErrorMessage = $script:localizedData.CredentialParametersAreMutallyExclusive -f $testTargetResourceParameters.Name
-                    { Test-TargetResource @testTargetResourceParameters } | Should Throw $expectedErrorMessage
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Throw $expectedErrorMessage
                 }
             }
 
@@ -1146,7 +1146,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1166,7 +1166,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
 
@@ -1177,7 +1177,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1197,7 +1197,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $false
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $false
                 }
             }
 
@@ -1209,7 +1209,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1229,7 +1229,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
 
@@ -1255,7 +1255,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1275,7 +1275,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $false
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $false
                 }
             }
 
@@ -1286,7 +1286,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1306,7 +1306,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
 
@@ -1314,7 +1314,7 @@ try
                 $testTargetResourceParameters = $serviceResourceWithAllProperties
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should check for a startup type and state conflict' {
@@ -1334,7 +1334,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
 
@@ -1358,7 +1358,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                        { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                     }
 
 
@@ -1389,7 +1389,7 @@ try
                     }
 
                     It 'Should return false' {
-                        Test-TargetResource @testTargetResourceParameters | Should Be $false
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $false
                     }
                 }
             }
@@ -1402,7 +1402,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1422,7 +1422,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
 
@@ -1446,7 +1446,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1466,7 +1466,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
 
@@ -1478,7 +1478,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1498,7 +1498,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $false
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $false
                 }
             }
 
@@ -1522,7 +1522,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                        { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                     }
 
                     It 'Should not check for a startup type and state conflict' {
@@ -1542,7 +1542,7 @@ try
                     }
 
                     It 'Should return false' {
-                        Test-TargetResource @testTargetResourceParameters | Should Be $false
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $false
                     }
                 }
             }
@@ -1571,7 +1571,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                        { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                     }
 
                     It 'Should not check for a startup type and state conflict' {
@@ -1591,7 +1591,7 @@ try
                     }
 
                     It 'Should return false' {
-                        Test-TargetResource @testTargetResourceParameters | Should Be $false
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $false
                     }
                 }
 
@@ -1602,7 +1602,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                        { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                     }
 
                     It 'Should not check for a startup type and state conflict' {
@@ -1622,7 +1622,7 @@ try
                     }
 
                     It 'Should return true' {
-                        Test-TargetResource @testTargetResourceParameters | Should Be $true
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $true
                     }
                 }
             }
@@ -1637,7 +1637,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1657,7 +1657,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $false
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $false
                 }
             }
 
@@ -1681,7 +1681,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should not check for a startup type and state conflict' {
@@ -1701,7 +1701,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $false
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $false
                 }
             }
 
@@ -1713,11 +1713,11 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Test-TargetResource @testTargetResourceParameters } | Should Not Throw
+                    { Test-TargetResource @testTargetResourceParameters } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
         }
@@ -1727,7 +1727,7 @@ try
 
             Context 'When a service does not exist' {
                 It 'Should not throw' {
-                    { Get-ServiceCimInstance -ServiceName $script:testServiceName } | Should Not Throw
+                    { Get-ServiceCimInstance -ServiceName $script:testServiceName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the CIM instance of the service with the given name' {
@@ -1735,7 +1735,7 @@ try
                 }
 
                 It 'Should return null' {
-                    Get-ServiceCimInstance -ServiceName $script:testServiceName | Should Be $null
+                    Get-ServiceCimInstance -ServiceName $script:testServiceName | Should -Be $null
                 }
             }
 
@@ -1745,7 +1745,7 @@ try
 
             Context 'When a service exists' {
                 It 'Should not throw' {
-                    { Get-ServiceCimInstance -ServiceName $script:testServiceName } | Should Not Throw
+                    { Get-ServiceCimInstance -ServiceName $script:testServiceName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the CIM instance of the service with the given name' {
@@ -1753,7 +1753,7 @@ try
                 }
 
                 It 'Should return the retrieved CIM instance' {
-                    Get-ServiceCimInstance -ServiceName $script:testServiceName | Should Be $testCimInstance
+                    Get-ServiceCimInstance -ServiceName $script:testServiceName | Should -Be $testCimInstance
                 }
             }
         }
@@ -1761,19 +1761,19 @@ try
         Describe 'xService\ConvertTo-StartupTypeString' {
             Context 'When StartupType is specifed as Auto' {
                 It 'Should return Automatic' {
-                    ConvertTo-StartupTypeString -StartMode 'Auto' | Should Be 'Automatic'
+                    ConvertTo-StartupTypeString -StartMode 'Auto' | Should -Be 'Automatic'
                 }
             }
 
             Context 'When StartupType is specifed as Manual' {
                 It 'Should return Manual' {
-                    ConvertTo-StartupTypeString -StartMode 'Manual' | Should Be 'Manual'
+                    ConvertTo-StartupTypeString -StartMode 'Manual' | Should -Be 'Manual'
                 }
             }
 
             Context 'When StartupType is specifed as Disabled' {
                 It 'Should return Disabled' {
-                    ConvertTo-StartupTypeString -StartMode 'Disabled' | Should Be 'Disabled'
+                    ConvertTo-StartupTypeString -StartMode 'Disabled' | Should -Be 'Disabled'
                 }
             }
         }
@@ -1797,20 +1797,20 @@ try
                         {
                             It 'Should throw error for conflicting state and startup type' {
                                 $errorMessage = $script:localizedData.StartupTypeStateConflict -f $assertNoStartupTypeStateConflictParameters.ServiceName, $startupTypeValue, $stateValue
-                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should Throw $errorMessage
+                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should -Throw $errorMessage
                             }
                         }
                         elseif ($stateValue -eq 'Stopped' -and $startupTypeValue -eq 'Automatic')
                         {
                             It 'Should throw error for conflicting state and startup type' {
                                 $errorMessage = $script:localizedData.StartupTypeStateConflict -f $assertNoStartupTypeStateConflictParameters.ServiceName, $startupTypeValue, $stateValue
-                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should Throw $errorMessage
+                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should -Throw $errorMessage
                             }
                         }
                         else
                         {
                             It 'Should not throw' {
-                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should Not Throw
+                                { Assert-NoStartupTypeStateConflict @assertNoStartupTypeStateConflictParameters } | Should -Not -Throw
                             }
                         }
                     }
@@ -1822,13 +1822,13 @@ try
             Context 'When Specified paths match' {
                 It 'Should return true' {
                     $matchingPath = 'MatchingPath'
-                    Test-PathsMatch -ExpectedPath $matchingPath -ActualPath $matchingPath | Should Be $true
+                    Test-PathsMatch -ExpectedPath $matchingPath -ActualPath $matchingPath | Should -Be $true
                 }
             }
 
             Context 'When Specified paths do not match' {
                 It 'Should return false' {
-                    Test-PathsMatch -ExpectedPath 'Path1' -ActualPath 'Path2' | Should Be $false
+                    Test-PathsMatch -ExpectedPath 'Path1' -ActualPath 'Path2' | Should -Be $false
                 }
             }
         }
@@ -1836,26 +1836,26 @@ try
         Describe 'xService\ConvertTo-StartName' {
             Context 'When Username is specified as LocalSystem' {
                 It 'Should return .\LocalSystem' {
-                    ConvertTo-StartName -Username 'LocalSystem' | Should Be '.\LocalSystem'
+                    ConvertTo-StartName -Username 'LocalSystem' | Should -Be '.\LocalSystem'
                 }
             }
 
             Context 'When Username is specified as LocalService' {
                 It 'Should return NT Authority\LocalService' {
-                    ConvertTo-StartName -Username 'LocalService' | Should Be 'NT Authority\LocalService'
+                    ConvertTo-StartName -Username 'LocalService' | Should -Be 'NT Authority\LocalService'
                 }
             }
 
             Context 'When Username is specified as NetworkService' {
                 It 'Should return NT Authority\NetworkService' {
-                    ConvertTo-StartName -Username 'NetworkService' | Should Be 'NT Authority\NetworkService'
+                    ConvertTo-StartName -Username 'NetworkService' | Should -Be 'NT Authority\NetworkService'
                 }
             }
 
             Context 'When custom username is specified without any \ or @ characters' {
                 It 'Should return custom username prefixed with .\' {
                     $customUsername = 'TestUsername'
-                    ConvertTo-StartName -Username $customUsername | Should Be ".\$customUsername"
+                    ConvertTo-StartName -Username $customUsername | Should -Be ".\$customUsername"
                 }
             }
 
@@ -1863,21 +1863,21 @@ try
                 It 'Should return custom username prefixed with .\ instead of the local computer name' {
                     $customUsername = 'TestUsername'
                     $customUsernameWithComputerNamePrefix = "$env:computerName\$customUsername"
-                    ConvertTo-StartName -Username $customUsernameWithComputerNamePrefix | Should Be ".\$customUsername"
+                    ConvertTo-StartName -Username $customUsernameWithComputerNamePrefix | Should -Be ".\$customUsername"
                 }
             }
 
             Context 'When custom username is specified with a \ character and a custom domain' {
                 It 'Should return the custom username with no changes' {
                     $customUsername = 'TestDomain\TestUsername'
-                    ConvertTo-StartName -Username $customUsername | Should Be $customUsername
+                    ConvertTo-StartName -Username $customUsername | Should -Be $customUsername
                 }
             }
 
             Context 'When custom username is specified with an @ character' {
                 It 'Should return the custom username with no changes' {
                     $customUsername = 'TestUsername@TestDomain'
-                    ConvertTo-StartName -Username $customUsername | Should Be $customUsername
+                    ConvertTo-StartName -Username $customUsername | Should -Be $customUsername
                 }
             }
         }
@@ -1903,7 +1903,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServicePath @setServicePathParameters } | Should Not Throw
+                        { Set-ServicePath @setServicePathParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service CIM instance' {
@@ -1919,7 +1919,7 @@ try
                     }
 
                     It 'Should return false' {
-                        Set-ServicePath @setServicePathParameters | Should Be $false
+                        Set-ServicePath @setServicePathParameters | Should -Be $false
                     }
                 }
 
@@ -1932,7 +1932,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServicePath @setServicePathParameters } | Should Not Throw
+                        { Set-ServicePath @setServicePathParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service CIM instance' {
@@ -1948,7 +1948,7 @@ try
                     }
 
                     It 'Should return true' {
-                        Set-ServicePath @setServicePathParameters | Should Be $true
+                        Set-ServicePath @setServicePathParameters | Should -Be $true
                     }
                 }
 
@@ -1967,7 +1967,7 @@ try
                     It 'Should throw error for failed service path change' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServicePathParameters.ServiceName, 'PathName', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServicePath @setServicePathParameters } | Should Throw $errorMessage
+                        { Set-ServicePath @setServicePathParameters } | Should -Throw $errorMessage
                     }
                 }
             }
@@ -2004,7 +2004,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should Not Throw
+                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service' {
@@ -2027,7 +2027,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should Not Throw
+                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service' {
@@ -2050,7 +2050,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should Not Throw
+                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service' {
@@ -2079,7 +2079,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should Not Throw
+                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service' {
@@ -2102,7 +2102,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should Not Throw
+                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service' {
@@ -2133,7 +2133,7 @@ try
                     It 'Should throw error for failed service path change' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceDependenciesParameters.ServiceName, 'ServiceDependencies', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should Throw $errorMessage
+                        { Set-ServiceDependency @setServiceDependenciesParameters } | Should -Throw $errorMessage
                     }
                 }
             }
@@ -2163,7 +2163,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2190,7 +2190,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2217,7 +2217,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2247,7 +2247,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2274,7 +2274,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2301,7 +2301,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2328,7 +2328,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2358,7 +2358,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2385,7 +2385,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Not Throw
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve service CIM instance' {
@@ -2420,7 +2420,7 @@ try
                     It 'Should throw an error for service change failure' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceAccountPropertyParameters.ServiceName, 'DesktopInteract', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Throw $errorMessage
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw $errorMessage
                     }
                 }
 
@@ -2433,7 +2433,7 @@ try
                     It 'Should throw an error for service change failure' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceAccountPropertyParameters.ServiceName, 'StartName, StartPassword', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Throw $errorMessage
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw $errorMessage
                     }
                 }
 
@@ -2446,7 +2446,7 @@ try
                     It 'Should throw an error for service change failure' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceAccountPropertyParameters.ServiceName, 'StartName, StartPassword', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should Throw $errorMessage
+                        { Set-ServiceAccountProperty @setServiceAccountPropertyParameters } | Should -Throw $errorMessage
                     }
                 }
             }
@@ -2479,7 +2479,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should Not Throw
+                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service CIM instance' {
@@ -2498,7 +2498,7 @@ try
                     }
 
                     It 'Should not throw' {
-                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should Not Throw
+                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should -Not -Throw
                     }
 
                     It 'Should retrieve the service CIM instance' {
@@ -2525,7 +2525,7 @@ try
                     It 'Should throw error for failed service change' {
                         $errorMessage = $script:localizedData.InvokeCimMethodFailed -f 'Change', $setServiceStartupTypeParameters.ServiceName, 'StartMode', $invokeCimMethodFailResult.ReturnValue
 
-                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should Throw $errorMessage
+                        { Set-ServiceStartupType @setServiceStartupTypeParameters } | Should -Throw $errorMessage
                     }
                 }
             }
@@ -2556,7 +2556,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2587,7 +2587,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2618,7 +2618,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2650,7 +2650,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2681,7 +2681,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2725,7 +2725,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2756,7 +2756,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2787,7 +2787,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2819,7 +2819,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2850,7 +2850,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Set-ServiceProperty @setServicePropertyParameters } | Should Not Throw
+                    { Set-ServiceProperty @setServicePropertyParameters } | Should -Not -Throw
                 }
 
                 It 'Should retrieve service CIM instance' {
@@ -2886,7 +2886,7 @@ try
                 }
 
                 It 'Should not throw' {
-                    { Remove-ServiceWithTimeout @removeServiceWithTimeoutParameters } | Should Not Throw
+                    { Remove-ServiceWithTimeout @removeServiceWithTimeoutParameters } | Should -Not -Throw
                 }
 
                 It 'Should remove service' {
@@ -2908,7 +2908,7 @@ try
 
                 It 'Should throw error for service removal timeout' {
                     $errorMessage = $script:localizedData.ServiceDeletionFailed -f $removeServiceWithTimeoutParameters.Name
-                    { Remove-ServiceWithTimeout @removeServiceWithTimeoutParameters } | Should Throw $errorMessage
+                    { Remove-ServiceWithTimeout @removeServiceWithTimeoutParameters } | Should -Throw $errorMessage
                 }
             }
         }
@@ -2925,7 +2925,7 @@ try
             $expectedTimeSpan = [TimeSpan]::FromMilliseconds($startServiceWithTimeoutParameters.StartupTimeout)
 
             It 'Should not throw' {
-                { Start-ServiceWithTimeout @startServiceWithTimeoutParameters } | Should Not Throw
+                { Start-ServiceWithTimeout @startServiceWithTimeoutParameters } | Should -Not -Throw
             }
 
             It 'Should start service' {
@@ -2949,7 +2949,7 @@ try
             $expectedTimeSpan = [TimeSpan]::FromMilliseconds($stopServiceWithTimeoutParameters.TerminateTimeout)
 
             It 'Should not throw' {
-                { Stop-ServiceWithTimeout @stopServiceWithTimeoutParameters } | Should Not Throw
+                { Stop-ServiceWithTimeout @stopServiceWithTimeoutParameters } | Should -Not -Throw
             }
 
             It 'Should stop service' {

--- a/Tests/Unit/MSFT_xUserResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xUserResource.Tests.ps1
@@ -61,17 +61,17 @@ try {
                     It 'Should return the user as Present' {
                         $getTargetResourceResult = Get-TargetResource $existingUserName
 
-                        $getTargetResourceResult['UserName']                | Should Be $existingUserName
-                        $getTargetResourceResult['Ensure']                  | Should Be 'Present'
-                        $getTargetResourceResult['Description']             | Should Be $existingDescription
-                        $getTargetResourceResult['PasswordChangeRequired']  | Should Be $null
+                        $getTargetResourceResult['UserName']                | Should -Be $existingUserName
+                        $getTargetResourceResult['Ensure']                  | Should -Be 'Present'
+                        $getTargetResourceResult['Description']             | Should -Be $existingDescription
+                        $getTargetResourceResult['PasswordChangeRequired']  | Should -Be $null
                     }
 
                     It 'Should return the user as Absent' {
                         $getTargetResourceResult = Get-TargetResource 'NotAUserName'
 
-                        $getTargetResourceResult['UserName']                | Should Be 'NotAUserName'
-                        $getTargetResourceResult['Ensure']                  | Should Be 'Absent'
+                        $getTargetResourceResult['UserName']                | Should -Be 'NotAUserName'
+                        $getTargetResourceResult['Ensure']                  | Should -Be 'Absent'
                     }
                 }
 
@@ -81,17 +81,17 @@ try {
                     It 'Should return the user as Present on Nano Server' -Skip:$script:skipMe {
                         $getTargetResourceResult = Get-TargetResource $existingUserName
 
-                        $getTargetResourceResult['UserName']                | Should Be $existingUserName
-                        $getTargetResourceResult['Ensure']                  | Should Be 'Present'
-                        $getTargetResourceResult['Description']             | Should Be $existingDescription
-                        $getTargetResourceResult['PasswordChangeRequired']  | Should Be $null
+                        $getTargetResourceResult['UserName']                | Should -Be $existingUserName
+                        $getTargetResourceResult['Ensure']                  | Should -Be 'Present'
+                        $getTargetResourceResult['Description']             | Should -Be $existingDescription
+                        $getTargetResourceResult['PasswordChangeRequired']  | Should -Be $null
                     }
 
                     It 'Should return the user as Absent' -Skip:$script:skipMe {
                         $getTargetResourceResult = Get-TargetResource 'NotAUserName'
 
-                        $getTargetResourceResult['UserName']                | Should Be 'NotAUserName'
-                        $getTargetResourceResult['Ensure']                  | Should Be 'Absent'
+                        $getTargetResourceResult['UserName']                | Should -Be 'NotAUserName'
+                        $getTargetResourceResult['Ensure']                  | Should -Be 'Absent'
                     }
                 }
             }
@@ -105,14 +105,14 @@ try {
                         New-User -Credential $newCredential1 -Description $newUserDescription1
 
                         It 'Should remove the user' {
-                            Test-User -UserName $newUserName1 | Should Be $true
+                            Test-User -UserName $newUserName1 | Should -Be $true
                             Set-TargetResource -UserName $newUserName1 -Ensure 'Absent'
-                            Test-User -UserName $newUserName1 | Should Be $false
+                            Test-User -UserName $newUserName1 | Should -Be $false
                         }
 
                         It 'Should add the new user' {
                             Set-TargetResource -UserName $newUserName2 -Password $newCredential2 -Ensure 'Present'
-                            Test-User -UserName $newUserName2 | Should Be $true
+                            Test-User -UserName $newUserName2 | Should -Be $true
                         }
 
                         It 'Should update the user' {
@@ -131,7 +131,7 @@ try {
                                                -PasswordChangeRequired $passwordChangeRequired `
                                                -PasswordChangeNotAllowed $passwordChangeNotAllowed
 
-                            Test-User -UserName $newUserName2 | Should Be $true
+                            Test-User -UserName $newUserName2 | Should -Be $true
                             $testTargetResourceResult1 =
                                     Test-TargetResource -UserName $newUserName2 `
                                                         -Password $newCredential2 `
@@ -141,7 +141,7 @@ try {
                                                         -Disabled $disabled `
                                                         -PasswordNeverExpires $passwordNeverExpires `
                                                         -PasswordChangeNotAllowed $passwordChangeNotAllowed
-                            $testTargetResourceResult1 | Should Be $true
+                            $testTargetResourceResult1 | Should -Be $true
                         }
                         It 'Should update the user again with different values' {
                             $disabled = $false
@@ -159,7 +159,7 @@ try {
                                                -PasswordChangeRequired $passwordChangeRequired `
                                                -PasswordChangeNotAllowed $passwordChangeNotAllowed
 
-                            Test-User -UserName $newUserName2 | Should Be $true
+                            Test-User -UserName $newUserName2 | Should -Be $true
                             $testTargetResourceResult2 =
                                     Test-TargetResource -UserName $newUserName2 `
                                                         -Password $newCredential1 `
@@ -169,7 +169,7 @@ try {
                                                         -Disabled $disabled `
                                                         -PasswordNeverExpires $passwordNeverExpires `
                                                         -PasswordChangeNotAllowed $passwordChangeNotAllowed
-                            $testTargetResourceResult2 | Should Be $true
+                            $testTargetResourceResult2 | Should -Be $true
                         }
                     }
                     finally
@@ -188,14 +188,14 @@ try {
                         New-User -Credential $newCredential1 -Description $newUserDescription1
 
                         It 'Should remove the user' -Skip:$script:skipMe {
-                            Test-User -UserName $newUserName1 | Should Be $true
+                            Test-User -UserName $newUserName1 | Should -Be $true
                             Set-TargetResource -UserName $newUserName1 -Ensure 'Absent'
-                            Test-User -UserName $newUserName1 | Should Be $false
+                            Test-User -UserName $newUserName1 | Should -Be $false
                         }
 
                         It 'Should add the new user' -Skip:$script:skipMe {
                             Set-TargetResource -UserName $newUserName2 -Password $newCredential2 -Ensure 'Present'
-                            Test-User -UserName $newUserName2 | Should Be $true
+                            Test-User -UserName $newUserName2 | Should -Be $true
                         }
 
                         It 'Should update the user' -Skip:$script:skipMe {
@@ -214,7 +214,7 @@ try {
                                                -PasswordChangeRequired $passwordChangeRequired `
                                                -PasswordChangeNotAllowed $passwordChangeNotAllowed
 
-                            Test-User -UserName $newUserName2 | Should Be $true
+                            Test-User -UserName $newUserName2 | Should -Be $true
                             $testTargetResourceResult1 =
                                     Test-TargetResource -UserName $newUserName2 `
                                                         -Password $newCredential2 `
@@ -224,7 +224,7 @@ try {
                                                         -Disabled $disabled `
                                                         -PasswordNeverExpires $passwordNeverExpires `
                                                         -PasswordChangeNotAllowed $passwordChangeNotAllowed
-                            $testTargetResourceResult1 | Should Be $true
+                            $testTargetResourceResult1 | Should -Be $true
                         }
                         It 'Should update the user again with different values' -Skip:$script:skipMe {
                             $disabled = $false
@@ -242,7 +242,7 @@ try {
                                                -PasswordChangeRequired $passwordChangeRequired `
                                                -PasswordChangeNotAllowed $passwordChangeNotAllowed
 
-                            Test-User -UserName $newUserName2 | Should Be $true
+                            Test-User -UserName $newUserName2 | Should -Be $true
                             $testTargetResourceResult2 =
                                     Test-TargetResource -UserName $newUserName2 `
                                                         -Password $newCredential1 `
@@ -252,7 +252,7 @@ try {
                                                         -Disabled $disabled `
                                                         -PasswordNeverExpires $passwordNeverExpires `
                                                         -PasswordChangeNotAllowed $passwordChangeNotAllowed
-                            $testTargetResourceResult2 | Should Be $true
+                            $testTargetResourceResult2 | Should -Be $true
                         }
                     }
                     finally
@@ -275,25 +275,25 @@ try {
                                                                         -Disabled $false `
                                                                         -PasswordNeverExpires $false `
                                                                         -PasswordChangeNotAllowed $false
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
 
                     It 'Should return true when user Absent and Ensure = Absent' {
                         $testTargetResourceResult = Test-TargetResource -UserName $absentUserName `
                                                                         -Ensure 'Absent'
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
 
                     It 'Should return false when user Absent and Ensure = Present' {
                         $testTargetResourceResult = Test-TargetResource -UserName $absentUserName `
                                                                         -Ensure 'Present'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when user Present and Ensure = Absent' {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Ensure 'Absent'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when Password is wrong' {
@@ -303,37 +303,37 @@ try {
 
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Password $badTestCredential
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when user Present and wrong Description' {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Description 'Wrong description'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when FullName is incorrect' {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -FullName 'Wrong FullName'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when Disabled is incorrect' {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Disabled $true
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when PasswordNeverExpires is incorrect' {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -PasswordNeverExpires $true
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when PasswordChangeNotAllowed is incorrect' {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -PasswordChangeNotAllowed $true
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
 
@@ -351,25 +351,25 @@ try {
                                                                         -Disabled $false `
                                                                         -PasswordNeverExpires $false `
                                                                         -PasswordChangeNotAllowed $false
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
 
                     It 'Should return true when user Absent and Ensure = Absent' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $absentUserName `
                                                                         -Ensure 'Absent'
-                        $testTargetResourceResult | Should Be $true
+                        $testTargetResourceResult | Should -Be $true
                     }
 
                     It 'Should return false when user Absent and Ensure = Present' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $absentUserName `
                                                                         -Ensure 'Present'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when user Present and Ensure = Absent' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Ensure 'Absent'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when Password is wrong' -Skip:$script:skipMe {
@@ -381,44 +381,44 @@ try {
 
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Password $badTestCredential
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when user Present and wrong Description' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Description 'Wrong description'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when FullName is incorrect' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -FullName 'Wrong FullName'
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when Disabled is incorrect' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -Disabled $true
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when PasswordNeverExpires is incorrect' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -PasswordNeverExpires $true
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
 
                     It 'Should return false when PasswordChangeNotAllowed is incorrect' -Skip:$script:skipMe {
                         $testTargetResourceResult = Test-TargetResource -UserName $existingUserName `
                                                                         -PasswordChangeNotAllowed $true
-                        $testTargetResourceResult | Should Be $false
+                        $testTargetResourceResult | Should -Be $false
                     }
                 }
             }
 
             Describe 'xUserResource/Assert-UserNameValid' {
                 It 'Should not throw when username contains all valid chars' {
-                    { Assert-UserNameValid -UserName 'abc123456!f_t-l098s' } | Should Not Throw
+                    { Assert-UserNameValid -UserName 'abc123456!f_t-l098s' } | Should -Not -Throw
                 }
 
                 It 'Should throw InvalidArgumentError when username contains only whitespace and dots' {
@@ -428,7 +428,7 @@ try {
                     $errorMessage = "The name $invalidName cannot be used."
                     $exception = New-Object System.ArgumentException $errorMessage;
                     $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $null
-                    { Assert-UserNameValid -UserName $invalidName } | Should Throw $errorRecord
+                    { Assert-UserNameValid -UserName $invalidName } | Should -Throw $errorRecord
                 }
 
                 It 'Should throw InvalidArgumentError when username contains an invalid char' {
@@ -438,7 +438,7 @@ try {
                     $errorMessage = "The name $invalidName cannot be used."
                     $exception = New-Object System.ArgumentException $errorMessage;
                     $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $null
-                    { Assert-UserNameValid -UserName $invalidName } | Should Throw $errorRecord
+                    { Assert-UserNameValid -UserName $invalidName } | Should -Throw $errorRecord
                 }
             }
         }

--- a/Tests/Unit/MSFT_xUserResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xUserResource.Tests.ps1
@@ -428,7 +428,7 @@ try {
                     $errorMessage = "The name $invalidName cannot be used."
                     $exception = New-Object System.ArgumentException $errorMessage;
                     $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $null
-                    { Assert-UserNameValid -UserName $invalidName } | Should -Throw $errorRecord
+                    { Assert-UserNameValid -UserName $invalidName } | Should -Throw -ExpectedMessage $errorRecord
                 }
 
                 It 'Should throw InvalidArgumentError when username contains an invalid char' {
@@ -438,7 +438,7 @@ try {
                     $errorMessage = "The name $invalidName cannot be used."
                     $exception = New-Object System.ArgumentException $errorMessage;
                     $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $null
-                    { Assert-UserNameValid -UserName $invalidName } | Should -Throw $errorRecord
+                    { Assert-UserNameValid -UserName $invalidName } | Should -Throw -ExpectedMessage $errorRecord
                 }
             }
         }

--- a/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsFeature.Tests.ps1
@@ -189,20 +189,20 @@ try {
                     Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $false }
 
                     $getTargetResourceResult = Get-TargetResource -Name $testWindowsFeatureName2
-                    $getTargetResourceResult.Name | Should Be $testWindowsFeatureName2
-                    $getTargetResourceResult.DisplayName | Should Be $mockWindowsFeatures[$testWindowsFeatureName2].DisplayName
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
-                    $getTargetResourceResult.IncludeAllSubFeature | Should Be $false
+                    $getTargetResourceResult.Name | Should -Be $testWindowsFeatureName2
+                    $getTargetResourceResult.DisplayName | Should -Be $mockWindowsFeatures[$testWindowsFeatureName2].DisplayName
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
+                    $getTargetResourceResult.IncludeAllSubFeature | Should -Be $false
                 }
 
                 It 'Should return the correct hashtable when on a 2008 Server' {
                     Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $true }
 
                     $getTargetResourceResult = Get-TargetResource -Name $testWindowsFeatureName2
-                    $getTargetResourceResult.Name | Should Be $testWindowsFeatureName2
-                    $getTargetResourceResult.DisplayName | Should Be $mockWindowsFeatures[$testWindowsFeatureName2].DisplayName
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
-                    $getTargetResourceResult.IncludeAllSubFeature | Should Be $false
+                    $getTargetResourceResult.Name | Should -Be $testWindowsFeatureName2
+                    $getTargetResourceResult.DisplayName | Should -Be $mockWindowsFeatures[$testWindowsFeatureName2].DisplayName
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
+                    $getTargetResourceResult.IncludeAllSubFeature | Should -Be $false
                 }
 
                 It 'Should return the correct hashtable when on a 2008 Server and Credential is passed' {
@@ -216,10 +216,10 @@ try {
                     }
 
                     $getTargetResourceResult = Get-TargetResource -Name $testWindowsFeatureName2 -Credential $testCredential
-                    $getTargetResourceResult.Name | Should Be $testWindowsFeatureName2
-                    $getTargetResourceResult.DisplayName | Should Be $mockWindowsFeatures[$testWindowsFeatureName2].DisplayName
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
-                    $getTargetResourceResult.IncludeAllSubFeature | Should Be $false
+                    $getTargetResourceResult.Name | Should -Be $testWindowsFeatureName2
+                    $getTargetResourceResult.DisplayName | Should -Be $mockWindowsFeatures[$testWindowsFeatureName2].DisplayName
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
+                    $getTargetResourceResult.IncludeAllSubFeature | Should -Be $false
 
                     Assert-MockCalled -CommandName Invoke-Command -Times 1 -Exactly -Scope It
 
@@ -231,10 +231,10 @@ try {
                     Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $false }
 
                     $getTargetResourceResult = Get-TargetResource -Name $testWindowsFeatureName1
-                    $getTargetResourceResult.Name | Should Be $testWindowsFeatureName1
-                    $getTargetResourceResult.DisplayName | Should Be $mockWindowsFeatures[$testWindowsFeatureName1].DisplayName
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
-                    $getTargetResourceResult.IncludeAllSubFeature | Should Be $true
+                    $getTargetResourceResult.Name | Should -Be $testWindowsFeatureName1
+                    $getTargetResourceResult.DisplayName | Should -Be $mockWindowsFeatures[$testWindowsFeatureName1].DisplayName
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                    $getTargetResourceResult.IncludeAllSubFeature | Should -Be $true
 
                     Assert-MockCalled -CommandName Test-IsWinServer2008R2SP1 -Times 1 -Exactly -Scope It
                 }
@@ -244,10 +244,10 @@ try {
                     $mockWindowsFeatures[$testSubFeatureName3].Installed = $false
 
                     $getTargetResourceResult = Get-TargetResource -Name $testWindowsFeatureName1
-                    $getTargetResourceResult.Name | Should Be $testWindowsFeatureName1
-                    $getTargetResourceResult.DisplayName | Should Be $mockWindowsFeatures[$testWindowsFeatureName1].DisplayName
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
-                    $getTargetResourceResult.IncludeAllSubFeature | Should Be $false
+                    $getTargetResourceResult.Name | Should -Be $testWindowsFeatureName1
+                    $getTargetResourceResult.DisplayName | Should -Be $mockWindowsFeatures[$testWindowsFeatureName1].DisplayName
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                    $getTargetResourceResult.IncludeAllSubFeature | Should -Be $false
 
                     Assert-MockCalled -CommandName Test-IsWinServer2008R2SP1 -Times 1 -Exactly -Scope It
 
@@ -260,7 +260,7 @@ try {
                 It 'Should throw invalid operation exception' {
                     Mock -CommandName Test-IsWinServer2008R2SP1 -MockWith { return $false }
                     $invalidName = 'InvalidFeature'
-                    { Get-TargetResource -Name $invalidName } | Should Throw ($script:localizedData.FeatureNotFoundError -f $invalidName)
+                    { Get-TargetResource -Name $invalidName } | Should -Throw ($script:localizedData.FeatureNotFoundError -f $invalidName)
                 }
             }
         }
@@ -298,12 +298,12 @@ try {
                 }
 
                 It 'Should call Add-WindowsFeature when Ensure set to Present' {
-                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Present' } | Should Not Throw
+                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Present' } | Should -Not -Throw
                     Assert-MockCalled -CommandName Add-WindowsFeature -Times 1 -Exactly -Scope It
                 }
 
                 It 'Should call Remove-WindowsFeature when Ensure set to Absent' {
-                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Absent' } | Should Not Throw
+                    { Set-TargetResource -Name $testWindowsFeatureName2 -Ensure 'Absent' } | Should -Not -Throw
                     Assert-MockCalled -CommandName Remove-WindowsFeature -Times 1 -Exactly -Scope It
                 }
 
@@ -377,7 +377,7 @@ try {
                         Set-TargetResource -Name $testWindowsFeatureName2 `
                                            -Ensure 'Present' `
                                            -Credential $testCredential
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                     Assert-MockCalled -CommandName Invoke-Command -Times 1 -Exactly -Scope It
                     Assert-MockCalled -CommandName Add-WindowsFeature -Times 0 -Scope It
                 }
@@ -388,7 +388,7 @@ try {
                         Set-TargetResource -Name $testWindowsFeatureName2 `
                                            -Ensure 'Absent' `
                                            -Credential $testCredential
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                     Assert-MockCalled -CommandName Invoke-Command -Times 1 -Exactly -Scope It
                     Assert-MockCalled -CommandName Remove-WindowsFeature -Times 0 -Scope It
                 }
@@ -447,7 +447,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Absent' `
                                                   -IncludeAllSubFeature $false
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 1 -Exactly -Scope It
                 }
 
@@ -458,7 +458,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Present' `
                                                   -IncludeAllSubFeature $false
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 1 -Exactly -Scope It
                     $mockWindowsFeatures[$testWindowsFeatureName1].Installed = $false
                 }
@@ -470,7 +470,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Present' `
                                                   -IncludeAllSubFeature $true
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 4 -Exactly -Scope It
                     $mockWindowsFeatures[$testWindowsFeatureName1].Installed = $false
                 }
@@ -482,7 +482,7 @@ try {
                                                   -Ensure 'Absent' `
                                                   -IncludeAllSubFeature $false `
                                                   -Credential $testCredential
-                    $testTargetResourceResult | Should Be $true
+                    $testTargetResourceResult | Should -Be $true
                     Assert-MockCalled -CommandName Invoke-Command -Times 1 -Exactly -Scope It
                 }
             }
@@ -494,7 +494,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Present' `
                                                   -IncludeAllSubFeature $false
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 1 -Exactly -Scope It
                 }
 
@@ -503,7 +503,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Absent' `
                                                   -IncludeAllSubFeature $false
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 1 -Exactly -Scope It
                     $mockWindowsFeatures[$testWindowsFeatureName1].Installed = $false
                 }
@@ -512,7 +512,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Present' `
                                                   -IncludeAllSubFeature $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 1 -Exactly -Scope It
                 }
 
@@ -520,7 +520,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Absent' `
                                                   -IncludeAllSubFeature $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 2 -Exactly -Scope It
                 }
 
@@ -529,7 +529,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Absent' `
                                                   -IncludeAllSubFeature $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 1 -Exactly -Scope It
                     $mockWindowsFeatures[$testWindowsFeatureName1].Installed = $false
                 }
@@ -540,7 +540,7 @@ try {
                     $testTargetResourceResult = Test-TargetResource -Name $testWindowsFeatureName1 `
                                                   -Ensure 'Present' `
                                                   -IncludeAllSubFeature $true
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                     Assert-MockCalled -CommandName Get-WindowsFeature -Times 3 -Exactly -Scope It
                     $mockWindowsFeatures[$testWindowsFeatureName1].Installed = $false
                     $mockWindowsFeatures[$testSubFeatureName2].Installed = $true
@@ -553,7 +553,7 @@ try {
                                                   -Ensure 'Present' `
                                                   -IncludeAllSubFeature $false `
                                                   -Credential $testCredential
-                    $testTargetResourceResult | Should Be $false
+                    $testTargetResourceResult | Should -Be $false
                     Assert-MockCalled -CommandName Invoke-Command -Times 1 -Exactly -Scope It
                 }
             }
@@ -587,27 +587,27 @@ try {
 
             It 'Should Not Throw' {
                 Mock -CommandName Import-Module -MockWith {}
-                { Import-ServerManager } | Should Not Throw
+                { Import-ServerManager } | Should -Not -Throw
             }
 
             It 'Should Not Throw when exception is Identity Reference Runtime Exception' {
                 $mockIdentityReferenceRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Some or all identity references could not be translated'
                 Mock -CommandName Import-Module -MockWith { Throw $mockIdentityReferenceRuntimeException }
 
-                { Import-ServerManager } | Should Not Throw
+                { Import-ServerManager } | Should -Not -Throw
             }
 
             It 'Should throw invalid operation exception when exception is not Identity Reference Runtime Exception' {
                 $mockOtherRuntimeException = New-Object -TypeName System.Management.Automation.RuntimeException -ArgumentList 'Other error'
                 Mock -CommandName Import-Module -MockWith { Throw $mockOtherRuntimeException }
 
-                { Import-ServerManager } | Should Throw ($script:localizedData.SkuNotSupported)
+                { Import-ServerManager } | Should -Throw ($script:localizedData.SkuNotSupported)
             }
 
             It 'Should throw invalid operation exception' {
                 Mock -CommandName Import-Module -MockWith { Throw }
 
-                { Import-ServerManager } | Should Throw ($script:localizedData.SkuNotSupported)
+                { Import-ServerManager } | Should -Throw ($script:localizedData.SkuNotSupported)
             }
         }
     }

--- a/Tests/Unit/MSFT_xWindowsOptionalFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsOptionalFeature.Tests.ps1
@@ -65,34 +65,34 @@ try
 
                 It 'Should throw when the DISM module is not available' {
                     Mock Import-Module -ParameterFilter { $Name -eq 'Dism' } -MockWith { Write-Error 'Cannot find module' }
-                    { Assert-ResourcePrerequisitesValid } | Should Throw $script:localizedData.DismNotAvailable
+                    { Assert-ResourcePrerequisitesValid } | Should -Throw $script:localizedData.DismNotAvailable
                 }
 
                 Mock Import-Module -ParameterFilter { $Name -eq 'Dism' } -MockWith { }
 
                 It 'Should throw when operating system is Server 2008 R2' {
                     Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -MockWith { return $fakeWin32OSObjects['Server2008R2'] }
-                    { Assert-ResourcePrerequisitesValid } | Should Throw $script:localizedData.NotSupportedSku
+                    { Assert-ResourcePrerequisitesValid } | Should -Throw $script:localizedData.NotSupportedSku
                 }
 
                 It 'Should throw when operating system is Server 2012' {
                     Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -MockWith { return $fakeWin32OSObjects['Server2012'] }
-                    { Assert-ResourcePrerequisitesValid } | Should Throw $script:localizedData.NotSupportedSku
+                    { Assert-ResourcePrerequisitesValid } | Should -Throw $script:localizedData.NotSupportedSku
                 }
 
                 It 'Should not throw when operating system is Windows 7' {
                     Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -MockWith { return $fakeWin32OSObjects['7'] }
-                    { Assert-ResourcePrerequisitesValid } | Should Not Throw
+                    { Assert-ResourcePrerequisitesValid } | Should -Not -Throw
                 }
 
                 It 'Should not throw when operating system is Windows 8.1' {
                     Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -MockWith { return $fakeWin32OSObjects['8.1'] }
-                    { Assert-ResourcePrerequisitesValid } | Should Not Throw
+                    { Assert-ResourcePrerequisitesValid } | Should -Not -Throw
                 }
 
                 It 'Should not throw when operating system is Server 2012 R2' {
                     Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -MockWith { return $fakeWin32OSObjects['Server2012R2'] }
-                    { Assert-ResourcePrerequisitesValid } | Should Not Throw
+                    { Assert-ResourcePrerequisitesValid } | Should -Not -Throw
                 }
             }
 
@@ -102,7 +102,7 @@ try
 
                 It 'Should return a Hashtable' {
                     $getTargetResourceResult = Get-TargetResource -Name $script:testFeatureName
-                    $getTargetResourceResult -is [System.Collections.Hashtable] | Should Be $true
+                    $getTargetResourceResult -is [System.Collections.Hashtable] | Should -Be $true
                 }
 
                 It 'Should call Assert-ResourcePrerequisitesValid with the feature name' {
@@ -112,7 +112,7 @@ try
 
                 It 'Should return Ensure as Present' {
                     $getTargetResourceResult = Get-TargetResource -Name $script:testFeatureName
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
                 }
             }
 
@@ -123,7 +123,7 @@ try
 
                 It 'Should return Ensure as Absent' {
                     $getTargetResourceResult = Get-TargetResource -Name $script:testFeatureName
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
                 }
             }
 
@@ -132,11 +132,11 @@ try
                 Mock Dism\Get-WindowsOptionalFeature { $FeatureName -eq $script:testFeatureName } -MockWith { return $script:fakeEnabledFeature }
 
                 It 'Should return true when Ensure set to Present' {
-                    Test-TargetResource -Name $testFeatureName -Ensure 'Present' | Should Be $true
+                    Test-TargetResource -Name $testFeatureName -Ensure 'Present' | Should -Be $true
                 }
 
                 It 'Should return false when Ensure set to Absent' {
-                    Test-TargetResource -Name $testFeatureName -Ensure 'Absent' | Should Be $false
+                    Test-TargetResource -Name $testFeatureName -Ensure 'Absent' | Should -Be $false
                 }
 
             }
@@ -146,11 +146,11 @@ try
                 Mock Dism\Get-WindowsOptionalFeature { $FeatureName -eq $script:testFeatureName } -MockWith { return $script:fakeDisabledFeature }
 
                 It 'Should return false when Ensure set to Present' {
-                    Test-TargetResource -Name $testFeatureName -Ensure 'Present' | Should Be $false
+                    Test-TargetResource -Name $testFeatureName -Ensure 'Present' | Should -Be $false
                 }
 
                 It 'Should return true when Ensure set to Absent' {
-                    Test-TargetResource -Name $testFeatureName -Ensure 'Absent' | Should Be $true
+                    Test-TargetResource -Name $testFeatureName -Ensure 'Absent' | Should -Be $true
                 }
             }
 
@@ -159,11 +159,11 @@ try
                 Mock Dism\Get-WindowsOptionalFeature { $FeatureName -eq $script:testFeatureName } -MockWith { }
 
                 It 'Should return false when Ensure set to Present' {
-                    Test-TargetResource -Name $testFeatureName -Ensure 'Present' | Should Be $false
+                    Test-TargetResource -Name $testFeatureName -Ensure 'Present' | Should -Be $false
                 }
 
                 It 'Should return true when Ensure set to Absent' {
-                    Test-TargetResource -Name $testFeatureName -Ensure 'Absent' | Should Be $true
+                    Test-TargetResource -Name $testFeatureName -Ensure 'Absent' | Should -Be $true
                 }
             }
 
@@ -262,11 +262,11 @@ try
 
             Context 'Convert-FeatureStateToEnsure' {
                 It 'Should return Present when state is Enabled' {
-                    Convert-FeatureStateToEnsure -State 'Enabled' | Should Be 'Present'
+                    Convert-FeatureStateToEnsure -State 'Enabled' | Should -Be 'Present'
                 }
 
                 It 'Should return Absent when state is Disabled' {
-                    Convert-FeatureStateToEnsure -State 'Disabled' | Should Be 'Absent'
+                    Convert-FeatureStateToEnsure -State 'Disabled' | Should -Be 'Absent'
                 }
 
                 It 'Should return the same state when state is not Enabled or Disabled' {
@@ -275,7 +275,7 @@ try
 
                     try
                     {
-                        Convert-FeatureStateToEnsure -State 'UnknownState' | Should Be 'UnknownState'
+                        Convert-FeatureStateToEnsure -State 'UnknownState' | Should -Be 'UnknownState'
                     }
                     finally
                     {
@@ -306,7 +306,7 @@ try
 
                 It 'Should return 3 strings from 3 PSCustomObjects and a null object' {
                     $propertiesAsStrings = Convert-CustomPropertyArrayToStringArray -CustomProperties $psCustomObjects
-                    $propertiesAsStrings.Length | Should Be 3
+                    $propertiesAsStrings.Length | Should -Be 3
                 }
 
                 It 'Should return the correct string for each object' {
@@ -314,7 +314,7 @@ try
 
                     foreach ($objectNumber in @(1, 2, 3))
                     {
-                        $propertiesAsStrings.Contains("Name = Object $objectNumber, Value = Value $objectNumber, Path = Path $objectNumber") | Should Be $true
+                        $propertiesAsStrings.Contains("Name = Object $objectNumber, Value = Value $objectNumber, Path = Path $objectNumber") | Should -Be $true
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xWindowsOptionalFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsOptionalFeature.Tests.ps1
@@ -65,19 +65,19 @@ try
 
                 It 'Should throw when the DISM module is not available' {
                     Mock Import-Module -ParameterFilter { $Name -eq 'Dism' } -MockWith { Write-Error 'Cannot find module' }
-                    { Assert-ResourcePrerequisitesValid } | Should -Throw $script:localizedData.DismNotAvailable
+                    { Assert-ResourcePrerequisitesValid } | Should -Throw -ExpectedMessage $script:localizedData.DismNotAvailable
                 }
 
                 Mock Import-Module -ParameterFilter { $Name -eq 'Dism' } -MockWith { }
 
                 It 'Should throw when operating system is Server 2008 R2' {
                     Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -MockWith { return $fakeWin32OSObjects['Server2008R2'] }
-                    { Assert-ResourcePrerequisitesValid } | Should -Throw $script:localizedData.NotSupportedSku
+                    { Assert-ResourcePrerequisitesValid } | Should -Throw -ExpectedMessage $script:localizedData.NotSupportedSku
                 }
 
                 It 'Should throw when operating system is Server 2012' {
                     Mock Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_OperatingSystem' } -MockWith { return $fakeWin32OSObjects['Server2012'] }
-                    { Assert-ResourcePrerequisitesValid } | Should -Throw $script:localizedData.NotSupportedSku
+                    { Assert-ResourcePrerequisitesValid } | Should -Throw -ExpectedMessage $script:localizedData.NotSupportedSku
                 }
 
                 It 'Should not throw when operating system is Windows 7' {

--- a/Tests/Unit/MSFT_xWindowsPackageCab.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsPackageCab.Tests.ps1
@@ -34,7 +34,7 @@ try
 
                 It 'Should return Ensure as Absent when package is not installed' {
                     $getTargetResourceResult = Get-TargetResource -Name $script:testPackageName @getTargetResourceCommonParams
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
 
                     Assert-MockCalled -CommandName 'Dism\Get-WindowsPackage'
                 }
@@ -43,7 +43,7 @@ try
                     Mock -CommandName 'Dism\Get-WindowsPackage' -MockWith { return @{ PackageState = 'NotPresent' } }
 
                     $getTargetResourceResult = Get-TargetResource -Name $script:testPackageName @getTargetResourceCommonParams
-                    $getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $getTargetResourceResult.Ensure | Should -Be 'Absent'
 
                     Assert-MockCalled -CommandName 'Dism\Get-WindowsPackage'
                 }
@@ -52,7 +52,7 @@ try
                     Mock -CommandName 'Dism\Get-WindowsPackage' -MockWith { return @{ PackageState = 'Installed' } }
 
                     $getTargetResourceResult = Get-TargetResource -Name $script:testPackageName @getTargetResourceCommonParams
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
 
                     Assert-MockCalled -CommandName 'Dism\Get-WindowsPackage'
                 }
@@ -61,7 +61,7 @@ try
                     Mock -CommandName 'Dism\Get-WindowsPackage' -MockWith { return @{ PackageState = 'InstallPending' } }
 
                     $getTargetResourceResult = Get-TargetResource -Name $script:testPackageName @getTargetResourceCommonParams
-                    $getTargetResourceResult.Ensure | Should Be 'Present'
+                    $getTargetResourceResult.Ensure | Should -Be 'Present'
 
                     Assert-MockCalled -CommandName 'Dism\Get-WindowsPackage'
                 }
@@ -107,24 +107,24 @@ try
                 Mock -CommandName 'Get-TargetResource' -MockWith { return @{ Ensure = 'Absent' } }
 
                 It 'Should return true when Get-TargetResource returns Ensure Absent and Ensure is set to Absent' {
-                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Absent' | Should Be $true
+                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Absent' | Should -Be $true
                     Assert-MockCalled -CommandName 'Get-TargetResource'
                 }
 
                 It 'Should return false when Get-TargetResource returns Ensure Absent and Ensure is set to Present' {
-                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Present' | Should Be $false
+                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Present' | Should -Be $false
                     Assert-MockCalled -CommandName 'Get-TargetResource'
                 }
 
                 Mock -CommandName 'Get-TargetResource' -MockWith { return @{ Ensure = 'Present' } }
 
                 It 'Should return true when Get-TargetResource returns Ensure Present and Ensure is set to Present' {
-                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Present' | Should Be $true
+                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Present' | Should -Be $true
                     Assert-MockCalled -CommandName 'Get-TargetResource'
                 }
 
                 It 'Should return false when Get-TargetResource returns Ensure Present and Ensure is set to Absent' {
-                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Absent' | Should Be $false
+                    Test-TargetResource -Name $script:testPackageName -SourcePath $script:testSourcePath -Ensure 'Absent' | Should -Be $false
                     Assert-MockCalled -CommandName 'Get-TargetResource'
                 }
 

--- a/Tests/Unit/MSFT_xWindowsProcess.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsProcess.Tests.ps1
@@ -139,9 +139,9 @@ try
                 $getTargetResourceResult = Get-TargetResource -Path $invalidPath `
                                                               -Arguments $processArguments
 
-                $getTargetResourceResult.Arguments | Should Be $processArguments
-                $getTargetResourceResult.Ensure | Should Be 'Absent'
-                $getTargetResourceResult.Path  | Should Be $invalidPath
+                $getTargetResourceResult.Arguments | Should -Be $processArguments
+                $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                $getTargetResourceResult.Path  | Should -Be $invalidPath
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -153,14 +153,14 @@ try
                                                               -Arguments $script:mockProcess2.Arguments `
                                                               -Credential $script:testCredential
 
-                $getTargetResourceResult.VirtualMemorySize | Should Be $script:mockProcess2.VirtualMemorySize64
-                $getTargetResourceResult.Arguments | Should Be $script:mockProcess2.Arguments
-                $getTargetResourceResult.Ensure | Should Be 'Present'
-                $getTargetResourceResult.PagedMemorySize | Should Be $script:mockProcess2.PagedMemorySize64
-                $getTargetResourceResult.Path | Should Be $script:mockProcess2.Path
-                $getTargetResourceResult.NonPagedMemorySize | Should Be $script:mockProcess2.NonpagedSystemMemorySize64
-                $getTargetResourceResult.HandleCount | Should Be $script:mockProcess2.HandleCount
-                $getTargetResourceResult.ProcessId | Should Be $script:mockProcess2.ProcessId
+                $getTargetResourceResult.VirtualMemorySize | Should -Be $script:mockProcess2.VirtualMemorySize64
+                $getTargetResourceResult.Arguments | Should -Be $script:mockProcess2.Arguments
+                $getTargetResourceResult.Ensure | Should -Be 'Present'
+                $getTargetResourceResult.PagedMemorySize | Should -Be $script:mockProcess2.PagedMemorySize64
+                $getTargetResourceResult.Path | Should -Be $script:mockProcess2.Path
+                $getTargetResourceResult.NonPagedMemorySize | Should -Be $script:mockProcess2.NonpagedSystemMemorySize64
+                $getTargetResourceResult.HandleCount | Should -Be $script:mockProcess2.HandleCount
+                $getTargetResourceResult.ProcessId | Should -Be $script:mockProcess2.ProcessId
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -172,14 +172,14 @@ try
                 $getTargetResourceResult = Get-TargetResource -Path $script:validPath1 `
                                                               -Arguments $script:mockProcess1.Arguments
 
-                $getTargetResourceResult.VirtualMemorySize | Should Be $script:mockProcess1.VirtualMemorySize64
-                $getTargetResourceResult.Arguments | Should Be $script:mockProcess1.Arguments
-                $getTargetResourceResult.Ensure | Should Be 'Present'
-                $getTargetResourceResult.PagedMemorySize | Should Be $script:mockProcess1.PagedMemorySize64
-                $getTargetResourceResult.Path | Should Be $script:mockProcess1.Path
-                $getTargetResourceResult.NonPagedMemorySize | Should Be $script:mockProcess1.NonpagedSystemMemorySize64
-                $getTargetResourceResult.HandleCount | Should Be $script:mockProcess1.HandleCount
-                $getTargetResourceResult.ProcessId | Should Be $script:mockProcess1.ProcessId
+                $getTargetResourceResult.VirtualMemorySize | Should -Be $script:mockProcess1.VirtualMemorySize64
+                $getTargetResourceResult.Arguments | Should -Be $script:mockProcess1.Arguments
+                $getTargetResourceResult.Ensure | Should -Be 'Present'
+                $getTargetResourceResult.PagedMemorySize | Should -Be $script:mockProcess1.PagedMemorySize64
+                $getTargetResourceResult.Path | Should -Be $script:mockProcess1.Path
+                $getTargetResourceResult.NonPagedMemorySize | Should -Be $script:mockProcess1.NonpagedSystemMemorySize64
+                $getTargetResourceResult.HandleCount | Should -Be $script:mockProcess1.HandleCount
+                $getTargetResourceResult.ProcessId | Should -Be $script:mockProcess1.ProcessId
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -223,7 +223,7 @@ try
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Credential $script:testCredential `
                                      -Ensure 'Absent'
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -235,7 +235,7 @@ try
                 { Set-TargetResource -Path $script:invalidPath `
                                      -Arguments '' `
                                      -Ensure 'Absent'
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -247,7 +247,7 @@ try
                 { Set-TargetResource -Path $script:errorProcess.Path `
                                      -Arguments '' `
                                      -Ensure 'Absent'
-                } | Should Throw $script:exceptionMessage
+                } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -262,7 +262,7 @@ try
                 { Set-TargetResource -Path $script:validPath1 `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Absent'
-                } | Should Throw $script:exceptionMessage
+                } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -279,7 +279,7 @@ try
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Credential $script:testCredential `
                                      -Ensure 'Present'
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -298,7 +298,7 @@ try
                                      -Credential $script:testCredential `
                                      -WorkingDirectory 'test working directory' `
                                      -Ensure 'Present'
-                } | Should Throw $script:exceptionMessage
+                } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -318,7 +318,7 @@ try
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Credential $script:testCredential `
                                      -Ensure 'Present'
-                } | Should Throw $testErrorRecord
+                } | Should -Throw $testErrorRecord
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -333,7 +333,7 @@ try
                 { Set-TargetResource -Path $script:invalidPath `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Present'
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -349,7 +349,7 @@ try
                 { Set-TargetResource -Path $script:invalidPath `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Present'
-                } | Should Throw $script:exceptionMessage
+                } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -365,7 +365,7 @@ try
                 { Set-TargetResource -Path $script:invalidPath `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Present'
-                } | Should Throw $script:exceptionMessage
+                } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -379,7 +379,7 @@ try
                 { Set-TargetResource -Path $script:validPath1 `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Present'
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -413,14 +413,14 @@ try
                 $testTargetResourceResult = Test-TargetResource -Path $script:validPath1 `
                                                                 -Arguments $script:mockProcess1.Arguments `
                                                                 -Ensure 'Present'
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return false when Ensure set to Present and process is not running' {
                 $testTargetResourceResult = Test-TargetResource -Path $script:invalidPath `
                                                                 -Arguments $script:mockProcess1.Arguments `
                                                                 -Ensure 'Present'
-                $testTargetResourceResult | Should Be $false
+                $testTargetResourceResult | Should -Be $false
             }
 
             It 'Should return true when Ensure set to Absent and process is not running and Credential passed' {
@@ -428,14 +428,14 @@ try
                                                                 -Arguments $script:mockProcess1.Arguments `
                                                                 -Credential $script:testCredential `
                                                                 -Ensure 'Absent'
-                $testTargetResourceResult | Should Be $true
+                $testTargetResourceResult | Should -Be $true
             }
 
             It 'Should return false when Ensure set to Absent and process is running' {
                 $testTargetResourceResult = Test-TargetResource -Path $script:validPath1 `
                                                                 -Arguments $script:mockProcess1.Arguments `
                                                                 -Ensure 'Absent'
-                $testTargetResourceResult | Should Be $false
+                $testTargetResourceResult | Should -Be $false
             }
 
         }
@@ -448,7 +448,7 @@ try
                 $rootedPath = 'C:\testProcess.exe'
 
                 $expandPathResult = Expand-Path -Path $rootedPath
-                $expandPathResult | Should Be $rootedPath
+                $expandPathResult | Should -Be $rootedPath
             }
 
             Mock -CommandName Test-Path -MockWith { return $false }
@@ -456,7 +456,7 @@ try
             It 'Should throw an invalid argument exception when Path is rooted and does not exist' {
                 $rootedPath = 'C:\invalidProcess.exe'
 
-                { Expand-Path -Path $rootedPath} | Should Throw $script:exceptionMessage
+                { Expand-Path -Path $rootedPath} | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -464,7 +464,7 @@ try
             It 'Should throw an invalid argument exception when Path is unrooted and does not exist' {
                  $unrootedPath = 'invalidfile.txt'
 
-                 { Expand-Path -Path $unrootedPath} | Should Throw $script:exceptionMessage
+                 { Expand-Path -Path $unrootedPath} | Should -Throw $script:exceptionMessage
 
                  Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -476,7 +476,7 @@ try
 
             It 'Should return the correct process when it exists and no arguments passed' {
                 $resultProcess = Get-ProcessCimInstance -Path $script:mockProcess2.Path
-                $resultProcess | Should Be @($script:mockProcess2)
+                $resultProcess | Should -Be @($script:mockProcess2)
 
                 Assert-MockCalled -CommandName Get-Process -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-CimInstance -Exactly 1 -Scope It
@@ -488,7 +488,7 @@ try
             It 'Should return the correct process when it exists and arguments are passed' {
                 $resultProcess = Get-ProcessCimInstance -Path $script:mockProcess1.Path `
                                                   -Arguments $script:mockProcess1.Arguments
-                $resultProcess | Should Be @($script:mockProcess1)
+                $resultProcess | Should -Be @($script:mockProcess1)
 
                 Assert-MockCalled -CommandName Get-Process -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-CimInstance -Exactly 1 -Scope It
@@ -502,7 +502,7 @@ try
                 $resultProcess = Get-ProcessCimInstance -Path $script:mockProcess1.Path `
                                                   -Arguments $script:mockProcess1.Arguments
 
-                Compare-Object -ReferenceObject $expectedProcesses -DifferenceObject $resultProcess | Should Be $null
+                Compare-Object -ReferenceObject $expectedProcesses -DifferenceObject $resultProcess | Should -Be $null
 
                 Assert-MockCalled -CommandName Get-Process -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-CimInstance -Exactly 3 -Scope It
@@ -515,7 +515,7 @@ try
                 $resultProcess = Get-ProcessCimInstance -Path $script:mockProcess2.Path `
                                                   -Arguments $script:mockProcess2.Arguments `
                                                   -UseGetCimInstanceThreshold 1
-                $resultProcess | Should Be @($script:mockProcess2, $script:mockProcess2)
+                $resultProcess | Should -Be @($script:mockProcess2, $script:mockProcess2)
 
                 Assert-MockCalled -CommandName Get-Process -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-CimInstance -Exactly 1 -Scope It
@@ -529,7 +529,7 @@ try
             It 'Should return the correct process when it exists and Credential is passed in' {
                 $resultProcess = Get-ProcessCimInstance -Path $script:mockProcess2.Path `
                                                   -Credential $script:testCredential
-                $resultProcess | Should Be @($script:mockProcess2)
+                $resultProcess | Should -Be @($script:mockProcess2)
 
                 Assert-MockCalled -CommandName Get-Process -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-CimInstance -Exactly 1 -Scope It
@@ -548,7 +548,7 @@ try
                                                         -Credential $script:testCredential `
                                                         -Arguments $script:mockProcess3.Arguments `
                                                         -UseGetCimInstanceThreshold 1
-                $resultProcess | Should Be @($script:mockProcess3, $script:mockProcess3)
+                $resultProcess | Should -Be @($script:mockProcess3, $script:mockProcess3)
 
                 Assert-MockCalled -CommandName Get-Process -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-CimInstance -Exactly 1 -Scope It
@@ -564,7 +564,7 @@ try
                                                         -Credential $script:testCredential `
                                                         -Arguments $script:mockProcess3.Arguments `
                                                         -UseGetCimInstanceThreshold 1
-                $resultProcess | Should Be @($script:mockProcess3, $script:mockProcess3)
+                $resultProcess | Should -Be @($script:mockProcess3, $script:mockProcess3)
 
                 Assert-MockCalled -CommandName Get-Process -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-CimInstance -Exactly 1 -Scope It
@@ -575,21 +575,21 @@ try
             It 'Should return the same string when there are no escaped characters' {
                 $inputString = 'testString%$.@123'
                 $convertedString = ConvertTo-EscapedStringForWqlFilter -FilterString $inputString
-                $convertedString | Should Be $inputString
+                $convertedString | Should -Be $inputString
             }
 
             It 'Should return a string with escaped characters: ("\)' {
                 $inputString = '\test"string"\123'
                 $expectedString = '\\test\"string\"\\123'
                 $convertedString = ConvertTo-EscapedStringForWqlFilter -FilterString $inputString
-                $convertedString | Should Be $expectedString
+                $convertedString | Should -Be $expectedString
             }
 
             It "Should return a string with escaped characters: ('\)" {
                 $inputString = "\test'string'\123"
                 $expectedString = "\\test\'string\'\\123"
                 $convertedString = ConvertTo-EscapedStringForWqlFilter -FilterString $inputString
-                $convertedString | Should Be $expectedString
+                $convertedString | Should -Be $expectedString
             }
         }
 
@@ -602,13 +602,13 @@ try
 
             It 'Should return the correct string with domain\user' {
                 $owner = Get-ProcessOwner -Process $script:mockProcess1
-                $owner | Should Be ($mockOwner.Domain + '\' + $mockOwner.User)
+                $owner | Should -Be ($mockOwner.Domain + '\' + $mockOwner.User)
             }
 
             It 'Should return the correct string with default-domain\user when domain is not there' {
                 $mockOwner.Domain = $null
                 $owner = Get-ProcessOwner -Process $script:mockProcess1
-                $owner | Should Be ($env:computerName + '\' + $mockOwner.User)
+                $owner | Should -Be ($env:computerName + '\' + $mockOwner.User)
             }
 
         }
@@ -617,27 +617,27 @@ try
             It 'Should return the correct arguments when single quotes are used' {
                 $inputString = 'test.txt a b c'
                 $argumentsReturned = Get-ArgumentsFromCommandLineInput -CommandLineInput $inputString
-                $argumentsReturned | Should Be 'a b c'
+                $argumentsReturned | Should -Be 'a b c'
             }
 
             It 'Should return the correct arguments when double quotes are used' {
                 $inputString = '"test file   test"   a b c'
                 $argumentsReturned = Get-ArgumentsFromCommandLineInput -CommandLineInput $inputString
-                $argumentsReturned | Should Be 'a b c'
+                $argumentsReturned | Should -Be 'a b c'
             }
 
             It 'Should return an empty string when an empty string is passed in' {
                 $inputString = $null
                 $resultString = [String]::Empty
                 $argumentsReturned = Get-ArgumentsFromCommandLineInput -CommandLineInput $inputString
-                $argumentsReturned | Should Be $resultString
+                $argumentsReturned | Should -Be $resultString
             }
 
             It 'Should return an empty string when there are no arguments' {
                 $inputString = 'test.txt'
                 $resultString = [String]::Empty
                 $argumentsReturned = Get-ArgumentsFromCommandLineInput -CommandLineInput $inputString
-                $argumentsReturned | Should Be $resultString
+                $argumentsReturned | Should -Be $resultString
             }
         }
 
@@ -651,12 +651,12 @@ try
 
             It 'Should not throw an exception if the hashtable does not contain a key' {
                 $mockKey = @('k1', 'k2', 'k3', 'k4', 'k5')
-                { Assert-HashTableDoesNotContainKey -Hashtable $mockHashtable -Key $mockKey } | Should Not Throw
+                { Assert-HashTableDoesNotContainKey -Hashtable $mockHashtable -Key $mockKey } | Should -Not -Throw
             }
 
             It 'Should throw an exception if the hashtable contains a key' {
                 $mockKey = @('k1', 'k2', 'Key3', 'k4', 'k5')
-                { Assert-HashTableDoesNotContainKey -Hashtable $mockHashtable -Key $mockKey } | Should Throw $script:exceptionMessage
+                { Assert-HashTableDoesNotContainKey -Hashtable $mockHashtable -Key $mockKey } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -671,14 +671,14 @@ try
 
             It 'Should return true when all processes are returned' {
                 $processCountResult = Wait-ProcessCount -ProcessSettings $mockProcessSettings -ProcessCount 2
-                $processCountResult | Should Be $true
+                $processCountResult | Should -Be $true
             }
 
             It 'Should return false when not all processes are returned' {
                 $processCountResult = Wait-ProcessCount -ProcessSettings $mockProcessSettings `
                                                         -ProcessCount 3 `
                                                         -WaitTime 10
-                $processCountResult | Should Be $false
+                $processCountResult | Should -Be $false
             }
         }
 
@@ -689,7 +689,7 @@ try
                 $rootedPath = 'C:\testProcess.exe'
 
                 { Assert-PathArgumentRooted -PathArgumentName 'mock test name' `
-                                            -PathArgument $rootedPath } | Should Not Throw
+                                            -PathArgument $rootedPath } | Should -Not -Throw
             }
 
             It 'Should throw an invalid argument exception when Path is unrooted' {
@@ -697,7 +697,7 @@ try
 
 
                  { Assert-PathArgumentRooted -PathArgumentName 'mock test name' `
-                                             -PathArgument $unrootedPath } | Should Throw $script:exceptionMessage
+                                             -PathArgument $unrootedPath } | Should -Throw $script:exceptionMessage
 
                  Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -710,14 +710,14 @@ try
                 Mock -CommandName Test-Path -MockWith { return $true }
 
                 { Assert-PathArgumentValid -PathArgumentName 'test name' `
-                                           -PathArgument 'validPath' } | Should Not Throw
+                                           -PathArgument 'validPath' } | Should -Not -Throw
             }
 
             It 'Should throw an invalid argument exception when Path is not valid' {
                 Mock -CommandName Test-Path -MockWith { return $false }
 
                 { Assert-PathArgumentValid -PathArgumentName 'test name' `
-                                           -PathArgument 'invalidPath' } | Should Throw $script:exceptionMessage
+                                           -PathArgument 'invalidPath' } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -733,8 +733,8 @@ try
 
                 $splitCredentialResult = Split-Credential -Credential $testCredential
 
-                $splitCredentialResult.Domain | Should Be 'domain'
-                $splitCredentialResult.Username | Should Be 'user'
+                $splitCredentialResult.Domain | Should -Be 'domain'
+                $splitCredentialResult.Username | Should -Be 'user'
             }
 
             It 'Should return correct domain and username with \ seperator' {
@@ -744,8 +744,8 @@ try
 
                 $splitCredentialResult = Split-Credential -Credential $testCredential
 
-                $splitCredentialResult.Domain | Should Be 'domain'
-                $splitCredentialResult.Username | Should Be 'user'
+                $splitCredentialResult.Domain | Should -Be 'domain'
+                $splitCredentialResult.Username | Should -Be 'user'
             }
 
             It 'Should return correct domain and username with a local user' {
@@ -755,8 +755,8 @@ try
 
                 $splitCredentialResult = Split-Credential -Credential $testCredential
 
-                $splitCredentialResult.Domain | Should Be $env:computerName
-                $splitCredentialResult.Username | Should Be 'localuser'
+                $splitCredentialResult.Domain | Should -Be $env:computerName
+                $splitCredentialResult.Username | Should -Be 'localuser'
             }
 
             It 'Should throw an invalid argument exception when more than one \ in username' {
@@ -764,7 +764,7 @@ try
                 $testPassword = ConvertTo-SecureString -String 'dummy' -AsPlainText -Force
                 $testCredential = New-Object -TypeName 'PSCredential' -ArgumentList @($testUsername, $testPassword)
 
-                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should Throw $script:exceptionMessage
+                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -774,7 +774,7 @@ try
                 $testPassword = ConvertTo-SecureString -String 'dummy' -AsPlainText -Force
                 $testCredential = New-Object -TypeName 'PSCredential' -ArgumentList @($testUsername, $testPassword)
 
-                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should Throw $script:exceptionMessage
+                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should -Throw $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }

--- a/Tests/Unit/MSFT_xWindowsProcess.Tests.ps1
+++ b/Tests/Unit/MSFT_xWindowsProcess.Tests.ps1
@@ -247,7 +247,7 @@ try
                 { Set-TargetResource -Path $script:errorProcess.Path `
                                      -Arguments '' `
                                      -Ensure 'Absent'
-                } | Should -Throw $script:exceptionMessage
+                } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -262,7 +262,7 @@ try
                 { Set-TargetResource -Path $script:validPath1 `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Absent'
-                } | Should -Throw $script:exceptionMessage
+                } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -298,7 +298,7 @@ try
                                      -Credential $script:testCredential `
                                      -WorkingDirectory 'test working directory' `
                                      -Ensure 'Present'
-                } | Should -Throw $script:exceptionMessage
+                } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -318,7 +318,7 @@ try
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Credential $script:testCredential `
                                      -Ensure 'Present'
-                } | Should -Throw $testErrorRecord
+                } | Should -Throw -ExpectedMessage $testErrorRecord
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -349,7 +349,7 @@ try
                 { Set-TargetResource -Path $script:invalidPath `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Present'
-                } | Should -Throw $script:exceptionMessage
+                } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -365,7 +365,7 @@ try
                 { Set-TargetResource -Path $script:invalidPath `
                                      -Arguments $script:mockProcess1.Arguments `
                                      -Ensure 'Present'
-                } | Should -Throw $script:exceptionMessage
+                } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName Expand-Path -Exactly 1 -Scope It
                 Assert-MockCalled -CommandName Get-ProcessCimInstance -Exactly 1 -Scope It
@@ -456,7 +456,7 @@ try
             It 'Should throw an invalid argument exception when Path is rooted and does not exist' {
                 $rootedPath = 'C:\invalidProcess.exe'
 
-                { Expand-Path -Path $rootedPath} | Should -Throw $script:exceptionMessage
+                { Expand-Path -Path $rootedPath} | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -464,7 +464,7 @@ try
             It 'Should throw an invalid argument exception when Path is unrooted and does not exist' {
                  $unrootedPath = 'invalidfile.txt'
 
-                 { Expand-Path -Path $unrootedPath} | Should -Throw $script:exceptionMessage
+                 { Expand-Path -Path $unrootedPath} | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                  Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -656,7 +656,7 @@ try
 
             It 'Should throw an exception if the hashtable contains a key' {
                 $mockKey = @('k1', 'k2', 'Key3', 'k4', 'k5')
-                { Assert-HashTableDoesNotContainKey -Hashtable $mockHashtable -Key $mockKey } | Should -Throw $script:exceptionMessage
+                { Assert-HashTableDoesNotContainKey -Hashtable $mockHashtable -Key $mockKey } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -697,7 +697,7 @@ try
 
 
                  { Assert-PathArgumentRooted -PathArgumentName 'mock test name' `
-                                             -PathArgument $unrootedPath } | Should -Throw $script:exceptionMessage
+                                             -PathArgument $unrootedPath } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                  Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -717,7 +717,7 @@ try
                 Mock -CommandName Test-Path -MockWith { return $false }
 
                 { Assert-PathArgumentValid -PathArgumentName 'test name' `
-                                           -PathArgument 'invalidPath' } | Should -Throw $script:exceptionMessage
+                                           -PathArgument 'invalidPath' } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -764,7 +764,7 @@ try
                 $testPassword = ConvertTo-SecureString -String 'dummy' -AsPlainText -Force
                 $testCredential = New-Object -TypeName 'PSCredential' -ArgumentList @($testUsername, $testPassword)
 
-                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should -Throw $script:exceptionMessage
+                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }
@@ -774,7 +774,7 @@ try
                 $testPassword = ConvertTo-SecureString -String 'dummy' -AsPlainText -Force
                 $testCredential = New-Object -TypeName 'PSCredential' -ArgumentList @($testUsername, $testPassword)
 
-                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should -Throw $script:exceptionMessage
+                { $splitCredentialResult = Split-Credential -Credential $testCredential } | Should -Throw -ExpectedMessage $script:exceptionMessage
 
                 Assert-MockCalled -CommandName New-InvalidArgumentException -Exactly 1 -Scope It
             }


### PR DESCRIPTION
#### Pull Request (PR) description
Updates Should statements in Pester tests to use dashes before parameters

#### This Pull Request (PR) fixes the following issues
Partially addresses #473 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/564)
<!-- Reviewable:end -->
