### PR TITLE
Fixes most remaining PSScriptAnalyzer issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Fixes all instances of the following PSScriptAnalyzer issues:
+  - PSUseOutputTypeCorrectly
+  - PSAvoidUsingConvertToSecureStringWithPlainText
+  - PSPossibleIncorrectComparisonWithNull
+  - PSAvoidDefaultValueForMandatoryParameter
+  - PSAvoidUsingInvokeExpression
 - xPackage and xMsiPackage
   - Add an ability to ignore a pending reboot if requested by package installation.
 - xRemoteFile

--- a/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
+++ b/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
@@ -25,8 +25,9 @@ function Publish-DSCModuleAndMof
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $True)]
+        [ValidateScript({Test-Path -Path $_})]
         [System.String]
-        $Source = $pwd,
+        $Source,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -38,7 +39,7 @@ function Publish-DSCModuleAndMof
     )
 
     # Create working directory
-    $tempFolder = "$pwd\temp"
+    $tempFolder = Join-Path -Path $Source -ChildPath 'temp'
     New-Item -Path $tempFolder -ItemType Directory -Force -ErrorAction SilentlyContinue
 
     # Copy the mof documents from the $Source to working dir
@@ -124,7 +125,7 @@ function CreateZipFromSource
     {
         $name = $Item.Name
         $alreadyExists = Get-Module -Name $name -ListAvailable
-        if (($alreadyExists -eq $null) -or ($Force))
+        if (($null -eq $alreadyExists) -or ($Force))
         {
             # Install the modules into PowerShell module path and overwrite the content
             Copy-Item -Path $item.FullName -Recurse -Force -Destination "$env:ProgramFiles\WindowsPowerShell\Modules"

--- a/Tests/Integration/MSFT_xArchive.TestHelper.psm1
+++ b/Tests/Integration/MSFT_xArchive.TestHelper.psm1
@@ -146,6 +146,7 @@ function New-ZipFileFromHashtable
 #>
 function Test-FileStructuresMatch
 {
+    [OutputType([System.Boolean])]
     [CmdletBinding()]
     param
     (
@@ -186,7 +187,7 @@ function Test-FileStructuresMatch
         $sourceChildItemName = Split-Path -Path $sourceChildItem.FullName -Leaf
         $destinationChildItem = $destinationContents[$sourceChildItemName]
 
-        if ($destinationChildItem -eq $null)
+        if ($null -eq $destinationChildItem)
         {
             return $false
         }

--- a/Tests/Integration/MSFT_xRemoteFile.Tests.ps1
+++ b/Tests/Integration/MSFT_xRemoteFile.Tests.ps1
@@ -39,7 +39,7 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($script:DSCResourceName)_Config -OutputPath `$TestDrive"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
             } | Should -Not -Throw

--- a/Tests/MSFT_xPackageResource.TestHelper.psm1
+++ b/Tests/MSFT_xPackageResource.TestHelper.psm1
@@ -1,3 +1,10 @@
+<#
+    Suppress PSAvoidUsingConvertToSecureStringWithPlainText since SecureString
+    objects are used for test passwords.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param ()
+
 $errorActionPreference = 'Stop'
 Set-StrictMode -Version 'Latest'
 

--- a/Tests/Unit/MSFT_xArchive.Tests.ps1
+++ b/Tests/Unit/MSFT_xArchive.Tests.ps1
@@ -1,3 +1,10 @@
+<#
+    Suppress PSAvoidUsingConvertToSecureStringWithPlainText since SecureString
+    objects are used for test passwords.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param ()
+
 $errorActionPreference = 'Stop'
 Set-StrictMode -Version 'Latest'
 

--- a/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_xMsiPackage.Tests.ps1
@@ -1,3 +1,10 @@
+<#
+    Suppress PSAvoidUsingConvertToSecureStringWithPlainText since SecureString
+    objects are used for test passwords.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param ()
+
 $errorActionPreference = 'Stop'
 Set-StrictMode -Version 'Latest'
 

--- a/Tests/Unit/MSFT_xScriptResource.Tests.ps1
+++ b/Tests/Unit/MSFT_xScriptResource.Tests.ps1
@@ -1,3 +1,10 @@
+<#
+    Suppress PSAvoidUsingConvertToSecureStringWithPlainText since SecureString
+    objects are used for test passwords.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
+param ()
+
 $errorActionPreference = 'Stop'
 Set-StrictMode -Version 'Latest'
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes most remaining PSScriptAnalyzer issues in #546. Fixes all instances of the following PSScriptAnalyzer issues:
  - PSUseOutputTypeCorrectly
  - PSAvoidUsingConvertToSecureStringWithPlainText
  - PSPossibleIncorrectComparisonWithNull
  - PSAvoidDefaultValueForMandatoryParameter
  - PSAvoidUsingInvokeExpression

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/598)
<!-- Reviewable:end -->
