### PR TITLE
MSFT_xPackageResource: Fix Unit Tests That Fail When Run From Path With Spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   - Common Tests - Relative Path Length
   - Common Tests - Required Script Analyzer Rules
   - Common Tests - Validate Markdown Links
+- Changes to
+  `Tests\Unit\MSFT_xPackageResource.Tests.ps1`
+  - Fixes issue where tests fail if run from a folder that contains spaces.
+    [issue #580](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/580)
 
 ## 8.5.0.0
 

--- a/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
+++ b/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.psm1
@@ -543,7 +543,7 @@ function Set-TargetResource
                     $id = Split-Path -Path $productEntry.Name -Leaf
                 }
 
-                $startInfo.Arguments = "/x $id /quiet /norestart"
+                $startInfo.Arguments = "/x `"$id`" /quiet /norestart"
 
                 if ($LogPath)
                 {

--- a/Tests/MSFT_xPackageResource.TestHelper.psm1
+++ b/Tests/MSFT_xPackageResource.TestHelper.psm1
@@ -1299,7 +1299,7 @@ function New-TestExecutable
                 self = self.Replace("\"", "");
                 string packagePath = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(self), "DSCSetupProject.msi");
 
-                string msiexecargs = String.Format("/i {0} {1}", packagePath, other);
+                string msiexecargs = String.Format("/i \"{0}\" {1}", packagePath, other);
                 System.Diagnostics.Process.Start(msiexecpath, msiexecargs).WaitForExit();
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue where tests fail if run from a folder that contains spaces.

#### This Pull Request (PR) fixes the following issues
- Fixes #580 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/588)
<!-- Reviewable:end -->
