### PR TITLE
Tests\Integration\xWindowsOptionalFeatureSet.Integration.Tests.ps1: Fix issues with disabled feature states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   - Common Tests - Relative Path Length
   - Common Tests - Required Script Analyzer Rules
   - Common Tests - Validate Markdown Links
+- Changes to
+  `Tests\Integration\xWindowsOptionalFeatureSet.Integration.Tests.ps1`
+  - Fixes issue where tests fail if disabled Windows Optional Features in up
+    in a state of 'DisabledWithPayloadRemoved'.
+    [issue #586](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/586)
 
 ## 8.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
   - Common Tests - Validate Markdown Links
 - Changes to
   `Tests\Integration\xWindowsOptionalFeatureSet.Integration.Tests.ps1`
-  - Fixes issue where tests fail if disabled Windows Optional Features in up
-    in a state of 'DisabledWithPayloadRemoved'.
+  - Fixes issue where tests fail if a Windows Optional Feature that is expected
+    to be disabled has a feature state of 'DisabledWithPayloadRemoved'.
     [issue #586](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/586)
 
 ## 8.5.0.0

--- a/Tests/Integration/xWindowsOptionalFeatureSet.Integration.Tests.ps1
+++ b/Tests/Integration/xWindowsOptionalFeatureSet.Integration.Tests.ps1
@@ -23,7 +23,7 @@ try
             $script:confgurationFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'xWindowsOptionalFeatureSet.config.ps1'
 
             $script:enabledStates = @( 'Enabled', 'EnablePending' )
-            $script:disabledStates = @( 'Disabled', 'DisablePending' )
+            $script:disabledStates = @( 'Disabled', 'DisablePending', 'DisabledWithPayloadRemoved' )
 
             $script:validFeatureNames = @( 'RSAT-RDS-Tools-Feature', 'Xps-Foundation-Xps-Viewer' )
 

--- a/Tests/MSFT_xPackageResource.TestHelper.psm1
+++ b/Tests/MSFT_xPackageResource.TestHelper.psm1
@@ -1299,7 +1299,7 @@ function New-TestExecutable
                 self = self.Replace("\"", "");
                 string packagePath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(self), "DSCSetupProject.msi");
 
-                string msiexecargs = String.Format("/i \"{0}\" {1}", packagePath, other);
+                string msiexecargs = String.Format("/i {0} {1}", packagePath, other);
                 System.Diagnostics.Process.Start(msiexecpath, msiexecargs).WaitForExit();
             }
         }

--- a/Tests/MSFT_xPackageResource.TestHelper.psm1
+++ b/Tests/MSFT_xPackageResource.TestHelper.psm1
@@ -1299,7 +1299,7 @@ function New-TestExecutable
                 self = self.Replace("\"", "");
                 string packagePath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(self), "DSCSetupProject.msi");
 
-                string msiexecargs = String.Format("/i {0} {1}", packagePath, other);
+                string msiexecargs = String.Format("/i \"{0}\" {1}", packagePath, other);
                 System.Diagnostics.Process.Start(msiexecpath, msiexecargs).WaitForExit();
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue where tests fail if disabled Windows Optional Features in up in a state of DisabledWithPayloadRemoved.

#### This Pull Request (PR) fixes the following issues
- Fixes #586 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/587)
<!-- Reviewable:end -->
