### PR TITLE
Tests\Unit\MSFT_xMsiPackage.Tests.ps1: Fixes issue where tests fail if executed from a drive other than C:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   - Common Tests - Required Script Analyzer Rules
   - Common Tests - Validate Markdown Links
 - Changes to `Tests\Unit\MSFT_xMsiPackage.Tests.ps1`
-  - Fixes issue where tests fail if executed from a drive other than C:
+  - Fixes issue where tests fail if executed from a drive other than C:.
     [issue #573](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/573)
 
 ## 8.5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   - Common Tests - Relative Path Length
   - Common Tests - Required Script Analyzer Rules
   - Common Tests - Validate Markdown Links
+- Changes to `Tests\Unit\MSFT_xMsiPackage.Tests.ps1`
+  - Fixes issue where tests fail if executed from a drive other than C:
+    [issue #573](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/573)
 
 ## 8.5.0.0
 

--- a/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'xMsiPackage Unit Tests' {
         $script:testIdentifyingNumber = '{DEADBEEF-80C6-41E6-A1B9-8BDB8A05027F}'
         $script:testWrongProductId = 'wrongId'
         $script:testPath = 'file://test.msi'
-        $script:destinationPath = Join-Path -Path $script:packageCacheLocation -ChildPath 'C:\'
+        $script:destinationPath = Join-Path -Path $script:packageCacheLocation -ChildPath (Get-Location).Drive.Root
         $script:testUriHttp = [System.Uri] 'http://test.msi'
         $script:testUriHttps = [System.Uri] 'https://test.msi'
         $script:testUriFile = [System.Uri] 'file://test.msi'


### PR DESCRIPTION
#### Pull Request (PR) description
Tests\Unit\MSFT_xMsiPackage.Tests.ps1: Fixes issue where tests fail if executed from a drive other than C:

#### This Pull Request (PR) fixes the following issues
-Fixes #573 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/578)
<!-- Reviewable:end -->
