### PR TITLE
Fix xGroupResoure Integration Test failures due to missing System.DirectoryServices.AccountManagement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixes issue in xGroupResource Integration tests where the tests would fail
+  if the System.DirectoryServices.AccountManagement namespace was not loaded.
 - Fixes all instances of the following PSScriptAnalyzer issues:
   - PSUseOutputTypeCorrectly
   - PSAvoidUsingConvertToSecureStringWithPlainText

--- a/Tests/MSFT_xGroupResource.TestHelper.psm1
+++ b/Tests/MSFT_xGroupResource.TestHelper.psm1
@@ -96,6 +96,8 @@ function Test-GroupExistsOnFullSKU
         $MembersToExclude
     )
 
+    Add-Type -AssemblyName System.DirectoryServices.AccountManagement -ErrorAction Stop
+
     $principalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' `
         -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Machine )
 
@@ -615,6 +617,8 @@ function Test-UserExistsOnFullSKU
         [System.String]
         $Username
     )
+
+    Add-Type -AssemblyName System.DirectoryServices.AccountManagement -ErrorAction Stop
 
     $principalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' `
         -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Machine )


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue in xGroupResource Integration tests where the tests would fail if the System.DirectoryServices.AccountManagement namespace was not loaded.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/602)
<!-- Reviewable:end -->
