### PR TITLE
Tests\Integration\MSFT_xDSCWebService.Integration.tests.ps1: Create self signed certificate if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Tests\Integration\MSFT_xDSCWebService.Integration.tests.ps1:
+  - Fixes issue where tests fail if a self signed certificate for DSC does not
+    already exist.
+    [issue #581](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/581)
 - Fixes all instances of the following PSScriptAnalyzer issues:
   - PSUseOutputTypeCorrectly
   - PSAvoidUsingConvertToSecureStringWithPlainText

--- a/Tests/Integration/MSFT_xDSCWebService.Integration.tests.ps1
+++ b/Tests/Integration/MSFT_xDSCWebService.Integration.tests.ps1
@@ -103,6 +103,15 @@ function Test-DSCPullServerIsPresent
 # Using try/finally to always cleanup.
 try
 {
+    # Get a self signed certificate to use with tests
+    New-DscSelfSignedCertificate
+
+    if (!(Test-Path -Path env:DscPublicCertificatePath) -or `
+        !(Test-Path -Path env:DscCertificateThumbprint))
+    {
+        throw "A DSC certificate is required for $script:dscResourceFriendlyName integration tests."
+    }
+
     # Make sure the DSC-Service and Web-Server Windows features are installed
     if (!(Install-WindowsFeatureAndVerify -Name 'DSC-Service') -or
         !(Install-WindowsFeatureAndVerify -Name 'Web-Server'))


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue where tests fail if a self signed certificate for DSC does not already exist.

#### This Pull Request (PR) fixes the following issues
- Fixes #581

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/601)
<!-- Reviewable:end -->
