### PR TITLE
Moved Code of Conduct into seperate file - Fixes #562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@
   - Fix an misnamed variable that causes an error during error message output.
     [issue #449](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/449))
 - Updates Should statements in Pester tests to use dashes before parameters.
+- Added a CODE\_OF\_CONDUCT.md with the same content as in the README.md
+  [issue #562](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/562)
 
 ## 8.4.0.0
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
+questions or comments.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,7 @@ versions going back to PowerShell 4, there is no automatic testing performed
 for these versions, and thus no guarantee that the module will work as
 expected.
 
-This project has adopted the
-[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the
-[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
-additional questions or comments.
+This project has adopted [this code of conduct](CODE_OF_CONDUCT.md).
 
 ## Branches
 


### PR DESCRIPTION
#### Pull Request (PR) description

This PR moves the Code of Conduct to a separate file and updates the README.MD accordingly. This is the standard that we've applied to all HQRM repositories.

#### This Pull Request (PR) fixes the following issues

- Fixes #562 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/568)
<!-- Reviewable:end -->
