### PR TITLE
Update tests to not rely on AppVeyor account being present for Administrator credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@
   pull DSCResource.Tests.
   [issue #505](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/505)
 - Updated `CommonTestHelper.psm1` to resolve style guideline violations.
+- Adds helper functions for use when creating test administrator user accounts,
+  and updates the following tests to use credentials created with these
+  functions.
+    - MSFT_xScriptResource.Integration.Tests.ps1
+    - MSFT_xServiceResource.Integration.Tests.ps1
+    - MSFT_xWindowsProcess.Integration.Tests.ps1
+    - xServiceSet.Integration.Tests.ps1
 
 ## 8.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,16 @@
 - Updated `CommonTestHelper.psm1` to resolve style guideline violations.
 - Adds helper functions for use when creating test administrator user accounts,
   and updates the following tests to use credentials created with these
-  functions.
+  functions:
     - MSFT_xScriptResource.Integration.Tests.ps1
     - MSFT_xServiceResource.Integration.Tests.ps1
     - MSFT_xWindowsProcess.Integration.Tests.ps1
     - xServiceSet.Integration.Tests.ps1
+  - Fixes the following issues:
+    - [issue #582](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/582)
+    - [issue #583](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/583)
+    - [issue #584](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/584)
+    - [issue #585](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/585)
 
 ## 8.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,15 +54,15 @@
 - Adds helper functions for use when creating test administrator user accounts,
   and updates the following tests to use credentials created with these
   functions:
-    - MSFT_xScriptResource.Integration.Tests.ps1
-    - MSFT_xServiceResource.Integration.Tests.ps1
-    - MSFT_xWindowsProcess.Integration.Tests.ps1
-    - xServiceSet.Integration.Tests.ps1
-  - Fixes the following issues:
-    - [issue #582](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/582)
-    - [issue #583](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/583)
-    - [issue #584](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/584)
-    - [issue #585](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/585)
+  - MSFT_xScriptResource.Integration.Tests.ps1
+  - MSFT_xServiceResource.Integration.Tests.ps1
+  - MSFT_xWindowsProcess.Integration.Tests.ps1
+  - xServiceSet.Integration.Tests.ps1
+- Fixes the following issues:
+  - [issue #582](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/582)
+  - [issue #583](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/583)
+  - [issue #584](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/584)
+  - [issue #585](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/585)
 
 ## 8.5.0.0
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1199,12 +1199,10 @@ function Add-PathPermission
         [System.String]
         $Path,
 
-        [ValidateNotNullOrEmpty()]
         [ValidateSet('Allow', 'Deny')]
         [System.String]
         $AccessControlType = 'Allow',
 
-        [ValidateNotNullOrEmpty()]
         [ValidateSet({[System.Security.AccessControl.FileSystemRights].GetEnumNames()})]
         [System.String]
         $FileSystemRight = 'FullControl',

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1213,7 +1213,7 @@ function Add-PathPermission
             [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
         ),
 
-        [System.Security.AccessControl.PropagationFlags]
+        [System.Security.AccessControl.PropagationFlags[]]
         $PropagationFlags = [System.Security.AccessControl.PropagationFlags]::None
     )
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1170,7 +1170,7 @@ function Add-MemberToGroup
         }
     }
 
-    # If the we group membership and the test user is not a member, make it a member
+    # If we found the group and the test user is not a member, make it a member
     if ($foundGroup -and !$foundMember)
     {
         Write-Verbose -Message "Adding account '$UserName' to group '$GroupName'" -Verbose

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1023,27 +1023,46 @@ function Initialize-TestAdministratorAccount
     param()
 
     # Get local Administrators group name
-    $adminGroupName = Get-WellKnownGroupName -WellKnownSidType ([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid)
+    $adminGroupName = Get-WellKnownGroupName `
+                        -WellKnownSidType ([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid)
 
     # Note: If we can find the WellKnownSidType for 'Remote Management Users'
     # we should switch to looking up the group name based on that instead.
     $remoteManagementGroupName = 'Remote Management Users'
 
     $testAdminUserName = 'xPSDSCTestAdmin'
+
     $testAdminPassword = Get-TestPassword
-    $securePassword = ConvertTo-SecureString -String $testAdminPassword -AsPlainText -Force
+    $securePassword = ConvertTo-SecureString `
+                        -String $testAdminPassword `
+                        -AsPlainText `
+                        -Force
 
     $adminGroup = Get-LocalGroupDE -GroupName $adminGroupName
     $remoteManagementGroup = Get-LocalGroupDE -GroupName $remoteManagementGroupName
 
     $testAdminUser = Get-LocalUserDE -UserName $testAdminUserName
 
-    Set-UserDEPassword -UserDE $testAdminUser -Password $testAdminPassword
+    Set-UserDEPassword `
+        -UserDE $testAdminUser `
+        -Password $testAdminPassword
 
-    Add-MemberToGroup -UserName $testAdminUserName -UserDE $testAdminUser -GroupName $adminGroupName -GroupDE $adminGroup
-    Add-MemberToGroup -UserName $testAdminUserName -UserDE $testAdminUser -GroupName $remoteManagementGroupName -GroupDE $remoteManagementGroup
+    Add-MemberToGroup `
+        -UserName $testAdminUserName `
+        -UserDE $testAdminUser `
+        -GroupName $adminGroupName `
+        -GroupDE $adminGroup
 
-    $script:xPSDesiredStateConfigurationTestAdminCreds = Get-PSCredentialObject -UserName "$($env:ComputerName)\$testAdminUserName" -Password $securePassword
+    Add-MemberToGroup `
+        -UserName $testAdminUserName `
+        -UserDE $testAdminUser `
+        -GroupName $remoteManagementGroupName `
+        -GroupDE $remoteManagementGroup
+
+    $script:xPSDesiredStateConfigurationTestAdminCreds = `
+        Get-PSCredentialObject `
+            -UserName "$($env:ComputerName)\$testAdminUserName" `
+            -Password $securePassword
 }
 
 <#
@@ -1067,11 +1086,9 @@ function Get-PSCredentialObject
         $Password
     )
 
-    [System.Management.Automation.PSCredential] $credentials = [System.Management.Automation.PSCredential] (
-        New-Object `
-            -TypeName 'System.Management.Automation.PSCredential' `
-            -ArgumentList @( $UserName, $Password )
-    )
+    $credentials = New-Object `
+                        -TypeName 'System.Management.Automation.PSCredential' `
+                        -ArgumentList @( $UserName, $Password )
 
     return $credentials
 }

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1002,13 +1002,13 @@ function Get-TestAdministratorAccountCredential
     [CmdletBinding()]
     param()
 
-    if (-not (Test-Path -Path Variable:Global:xPSDesiredStateConfigurationTestAdminCreds) -or `
-        $null -eq $global:xPSDesiredStateConfigurationTestAdminCreds)
+    if (-not (Test-Path -Path Variable:Script:xPSDesiredStateConfigurationTestAdminCreds) -or `
+        $null -eq $script:xPSDesiredStateConfigurationTestAdminCreds)
     {
         Initialize-TestAdministratorAccount
     }
 
-    return $global:xPSDesiredStateConfigurationTestAdminCreds
+    return $script:xPSDesiredStateConfigurationTestAdminCreds
 }
 
 <#
@@ -1033,8 +1033,6 @@ function Initialize-TestAdministratorAccount
     $testAdminPassword = Get-TestPassword
     $securePassword = ConvertTo-SecureString -String $testAdminPassword -AsPlainText -Force
 
-    $localDirectory = Get-LocalDirectory
-
     $adminGroup = Get-LocalGroupDE -GroupName $adminGroupName
     $remoteManagementGroup = Get-LocalGroupDE -GroupName $remoteManagementGroupName
 
@@ -1045,7 +1043,7 @@ function Initialize-TestAdministratorAccount
     Add-MemberToGroup -UserName $testAdminUserName -UserDE $testAdminUser -GroupName $adminGroupName -GroupDE $adminGroup
     Add-MemberToGroup -UserName $testAdminUserName -UserDE $testAdminUser -GroupName $remoteManagementGroupName -GroupDE $remoteManagementGroup
 
-    $global:xPSDesiredStateConfigurationTestAdminCreds = Get-PSCredentialObject -UserName "$($env:ComputerName)\$testAdminUserName" -Password $securePassword
+    $script:xPSDesiredStateConfigurationTestAdminCreds = Get-PSCredentialObject -UserName "$($env:ComputerName)\$testAdminUserName" -Password $securePassword
 }
 
 <#
@@ -1207,7 +1205,7 @@ function Add-PathPermission
     $rule = New-Object `
                 -TypeName System.Security.AccessControl.FileSystemAccessRule `
                 -ArgumentList @( $IdentityReference, $FileSystemRight, $InheritanceFlags, $PropagationFlags, $AccessControlType )
-    
+
     $null = $acl.SetAccessRule($rule)
 
     Set-ACL -Path $Path -AclObject $acl
@@ -1314,6 +1312,8 @@ function Get-LocalUserDE
 #>
 function Set-UserDEPassword
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
     [CmdletBinding()]
     param
     (
@@ -1329,7 +1329,7 @@ function Set-UserDEPassword
 
     Write-Verbose -Message "Setting password on account '$($UserDE.Path)'" -Verbose
 
-    $null = $UserDE.SetPassword($Password) 
+    $null = $UserDE.SetPassword($Password)
     $null = $UserDE.SetInfo() | Out-Null
 }
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1359,7 +1359,7 @@ function Set-UserDEPassword
     Write-Verbose -Message "Setting password on account '$($UserDE.Path)'" -Verbose
 
     $null = $UserDE.SetPassword($Password)
-    $null = $UserDE.SetInfo() | Out-Null
+    $null = $UserDE.SetInfo()
 }
 
 Export-ModuleMember -Function @(

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1089,6 +1089,8 @@ function Get-TestPassword
     [CmdletBinding()]
     param()
 
+    $password = ''
+
     $randomGenerator = New-Object -TypeName 'System.Random'
 
     $passwordLength = Get-Random -Minimum 15 -Maximum 126
@@ -1332,18 +1334,19 @@ function Set-UserDEPassword
 }
 
 Export-ModuleMember -Function @(
-    'Test-GetTargetResourceResult', `
-    'Wait-ScriptBlockReturnTrue', `
-    'Test-IsFileLocked', `
-    'Test-SetTargetResourceWithWhatIf', `
-    'Enter-DscResourceTestEnvironment', `
-    'Exit-DscResourceTestEnvironment', `
-    'Invoke-GetTargetResourceUnitTest', `
-    'Invoke-SetTargetResourceUnitTest', `
-    'Invoke-TestTargetResourceUnitTest', `
-    'Invoke-ExpectedMocksAreCalledTest', `
-    'Invoke-GenericUnitTest',
-    'Test-SkipContinuousIntegrationTask',
+    'Add-PathPermission',
+    'Enter-DscResourceTestEnvironment',
+    'Exit-DscResourceTestEnvironment',
+    'Get-TestAdministratorAccountCredential',
     'Install-WindowsFeatureAndVerify',
-    'Get-TestAdministratorAccountCredential'
+    'Invoke-ExpectedMocksAreCalledTest',
+    'Invoke-GenericUnitTest',
+    'Invoke-GetTargetResourceUnitTest',
+    'Invoke-SetTargetResourceUnitTest',
+    'Invoke-TestTargetResourceUnitTest',
+    'Test-GetTargetResourceResult',
+    'Test-IsFileLocked',
+    'Test-SetTargetResourceWithWhatIf',
+    'Test-SkipContinuousIntegrationTask',
+    'Wait-ScriptBlockReturnTrue'
 )

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -720,7 +720,7 @@ function Enter-DscResourceTestEnvironment
 
     if (Test-DscResourceTestsNeedsInstallOrUpdate)
     {
-        Install-DscResourceTests
+        Install-DscResourceTestsModule
     }
 
     Import-Module -Name $testHelperFilePath
@@ -810,7 +810,7 @@ function Test-DscResourceTestsNeedsInstallOrUpdate
         Git is not installed then a warning will be
         displayed and the repository will not be pulled.
 #>
-function Install-DscResourceTests
+function Install-DscResourceTestsModule
 {
     [CmdletBinding()]
     param
@@ -1314,6 +1314,7 @@ function Set-UserDEPassword
 {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingUserNameAndPassWordParams', '')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     [CmdletBinding()]
     param
     (

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1200,10 +1200,12 @@ function Add-PathPermission
         $Path,
 
         [ValidateNotNullOrEmpty()]
+        [ValidateSet('Allow', 'Deny')]
         [System.String]
         $AccessControlType = 'Allow',
 
         [ValidateNotNullOrEmpty()]
+        [ValidateSet({[System.Security.AccessControl.FileSystemRights].GetEnumNames()})]
         [System.String]
         $FileSystemRight = 'FullControl',
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1243,7 +1243,10 @@ function Get-WellKnownGroupName
         $WellKnownSidType
     )
 
-    $groupSID = New-Object -TypeName System.Security.Principal.SecurityIdentifier($WellKnownSidType, $null)
+    $groupSID = New-Object `
+                    -TypeName System.Security.Principal.SecurityIdentifier `
+                    -ArgumentList @( $WellKnownSidType, $null )
+
     $groupName = $groupSID.Translate([System.Security.Principal.NTAccount]).Value.Split('\')[1]
 
     return $groupName
@@ -1286,7 +1289,8 @@ function Get-LocalGroupDE
 
     Write-Verbose -Message "Getting Local Group '$GroupName' Directory Entry" -Verbose
 
-    $groupDE = [System.DirectoryServices.DirectoryEntry] (((Get-LocalDirectory).Path) + '/' + $GroupName + ',group')
+    $groupAddress = (((Get-LocalDirectory).Path) + '/' + $GroupName + ',group')
+    $groupDE = [System.DirectoryServices.DirectoryEntry] $groupAddress
 
     return $groupDE
 }
@@ -1311,7 +1315,8 @@ function Get-LocalUserDE
 
     $localDirectory = Get-LocalDirectory
 
-    $userDE = [System.DirectoryServices.DirectoryEntry] (($localDirectory.Path) + '/' + $UserName + ',user')
+    $userAddress = ($localDirectory.Path) + '/' + $UserName + ',user'
+    $userDE = [System.DirectoryServices.DirectoryEntry] $userAddress
 
     if ($null -eq $userDE.distinguishedName)
     {

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1252,7 +1252,7 @@ function Get-WellKnownGroupName
                             -ArgumentList @( $Sid )
         }
 
-        'UsingSid'
+        'UsingSidType'
         {
             $groupSID = New-Object `
                             -TypeName System.Security.Principal.SecurityIdentifier `

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1244,17 +1244,25 @@ function Get-WellKnownGroupName
         $WellKnownSidType
     )
 
-    if (!([String]::IsNullOrEmpty($Sid)))
-    {
-        $groupSID = New-Object `
-                        -TypeName System.Security.Principal.SecurityIdentifier `
-                        -ArgumentList @( $Sid )
-    }
-    else
-    {
-        $groupSID = New-Object `
-                        -TypeName System.Security.Principal.SecurityIdentifier `
-                        -ArgumentList @( $WellKnownSidType, $null )
+    switch ($PSCmdlet.ParameterSetName) {
+        'UsingSid'
+        {
+            $groupSID = New-Object `
+                            -TypeName System.Security.Principal.SecurityIdentifier `
+                            -ArgumentList @( $Sid )
+        }
+
+        'UsingSid'
+        {
+            $groupSID = New-Object `
+                            -TypeName System.Security.Principal.SecurityIdentifier `
+                            -ArgumentList @( $WellKnownSidType, $null )
+        }
+
+        default
+        {
+            throw 'ParameterSet not implemented in Get-WellKnownGroupName'
+        }
     }
 
     $groupName = $groupSID.Translate([System.Security.Principal.NTAccount]).Value.Split('\')[1]

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1221,7 +1221,13 @@ function Add-PathPermission
 
     $rule = New-Object `
                 -TypeName System.Security.AccessControl.FileSystemAccessRule `
-                -ArgumentList @( $IdentityReference, $FileSystemRight, $InheritanceFlags, $PropagationFlags, $AccessControlType )
+                -ArgumentList @(
+                    $IdentityReference,
+                    $FileSystemRight,
+                    $InheritanceFlags,
+                    $PropagationFlags,
+                    $AccessControlType
+                )
 
     $null = $acl.SetAccessRule($rule)
 

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1155,8 +1155,8 @@ function Add-LocalGroupMemberUsingDirectoryEntry
         {
             Write-Verbose -Message "Account '$($userDE.Name)' is already a member of group at path '$($GroupDE.Path)'" -Verbose
 
-            $foundMember = $true       
-            break     
+            $foundMember = $true
+            break
         }
     }
 
@@ -1248,7 +1248,7 @@ function Get-WellKnownGroupName
     {
         $groupSID = New-Object `
                         -TypeName System.Security.Principal.SecurityIdentifier `
-                        -ArgumentList @( $Sid )        
+                        -ArgumentList @( $Sid )
     }
     else
     {

--- a/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
@@ -19,7 +19,10 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
 try
 {
     Describe 'xScript Integration Tests' {
+
         BeforeAll {
+            $testCredential = Get-TestAdministratorAccountCredential
+
             # Import xScript module for Get-TargetResource, Test-TargetResource
             $moduleRootFilePath = Split-Path -Path $script:testsFolderFilePath -Parent
             $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
@@ -31,7 +34,15 @@ try
             $script:configurationWithCredentialFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_xScriptResource_WithCredential.config.ps1'
 
             # Cannot use $TestDrive here because script is run outside of Pester
-            $script:testFilePath = Join-Path -Path $env:SystemDrive -ChildPath 'TestFile.txt'
+            $script:testFolderPath = Join-Path -Path $env:SystemDrive -ChildPath 'Test Folder'
+            $script:testFilePath = Join-Path -Path $script:testFolderPath -ChildPath 'TestFile.txt'
+
+            if (-not (Test-Path -Path $script:testFolderPath))
+            {
+                mkdir -Path $script:testFolderPath
+            }
+
+            Add-PathPermission -Path $script:testFolderPath -IdentityReference $testCredential.UserName
 
             if (Test-Path -Path $script:testFilePath)
             {
@@ -93,7 +104,7 @@ try
             $resourceParameters = @{
                 FilePath = $script:testFilePath
                 FileContent = 'Test file content'
-                Credential = Get-TestAdministratorAccountCredential
+                Credential = $testCredential
             }
 
             It 'Should have removed test file before config runs' {

--- a/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
@@ -16,34 +16,6 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceName 'MSFT_xScriptResource' `
     -TestType 'Integration'
 
-            $testCredential = Get-TestAdministratorAccountCredential
-
-            # Import xScript module for Get-TargetResource, Test-TargetResource
-            $moduleRootFilePath = Split-Path -Path $script:testsFolderFilePath -Parent
-            $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
-            $scriptResourceFolderFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'MSFT_xScriptResource'
-            $scriptResourceModuleFilePath = Join-Path -Path $scriptResourceFolderFilePath -ChildPath 'MSFT_xScriptResource.psm1'
-            Import-Module -Name $scriptResourceModuleFilePath
-
-            $script:configurationNoCredentialFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_xScriptResource_NoCredential.config.ps1'
-            $script:configurationWithCredentialFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_xScriptResource_WithCredential.config.ps1'
-
-            # Cannot use $TestDrive here because script is run outside of Pester
-            $script:testFolderPath = Join-Path -Path $env:SystemDrive -ChildPath 'Test Folder'
-            $script:testFilePath = Join-Path -Path $script:testFolderPath -ChildPath 'TestFile.txt'
-
-            if (-not (Test-Path -Path $script:testFolderPath))
-            {
-                mkdir -Path $script:testFolderPath
-            }
-
-            Add-PathPermission -Path $script:testFolderPath -IdentityReference $testCredential.UserName
-
-            if (Test-Path -Path $script:testFilePath)
-            {
-                Remove-Item -Path $script:testFilePath -Force
-            }
-
 try
 {
     Describe 'xScript Integration Tests' {

--- a/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
@@ -21,6 +21,7 @@ try
     Describe 'xScript Integration Tests' {
 
         BeforeAll {
+            # Get test administrator account credentials
             $testCredential = Get-TestAdministratorAccountCredential
 
             # Import xScript module for Get-TargetResource, Test-TargetResource
@@ -37,13 +38,18 @@ try
             $script:testFolderPath = Join-Path -Path $env:SystemDrive -ChildPath 'Test Folder'
             $script:testFilePath = Join-Path -Path $script:testFolderPath -ChildPath 'TestFile.txt'
 
+            # Create the test folder if it doesn't exist
             if (-not (Test-Path -Path $script:testFolderPath))
             {
                 mkdir -Path $script:testFolderPath
             }
 
-            Add-PathPermission -Path $script:testFolderPath -IdentityReference $testCredential.UserName
+            # Make sure test admin account has permissions on the test folder
+            Add-PathPermission `
+                -Path $script:testFolderPath `
+                -IdentityReference $testCredential.UserName
 
+            # Remove the test file if it exists
             if (Test-Path -Path $script:testFilePath)
             {
                 Remove-Item -Path $script:testFilePath -Force

--- a/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
@@ -16,6 +16,34 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceName 'MSFT_xScriptResource' `
     -TestType 'Integration'
 
+            $testCredential = Get-TestAdministratorAccountCredential
+
+            # Import xScript module for Get-TargetResource, Test-TargetResource
+            $moduleRootFilePath = Split-Path -Path $script:testsFolderFilePath -Parent
+            $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
+            $scriptResourceFolderFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'MSFT_xScriptResource'
+            $scriptResourceModuleFilePath = Join-Path -Path $scriptResourceFolderFilePath -ChildPath 'MSFT_xScriptResource.psm1'
+            Import-Module -Name $scriptResourceModuleFilePath
+
+            $script:configurationNoCredentialFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_xScriptResource_NoCredential.config.ps1'
+            $script:configurationWithCredentialFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_xScriptResource_WithCredential.config.ps1'
+
+            # Cannot use $TestDrive here because script is run outside of Pester
+            $script:testFolderPath = Join-Path -Path $env:SystemDrive -ChildPath 'Test Folder'
+            $script:testFilePath = Join-Path -Path $script:testFolderPath -ChildPath 'TestFile.txt'
+
+            if (-not (Test-Path -Path $script:testFolderPath))
+            {
+                mkdir -Path $script:testFolderPath
+            }
+
+            Add-PathPermission -Path $script:testFolderPath -IdentityReference $testCredential.UserName
+
+            if (Test-Path -Path $script:testFilePath)
+            {
+                Remove-Item -Path $script:testFilePath -Force
+            }
+
 try
 {
     Describe 'xScript Integration Tests' {

--- a/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
@@ -93,7 +93,7 @@ try
             $resourceParameters = @{
                 FilePath = $script:testFilePath
                 FileContent = 'Test file content'
-                Credential = Get-AppVeyorAdministratorCredential
+                Credential = Get-TestAdministratorAccountCredential
             }
 
             It 'Should have removed test file before config runs' {

--- a/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xScriptResource.Integration.Tests.ps1
@@ -19,7 +19,6 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
 try
 {
     Describe 'xScript Integration Tests' {
-
         BeforeAll {
             # Get test administrator account credentials
             $testCredential = Get-TestAdministratorAccountCredential

--- a/Tests/Integration/MSFT_xServiceResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xServiceResource.Integration.Tests.ps1
@@ -29,7 +29,7 @@ try
 {
     Describe 'xService Integration Tests' {
         BeforeAll {
-            # Import CommonResourceHelper for Test-IsNanoServer, Get-AppveyorAdministratorCredential
+            # Import CommonResourceHelper for Test-IsNanoServer, Get-TestAdministratorAccountCredential
             $moduleRootFilePath = Split-Path -Path $script:testsFolderFilePath -Parent
             $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
             $commonResourceHelperFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'CommonResourceHelper.psm1'
@@ -298,7 +298,7 @@ try
             $configurationName = 'TestCreateService'
             $resourceParameters = @{
                 Name = 'TestService'
-                Credential = Get-AppVeyorAdministratorCredential
+                Credential = Get-TestAdministratorAccountCredential
             }
 
             It 'Should compile and apply the MOF without throwing' {

--- a/Tests/Integration/MSFT_xServiceResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xServiceResource.Integration.Tests.ps1
@@ -1,8 +1,5 @@
 <#
-    These tests should only be run in AppVeyor since they currently require the AppVeyor
-    administrator account credential to run.
-
-    Also please note that these tests are currently dependent on each other.
+    Please note that these tests are currently dependent on each other.
     They must be run in the order given and if one test fails, subsequent tests will
     also fail.
 #>

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -310,7 +310,7 @@ try
             )
         }
 
-        $testCredential = Get-AppVeyorAdministratorCredential
+        $testCredential = Get-TestAdministratorAccountCredential
 
         $testProcessPath = Join-Path -Path (Split-Path $PSScriptRoot -Parent) `
                                      -ChildPath 'WindowsProcessTestProcess.exe'

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -504,7 +504,9 @@ try
                 $pathResult | Should -Be $false
             }
 
-            Add-PathPermission -Path (Split-Path -Path $logFilePath) -IdentityReference $testCredential.UserName
+            Add-PathPermission `
+                -Path (Split-Path -Path $logFilePath) `
+                -IdentityReference $testCredential.UserName
 
             It 'Should compile without throwing' {
                 {

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -359,7 +359,7 @@ try
                 $pathResult | Should -Be $false
             }
         }
-        
+
         Context 'Should start a new testProcess instance as running' {
             $configurationName = 'MSFT_xWindowsProcess_StartProcessWithCredential'
             $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
@@ -524,7 +524,10 @@ try
             $null = Start-Sleep -Seconds 2
 
             It 'Should start another process running' {
-                Start-Process -FilePath $testProcessPath -ArgumentList @($logFilePath) -Credential $testCredential
+                Start-Process `
+                    -FilePath $testProcessPath `
+                    -ArgumentList @($logFilePath) `
+                    -Credential $testCredential
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -504,6 +504,7 @@ try
                 $pathResult | Should -Be $false
             }
 
+            # Make sure test admin account has permissions on log folder
             Add-PathPermission `
                 -Path (Split-Path -Path $logFilePath) `
                 -IdentityReference $testCredential.UserName

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -1,8 +1,5 @@
 <#
-    These tests should only be run in AppVeyor since the second half of the tests require
-    the AppVeyor administrator account credential to run.
-
-    Also please note that some of these tests depend on each other.
+    Please note that some of these tests depend on each other.
     They must be run in the order given - if one test fails, subsequent tests may
     also fail.
 #>
@@ -362,7 +359,7 @@ try
                 $pathResult | Should -Be $false
             }
         }
-
+        
         Context 'Should start a new testProcess instance as running' {
             $configurationName = 'MSFT_xWindowsProcess_StartProcessWithCredential'
             $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
@@ -507,6 +504,8 @@ try
                 $pathResult | Should -Be $false
             }
 
+            Add-PathPermission -Path (Split-Path -Path $logFilePath) -IdentityReference $testCredential.UserName
+
             It 'Should compile without throwing' {
                 {
                     .$configFile -ConfigurationName $configurationName
@@ -525,7 +524,7 @@ try
             $null = Start-Sleep -Seconds 2
 
             It 'Should start another process running' {
-                Start-Process -FilePath $testProcessPath -ArgumentList @($logFilePath)
+                Start-Process -FilePath $testProcessPath -ArgumentList @($logFilePath) -Credential $testCredential
             }
 
             It 'Should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -499,15 +499,15 @@ try
             $configurationName = 'MSFT_xWindowsProcess_StartMultipleProcessesWithCredential'
             $configurationPath = Join-Path -Path $TestDrive -ChildPath $configurationName
 
-            It 'Should not have a logfile already present' {
-                $pathResult = Test-Path $logFilePath
-                $pathResult | Should -Be $false
-            }
-
             # Make sure test admin account has permissions on log folder
             Add-PathPermission `
                 -Path (Split-Path -Path $logFilePath) `
                 -IdentityReference $testCredential.UserName
+
+            It 'Should not have a logfile already present' {
+                $pathResult = Test-Path $logFilePath
+                $pathResult | Should -Be $false
+            }
 
             It 'Should compile without throwing' {
                 {

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -526,6 +526,7 @@ try
             # Wait a moment for the process to stop/start
             $null = Start-Sleep -Seconds 2
 
+            # Start another instance of the same process using the same credentials.
             It 'Should start another process running' {
                 Start-Process `
                     -FilePath $testProcessPath `

--- a/Tests/Integration/xServiceSet.Integration.Tests.ps1
+++ b/Tests/Integration/xServiceSet.Integration.Tests.ps1
@@ -29,7 +29,7 @@ try
 {
     Describe 'xServiceSet Integration Tests' {
         BeforeAll {
-            # Import CommonResourceHelper for Get-AppveyorAdministratorCredential
+            # Import CommonResourceHelper for Get-TestAdministratorAccountCredential
             $moduleRootFilePath = Split-Path -Path $script:testsFolderFilePath -Parent
             $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
             $commonResourceHelperFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'CommonResourceHelper.psm1'
@@ -138,7 +138,7 @@ try
                 Name = @( $script:service1Properties.Name )
                 Ensure = 'Present'
                 StartupType = 'Manual'
-                Credential = Get-AppVeyorAdministratorCredential
+                Credential = Get-TestAdministratorAccountCredential
                 State = 'Stopped'
             }
 

--- a/Tests/Integration/xServiceSet.Integration.Tests.ps1
+++ b/Tests/Integration/xServiceSet.Integration.Tests.ps1
@@ -1,8 +1,5 @@
 <#
-    These tests should only be run in AppVeyor since they currently require the AppVeyor
-    administrator account credential to run.
-
-    Also please note that these tests are currently dependent on each other.
+    Please note that these tests are currently dependent on each other.
     They must be run in the order given and if one test fails, subsequent tests will
     also fail.
 #>
@@ -134,11 +131,14 @@ try
             }
 
             $configurationName = 'TestEditOneServiceSet'
+
+            $testAdminCreds = (Get-TestAdministratorAccountCredential)
+
             $resourceParameters = @{
                 Name = @( $script:service1Properties.Name )
                 Ensure = 'Present'
                 StartupType = 'Manual'
-                Credential = Get-TestAdministratorAccountCredential
+                Credential =  $testAdminCreds
                 State = 'Stopped'
             }
 
@@ -169,8 +169,8 @@ try
                 $serviceCimInstance.StartMode | Should -Be $resourceParameters.StartupType
             }
 
-            It 'Should have set the service start name to the appveyor account name' {
-                $serviceCimInstance.StartName | Should -Be '.\appveyor'
+            It 'Should have set the service start name to the test credential account name' {
+                $serviceCimInstance.StartName | Should -Be ".\$($testAdminCreds.UserName.Split('\')[1])"
             }
         }
 

--- a/Tests/Integration/xServiceSet.Integration.Tests.ps1
+++ b/Tests/Integration/xServiceSet.Integration.Tests.ps1
@@ -132,7 +132,7 @@ try
 
             $configurationName = 'TestEditOneServiceSet'
 
-            $testAdminCreds = (Get-TestAdministratorAccountCredential)
+            $testAdminCreds = Get-TestAdministratorAccountCredential
 
             $resourceParameters = @{
                 Name = @( $script:service1Properties.Name )


### PR DESCRIPTION
#### Pull Request (PR) description
Adds common test helper functions to aid in creating test administrator user accounts. Updates the following tests to use these functions to obtain test administrators account credentials instead of relying on an AppVeyor account being present.

- MSFT_xScriptResource.Integration.Tests.ps1
- MSFT_xServiceResource.Integration.Tests.ps1
- MSFT_xWindowsProcess.Integration.Tests.ps1
- xServiceSet.Integration.Tests.ps1

#### This Pull Request (PR) fixes the following issues
- Fixes #582 
- Fixes #583 
- Fixes #584 
- Fixes #585

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/594)
<!-- Reviewable:end -->
