### PR TITLE
Fix Most Remaining Script Analyzer Issues Flagged During Meta Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,8 +134,8 @@
 - Adds spaces between comment hashtags and comments.
 - Fixes script analyzer issues in MSFT_xServiceResource.psm1.
   [issue #491](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/491)
-- Fixes script analyzer issues in MSFT_xWindowsPackageCab.psm1.
-  [issue #495](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/495)
+- Fixes script analyzer issues in MSFT_xWindowsPackageCab.psm1
+  [issue #495](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/495).
 - xFileUpload:
   - Fixes script analyzer issues in xFileUpload.schema.psm1.
     [issue #497](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/497)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,8 +147,20 @@
   year.
 - Auto-formatted the module manifest to improve layout.
 - Changes to xPackage
-  - Fix an misnamed variable that causes an error during error message output.
-    [issue #449](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/449))
+- Fix an misnamed variable that causes an error during error message output.
+  [issue #449](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/449))
+- Fixes script analyzer issues in MSFT_xPSSessionConfiguration.psm1.
+  [issue #566](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/566)
+- Fixes script analyzer issues in xGroupSet.schema.psm1.
+  [issue #498](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/498)
+- Fixes script analyzer issues in xProcessSet.schema.psm1.
+  [issue #499](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/499)
+- Fixes script analyzer issues in xServiceSet.schema.psm1.
+  [issue #500](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/500)
+- Fixes script analyzer issues in xWindowsFeatureSet.schema.psm1.
+  [issue #501](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/501)
+- Fixes script analyzer issues in xWindowsOptionalFeatureSet.schema.psm1.
+  [issue #502](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/502)
 
 ## 8.4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,8 +134,8 @@
 - Adds spaces between comment hashtags and comments.
 - Fixes script analyzer issues in MSFT_xServiceResource.psm1.
   [issue #491](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/491)
-- Fixes script analyzer issues in MSFT_xWindowsPackageCab.psm1
-  [issue #495](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/495).
+- Fixes script analyzer issues in MSFT_xWindowsPackageCab.psm1.
+  [issue #495](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/495)
 - xFileUpload:
   - Fixes script analyzer issues in xFileUpload.schema.psm1.
     [issue #497](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/497)
@@ -160,7 +160,7 @@
   [issue #500](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/500)
 - Fixes script analyzer issues in xWindowsFeatureSet.schema.psm1.
   [issue #501](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/501)
-- Fixes script analyzer issues in xWindowsOptionalFeatureSet.schema.psm1.
+- Fixes script analyzer issues in xWindowsOptionalFeatureSet.schema.psm1
   [issue #502](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/502)
 - Updates Should statements in Pester tests to use dashes before parameters.
 - Added a CODE\_OF\_CONDUCT.md with the same content as in the README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,8 +147,8 @@
   year.
 - Auto-formatted the module manifest to improve layout.
 - Changes to xPackage
-- Fix an misnamed variable that causes an error during error message output.
-  [issue #449](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/449))
+  - Fix an misnamed variable that causes an error during error message output.
+    [issue #449](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/449))
 - Fixes script analyzer issues in MSFT_xPSSessionConfiguration.psm1.
   [issue #566](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/566)
 - Fixes script analyzer issues in xGroupSet.schema.psm1.

--- a/DSCResources/MSFT_xPSSessionConfiguration/MSFT_xPSSessionConfiguration.psm1
+++ b/DSCResources/MSFT_xPSSessionConfiguration/MSFT_xPSSessionConfiguration.psm1
@@ -547,6 +547,7 @@ function Test-TargetResource
 function Get-EndpointAccessMode
 {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -634,6 +635,7 @@ function Write-EndpointMessage
 function Get-ValidatedResourcePropertyTable
 {
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/DSCResources/xGroupSet/xGroupSet.schema.psm1
+++ b/DSCResources/xGroupSet/xGroupSet.schema.psm1
@@ -38,16 +38,20 @@ Configuration xGroupSet
         [String[]]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure,
 
+        [Parameter()]
         [String[]]
         $MembersToInclude,
 
+        [Parameter()]
         [String[]]
         $MembersToExclude,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]

--- a/DSCResources/xProcessSet/xProcessSet.schema.psm1
+++ b/DSCResources/xProcessSet/xProcessSet.schema.psm1
@@ -53,27 +53,33 @@ Configuration xProcessSet
         [String[]]
         $Path,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $StandardOutputPath,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $StandardErrorPath,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $StandardInputPath,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $WorkingDirectory

--- a/DSCResources/xServiceSet/xServiceSet.schema.psm1
+++ b/DSCResources/xServiceSet/xServiceSet.schema.psm1
@@ -53,22 +53,27 @@ Configuration xServiceSet
         [String[]]
         $Name,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure,
 
+        [Parameter()]
         [ValidateSet('Automatic', 'Manual', 'Disabled')]
         [String]
         $StartupType,
 
+        [Parameter()]
         [ValidateSet('LocalSystem', 'LocalService', 'NetworkService')]
         [String]
         $BuiltInAccount,
 
+        [Parameter()]
         [ValidateSet('Running', 'Stopped', 'Ignore')]
         [String]
         $State,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]

--- a/DSCResources/xWindowsFeatureSet/xWindowsFeatureSet.schema.psm1
+++ b/DSCResources/xWindowsFeatureSet/xWindowsFeatureSet.schema.psm1
@@ -43,22 +43,27 @@ Configuration xWindowsFeatureSet
         [String[]]
         $Name,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $Source,
 
+        [Parameter()]
         [Boolean]
         $IncludeAllSubFeature,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $Credential,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $LogPath

--- a/DSCResources/xWindowsOptionalFeatureSet/xWindowsOptionalFeatureSet.schema.psm1
+++ b/DSCResources/xWindowsOptionalFeatureSet/xWindowsOptionalFeatureSet.schema.psm1
@@ -48,16 +48,20 @@ Configuration xWindowsOptionalFeatureSet
         [String]
         $Ensure,
 
+        [Parameter()]
         [Boolean]
         $RemoveFilesOnDisable,
 
+        [Parameter()]
         [Boolean]
         $NoWindowsUpdateCheck,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $LogPath,
 
+        [Parameter()]
         [ValidateSet('ErrorsOnly', 'ErrorsAndWarning', 'ErrorsAndWarningAndInformation')]
         [String]
         $LogLevel


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes most of the remaining script analyzer issues that are flagged during meta tests. Fixes issues in the following files: MSFT_xPSSessionConfiguration.psm1, xGroupSet.schema.psm1, xProcessSet.schema.psm1, xServiceSet.schema.psm1, xWindowsFeatureSet.schema.psm1, xWindowsOptionalFeatureSet.schema.psm1

#### This Pull Request (PR) fixes the following issues
- Fixes #498 
- Fixes #499 
- Fixes #500 
- Fixes #501 
- Fixes #502 
- Fixes #566 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/567)
<!-- Reviewable:end -->
