### PR TITLE
xWindowsOptionalFeatureSet.Integration.Tests.ps1: Fixes test failure due to unassigned windowsOptionalFeatureName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Versions
 
+- Fixes test failures in xWindowsOptionalFeatureSet.Integration.Tests.ps1 due
+  to accessing the windowsOptionalFeatureName variable before it is assigned.
+  [issue #612](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/612)
+
 ## Unreleased
 
 ## 8.6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Versions
 
+## Unreleased
+
 - Fixes test failures in xWindowsOptionalFeatureSet.Integration.Tests.ps1 due
   to accessing the windowsOptionalFeatureName variable before it is assigned.
   [issue #612](https://github.com/PowerShell/xPSDesiredStateConfiguration/issues/612)
-
-## Unreleased
 
 ## 8.6.0.0
 

--- a/Tests/Integration/xWindowsOptionalFeatureSet.Integration.Tests.ps1
+++ b/Tests/Integration/xWindowsOptionalFeatureSet.Integration.Tests.ps1
@@ -48,7 +48,7 @@ try
                     }
                     elseif ($originalFeature.State -in $script:enabledStates)
                     {
-                        Dism\Enable-WindowsOptionalFeature -Online -FeatureName $windowsOptionalFeatureName -NoRestart
+                        Dism\Enable-WindowsOptionalFeature -Online -FeatureName $validFeatureName -NoRestart
                     }
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description
- Fixes test failures in xWindowsOptionalFeatureSet.Integration.Tests.ps1 due
  to accessing the windowsOptionalFeatureName variable before it is assigned.

#### This Pull Request (PR) fixes the following issues
- Fixes #612 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/616)
<!-- Reviewable:end -->
