### PR TITLE
PublishModulesAndMofsToPullServer: Fixed a bug in Publish-MOFToPullServer introduced in 8.5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- PublishModulesAndMofsToPullServer.psm1:
+  - Fixes issue in Publish-MOFToPullServer that was introduced in 8.5.0.0, making
+    the function unusable.
 - MSFT_xWindowsProcess:
   - Fixes issue where a process will fail to be created if a $Path is passed
     that contains one or more spaces, and the resource is using $Credentials.

--- a/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
+++ b/DSCPullServerSetup/PublishModulesAndMofsToPullServer.psm1
@@ -421,7 +421,7 @@ function Publish-MOFToPullServer
     }
     Process
     {
-        $fileInfo = New-Item -Path $FullName -ItemType File
+        $fileInfo = Get-Item -Path $FullName
         if ($fileInfo.Extension -eq '.mof')
         {
             if (Test-Path -Path $FullName)


### PR DESCRIPTION

#### Pull Request (PR) description
<!--
The big makes the function unusable. This small fix, takes care of that.
The earlier change introduced in 8.5.0.0 was a misunderstood change from instantiating an object with file information to actually trying to create a file. 
-->

#### This Pull Request (PR) fixes the following issues
<!--
None
-->

#### Task list
- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/617)
<!-- Reviewable:end -->
