### PR TITLE
Update Common Test Helper to only update DSCResource.Tests when over 60 minutes old - Fixes #505

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   and reduce the likelihood of connectivity issues caused by inability to
   pull DSCResource.Tests.
   [issue #505](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/505)
+- Updated `CommonTestHelper.psm1` to resolve style guideline violations.
 
 ## 8.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
   `Tests\Unit\MSFT_xPackageResource.Tests.ps1`
   - Fixes issue where tests fail if run from a folder that contains spaces.
     [issue #580](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/580)
+- Changes to test helper Enter-DscResourceTestEnvironment so that it only
+  updates DSCResource.Tests when it is longer than 60 minutes since
+  it was last pulled. This is to improve performance of test execution
+  and reduce the likelihood of connectivity issues caused by inability to
+  pull DSCResource.Tests.
+  [issue #505](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/505)
 
 ## 8.5.0.0
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -823,7 +823,6 @@ function Test-DscResourceTestsNeedsInstallOrUpdate
 #>
 function Install-DscResourceTests
 {
-    [OutputType([System.Boolean])]
     [CmdletBinding()]
     param
     (

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -786,17 +786,17 @@ function Test-DscResourceTestsNeedsInstallOrUpdate
 
             if ($magicFileLastWriteTime -and $magicFileLastWriteTime -lt $timeWhenUpdateRequired)
             {
-                Write-Verbose -Message ('DSCResource.Tests was last updated on {0}. Update not required.' -f $magicFileLastWriteTime)
+                Write-Verbose -Message ('DSCResource.Tests was last updated at {0}. Update not required.' -f $magicFileLastWriteTime) -Verbose
                 return $false
             }
             else
             {
-                Write-Verbose -Message ('DSCResource.Tests was last updated on {0}. Update required.' -f $magicFileLastWriteTime)
+                Write-Verbose -Message ('DSCResource.Tests was last updated at {0}. Update is required.' -f $magicFileLastWriteTime) -Verbose
             }
         }
     }
 
-    Write-Verbose -Message 'DSCResource.Tests needs to be updated.'
+    Write-Verbose -Message 'DSCResource.Tests needs to be updated.' -Verbose
     return $true
 }
 
@@ -839,7 +839,7 @@ function Install-DscResourceTests
         if ($gitInstalled)
         {
             Push-Location -Path $dscResourceTestsPath
-            Write-Verbose -Message 'Updating DSCResource.Tests.'
+            Write-Verbose -Message 'Updating DSCResource.Tests.' -Verbose
             git pull origin dev --quiet
             $writeMagicFile = $true
             Pop-Location
@@ -857,7 +857,7 @@ function Install-DscResourceTests
         }
 
         Push-Location -Path $moduleRootPath
-        Write-Verbose -Message 'Cloning DSCResource.Tests.'
+        Write-Verbose -Message 'Cloning DSCResource.Tests.' -Verbose
         git clone 'https://github.com/PowerShell/DscResource.Tests' --quiet
         $writeMagicFile = $true
         Pop-Location

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -758,11 +758,15 @@ function Enter-DscResourceTestEnvironment
         is used to determine if the repository needs to be
         updated.
 
-        If the last write time of the magic file is over 60
-        minutes old then this will cause the function to
-        return true.
+        If the last write time of the magic file is over a
+        specified number of minutes old then this will cause
+        the function to return true.
 
         The magic file is called DSC_LAST_FETCH.
+
+    .PARAMETER RefreshAfterMinutes
+        The number of minutes old the magic file should be
+        before requiring an update. Defaults to 60 minutes.
 #>
 function Test-DscResourceTestsNeedsInstallOrUpdate
 {
@@ -770,6 +774,9 @@ function Test-DscResourceTestsNeedsInstallOrUpdate
     [CmdletBinding()]
     param
     (
+        [Parameter()]
+        [System.Int32]
+        $RefreshAfterMinutes = 60
     )
 
     $moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
@@ -782,7 +789,7 @@ function Test-DscResourceTestsNeedsInstallOrUpdate
         if (Test-Path -Path $magicFilePath)
         {
             $magicFileLastWriteTime = (Get-Item -Path $magicFilePath).LastWriteTime
-            $timeWhenUpdateRequired = (Get-Date) + [timespan]::FromMinutes(60)
+            $timeWhenUpdateRequired = (Get-Date) + [timespan]::FromMinutes($RefreshAfterMinutes)
 
             if ($magicFileLastWriteTime -and $magicFileLastWriteTime -lt $timeWhenUpdateRequired)
             {
@@ -839,7 +846,7 @@ function Install-DscResourceTests
         {
             Push-Location -Path $dscResourceTestsPath
             Write-Verbose -Message 'Updating DSCResource.Tests.' -Verbose
-            git pull origin dev --quiet
+            & git @('pull','origin','dev','--quiet')
             $writeMagicFile = $true
             Pop-Location
         }
@@ -857,7 +864,7 @@ function Install-DscResourceTests
 
         Push-Location -Path $moduleRootPath
         Write-Verbose -Message 'Cloning DSCResource.Tests.' -Verbose
-        git clone 'https://github.com/PowerShell/DscResource.Tests' --quiet
+        & git @('clone','https://github.com/PowerShell/DscResource.Tests','--quiet')
         $writeMagicFile = $true
         Pop-Location
     }


### PR DESCRIPTION
#### Pull Request (PR) description

Changes to test helper Enter-DscResourceTestEnvironment so that it only updates DSCResource.Tests when it is longer than 60 minutes since it was last pulled. This is to improve performance of test execution
and reduce the likelihood of connectivity issues caused by inability to pull DSCResource.Tests.

It uses a magic file in the .Git folder of the DSCResource.Tests to determine the last date/time of update. if the magic file last write date is older than 60 minutes then git clone will be performed.

#### This Pull Request (PR) fixes the following issues

- Fixes #505 
- Fixes #590

#### Task list

- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/591)
<!-- Reviewable:end -->
