### PR TITLE
Suppress forced Verbose output in Integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Suppresses forced Verbose output in MSFT_xArchive.EndToEnd.Tests.ps1,
+  MSFT_xDSCWebService.Integration.tests.ps1, and
+  MSFT_xWindowsProcess.Integration.Tests.ps1.
+  [issue #514](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/514)
 - Fixes all instances of the following PSScriptAnalyzer issues:
   - PSUseOutputTypeCorrectly
   - PSAvoidUsingConvertToSecureStringWithPlainText

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## Unreleased
 
 - Suppresses forced Verbose output in MSFT_xArchive.EndToEnd.Tests.ps1,
-  MSFT_xDSCWebService.Integration.tests.ps1, and
-  MSFT_xWindowsProcess.Integration.Tests.ps1.
+  MSFT_xDSCWebService.Integration.tests.ps1,
+  MSFT_xPackageResource.Integration.Tests.ps1, MSFT_xRemoteFile.Tests.ps1,
+  MSFT_xUserResource.Integration.Tests.ps1,
+  MSFT_xWindowsProcess.Integration.Tests.ps1, and
+  xFileUpload.Integration.Tests.ps1.
   [issue #514](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/514)
 - Fixes all instances of the following PSScriptAnalyzer issues:
   - PSUseOutputTypeCorrectly

--- a/Tests/CommonTestHelper.psm1
+++ b/Tests/CommonTestHelper.psm1
@@ -1153,7 +1153,7 @@ function Add-LocalGroupMemberUsingDirectoryEntry
 
         if ($userDE.Name -like $memberName)
         {
-            Write-Verbose -Message "Account '$($userDE.Name)' is already a member of group at path '$($GroupDE.Path)'" -Verbose
+            Write-Verbose -Message "Account '$($userDE.Name)' is already a member of group at path '$($GroupDE.Path)'"
 
             $foundMember = $true
             break
@@ -1305,7 +1305,7 @@ function Get-LocalGroupDirectoryEntry
         $GroupName
     )
 
-    Write-Verbose -Message "Getting Local Group '$GroupName' Directory Entry" -Verbose
+    Write-Verbose -Message "Getting Local Group '$GroupName' Directory Entry"
 
     $groupAddress = (((Get-LocalDirectory).Path) + '/' + $GroupName + ',group')
     $groupDE = [System.DirectoryServices.DirectoryEntry] $groupAddress
@@ -1330,7 +1330,7 @@ function New-LocalUserUsingDirectoryEntry
         $UserName
     )
 
-    Write-Verbose -Message "Getting Local User '$UserName' Directory Entry" -Verbose
+    Write-Verbose -Message "Getting Local User '$UserName' Directory Entry"
 
     $localDirectory = Get-LocalDirectory
 

--- a/Tests/Integration/MSFT_xArchive.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_xArchive.EndToEnd.Tests.ps1
@@ -145,7 +145,6 @@ Describe 'xArchive End to End Tests' {
             Path = $script:testArchiveFilePath
             Destination = $destination
             Ensure = 'Present'
-            Verbose = $true
         }
 
         It 'Should return false from Test-TargetResource with the same parameters before configuration' {
@@ -228,7 +227,6 @@ Describe 'xArchive End to End Tests' {
             Path = $script:testArchiveFilePath
             Destination = $destination
             Ensure = 'Present'
-            Verbose = $true
         }
 
         It 'Should return false from Test-TargetResource with the same parameters before configuration' {
@@ -300,7 +298,6 @@ Describe 'xArchive End to End Tests' {
             Path = $script:testArchiveFilePath
             Destination = $destination
             Ensure = 'Present'
-            Verbose = $true
         }
 
         It 'Should return true from Test-TargetResource with the same parameters before configuration' {
@@ -355,7 +352,6 @@ Describe 'xArchive End to End Tests' {
             Validate = $true
             Checksum = 'SHA-256'
             Force = $false
-            Verbose = $true
         }
 
         It 'Should return false from Test-TargetResource with the same parameters before configuration' {
@@ -415,7 +411,6 @@ Describe 'xArchive End to End Tests' {
             Validate = $true
             Checksum = 'SHA-256'
             Force = $true
-            Verbose = $true
         }
 
         It 'Should return false from Test-TargetResource with the same parameters before configuration' {
@@ -474,7 +469,6 @@ Describe 'xArchive End to End Tests' {
             Validate = $true
             Checksum = 'SHA-256'
             Force = $true
-            Verbose = $true
         }
 
         It 'Should return true from Test-TargetResource with the same parameters before configuration' {
@@ -526,7 +520,6 @@ Describe 'xArchive End to End Tests' {
             Path = $script:testArchiveFilePath
             Destination = $destination
             Ensure = 'Absent'
-            Verbose = $true
         }
 
         It 'Should return false from Test-TargetResource with the same parameters before configuration' {
@@ -615,7 +608,6 @@ Describe 'xArchive End to End Tests' {
             Path = $script:testArchiveFilePath
             Destination = $destination
             Ensure = 'Absent'
-            Verbose = $true
         }
 
         It 'Should return false from Test-TargetResource with the same parameters before configuration' {
@@ -685,7 +677,6 @@ Describe 'xArchive End to End Tests' {
             Path = $script:testArchiveFilePath
             Destination = $destination
             Ensure = 'Absent'
-            Verbose = $true
         }
 
         It 'Should return true from Test-TargetResource with the same parameters before configuration' {
@@ -726,7 +717,6 @@ Describe 'xArchive End to End Tests' {
             Path = $script:testArchiveFilePath
             Destination = $destination
             Ensure = 'Absent'
-            Verbose = $true
         }
 
         It 'Should return true from Test-TargetResource with the same parameters before configuration' {
@@ -777,7 +767,6 @@ Describe 'xArchive End to End Tests' {
             Validate = $true
             Checksum = 'SHA-256'
             Force = $true
-            Verbose = $true
         }
 
         It 'Should return true from Test-TargetResource with the same parameters before configuration' {
@@ -832,7 +821,6 @@ Describe 'xArchive End to End Tests' {
             Validate = $true
             Checksum = 'SHA-256'
             Force = $true
-            Verbose = $true
         }
 
         It 'Should return false from Test-TargetResource with the same parameters before configuration' {

--- a/Tests/Integration/MSFT_xArchive.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_xArchive.EndToEnd.Tests.ps1
@@ -156,7 +156,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateOnly -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -239,7 +239,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateOnly -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -311,7 +311,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateOnly -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -367,7 +367,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateAndChecksum -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Throw
         }
 
@@ -426,7 +426,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateAndChecksum -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -485,7 +485,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateAndChecksum -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -537,7 +537,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateOnly -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -626,7 +626,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateOnly -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -696,7 +696,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateOnly -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -737,7 +737,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateOnly -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -788,7 +788,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateAndChecksum -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 
@@ -843,7 +843,7 @@ Describe 'xArchive End to End Tests' {
             {
                 . $script:confgurationFilePathValidateAndChecksum -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @archiveParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force -Verbose
+                Start-DscConfiguration -Path $TestDrive -ErrorAction Stop -Wait -Force
             } | Should -Not -Throw
         }
 

--- a/Tests/Integration/MSFT_xDSCWebService.Integration.tests.ps1
+++ b/Tests/Integration/MSFT_xDSCWebService.Integration.tests.ps1
@@ -56,7 +56,6 @@ function Invoke-CommonResourceTesting
                 Path         = $TestDrive
                 ComputerName = 'localhost'
                 Wait         = $true
-                Verbose      = $true
                 Force        = $true
                 ErrorAction  = 'Stop'
             }

--- a/Tests/Integration/MSFT_xDSCWebService.Integration.tests.ps1
+++ b/Tests/Integration/MSFT_xDSCWebService.Integration.tests.ps1
@@ -66,12 +66,12 @@ function Invoke-CommonResourceTesting
 
     It 'Should be able to call Get-DscConfiguration without throwing' {
         {
-            $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+            $script:currentConfiguration = Get-DscConfiguration -ErrorAction Stop
         } | Should -Not -Throw
     }
 
     It 'Should return $true when Test-DscConfiguration is run' {
-        Test-DscConfiguration -Verbose | Should -Be $true
+        Test-DscConfiguration | Should -Be $true
     }
 }
 

--- a/Tests/Integration/MSFT_xPackageResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xPackageResource.Integration.Tests.ps1
@@ -96,7 +96,7 @@ try
 
                 & $configurationName -OutputPath $configurationPath
 
-                Start-DscConfiguration -Path $configurationPath -Wait -Force -Verbose
+                Start-DscConfiguration -Path $configurationPath -Wait -Force
 
                 Test-PackageInstalledByName -Name $script:packageName | Should -Be $true
             }

--- a/Tests/Integration/MSFT_xRemoteFile.Tests.ps1
+++ b/Tests/Integration/MSFT_xRemoteFile.Tests.ps1
@@ -41,12 +41,12 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive `
-                    -ComputerName localhost -Wait -Verbose -Force
+                    -ComputerName localhost -Wait -Force
             } | Should -Not -Throw
         }
 
         It 'should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            { Get-DscConfiguration -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 

--- a/Tests/Integration/MSFT_xUserResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xUserResource.Integration.Tests.ps1
@@ -67,11 +67,11 @@ try {
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                    { Get-DscConfiguration -ErrorAction Stop } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
-                    $currentConfig = Get-DscConfiguration -Verbose -ErrorAction Stop
+                    $currentConfig = Get-DscConfiguration -ErrorAction Stop
                     $currentConfig.UserName | Should -Be $testUserName
                     $currentConfig.Ensure | Should -Be 'Present'
                     $currentConfig.Description | Should -Be $TestDescription
@@ -120,11 +120,11 @@ try {
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                    { Get-DscConfiguration -ErrorAction Stop } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
-                    $currentConfig = Get-DscConfiguration -Verbose -ErrorAction Stop
+                    $currentConfig = Get-DscConfiguration -ErrorAction Stop
                     $currentConfig.UserName | Should -Be $testUserName
                     $currentConfig.Ensure | Should -Be 'Present'
                     $currentConfig.Description | Should -Be $TestDescription
@@ -172,11 +172,11 @@ try {
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                    { Get-DscConfiguration -ErrorAction Stop } | Should -Not -Throw
                 }
 
                 It 'Should return the correct configuration' {
-                    $currentConfig = Get-DscConfiguration -Verbose -ErrorAction Stop
+                    $currentConfig = Get-DscConfiguration -ErrorAction Stop
                     $currentConfig.UserName | Should -Be $testUserName
                     $currentConfig.Ensure | Should -Be 'Absent'
                 }

--- a/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWindowsProcess.Integration.Tests.ps1
@@ -90,7 +90,7 @@ try
                                          -Ensure 'Present' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -136,7 +136,7 @@ try
                                          -Ensure 'Present' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -178,7 +178,7 @@ try
                                          -Ensure 'Absent' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -219,7 +219,7 @@ try
                                          -Ensure 'Present' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -269,7 +269,7 @@ try
                                          -Ensure 'Absent' `
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -336,7 +336,7 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -379,7 +379,7 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -427,7 +427,7 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -471,7 +471,7 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -519,7 +519,7 @@ try
                                          -Credential $testCredential `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 
@@ -580,7 +580,7 @@ try
                                          -ErrorAction 'Stop' `
                                          -OutputPath $configurationPath `
                                          -ConfigurationData $ConfigData
-                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force -Verbose
+                    Start-DscConfiguration -Path $configurationPath -ErrorAction 'Stop' -Wait -Force
                 } | Should -Not -Throw
             }
 

--- a/Tests/Integration/xFileUpload.Integration.Tests.ps1
+++ b/Tests/Integration/xFileUpload.Integration.Tests.ps1
@@ -74,7 +74,6 @@ try
                         -ErrorAction 'Stop' `
                         -Wait `
                         -Force `
-                        -Verbose
                 } | Should -Not -Throw
             }
 
@@ -109,7 +108,6 @@ try
                         -ErrorAction 'Stop' `
                         -Wait `
                         -Force `
-                        -Verbose
                 } | Should -Not -Throw
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Suppresses forced Verbose output in MSFT_xArchive.EndToEnd.Tests.ps1, MSFT_xDSCWebService.Integration.tests.ps1, and MSFT_xWindowsProcess.Integration.Tests.ps1.

#### This Pull Request (PR) fixes the following issues
- Fixes #514 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/603)
<!-- Reviewable:end -->
