### PR TITLE
Add a retry mechanism when download fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- MSFT_xRemoteFile:
+  - Add a retry mechanism when the download fails.
+
 ## 8.8.0.0
 
 - Ports fix for the following issue:

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -253,24 +253,30 @@ function Set-TargetResource
         $ProgressPreference = 'SilentlyContinue'
 
         Write-Verbose -Message ($script:localizedData.DownloadingURI -f $DestinationPath, $URI)
-        $nbAttempt = 0
+        $count = 0
         $success = $false
+
         do
         {
             try
             {
-                $nbAttempt++
-                Invoke-WebRequest @PSBoundParameters -Headers $headersHashtable -OutFile $DestinationPath
+                $count++
+                Invoke-WebRequest `
+                    @PSBoundParameters `
+                    -Headers $headersHashtable `
+                    -OutFile $DestinationPath
                 $success = $true
             }
             catch [System.Exception]
             {
-                Write-Verbose -Message ($script:localizedData.DownloadingFailedRetry -f $URI, $nbAttempt, $_.Exception.Message)
-                if ($nbAttempt -gt 5)
+                Write-Verbose -Message ($script:localizedData.DownloadingFailedRetry -f $URI, $count, $_.Exception.Message)
+
+                if ($count -gt 5)
                 {
                     # Inside catch variable $_ is not the exception itself, but a System.Management.Automation.ErrorRecord that contains the actual Exception
                     throw $_.Exception
                 }
+
                 Start-Sleep -Seconds 5
             }
         }
@@ -294,7 +300,6 @@ function Set-TargetResource
     {
         $ProgressPreference = $currentProgressPreference
     }
-
 
     # Update cache
     if (Test-Path -Path $DestinationPath)

--- a/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
+++ b/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.psm1
@@ -271,7 +271,7 @@ function Set-TargetResource
                     # Inside catch variable $_ is not the exception itself, but a System.Management.Automation.ErrorRecord that contains the actual Exception
                     throw $_.Exception
                 }
-				Start-Sleep -Seconds 5
+                Start-Sleep -Seconds 5
             }
         }
         while ($success -eq $false)

--- a/DSCResources/MSFT_xRemoteFile/en-us/MSFT_xRemoteFile.strings.psd1
+++ b/DSCResources/MSFT_xRemoteFile/en-us/MSFT_xRemoteFile.strings.psd1
@@ -12,6 +12,7 @@ ConvertFrom-StringData @'
     DownloadOutOfMemoryException=Invoking web request failed with OutOfMemoryException- Possible cause is the requested file being too big. {0}
     DownloadException=Invoking web request failed with error. {0}
     DownloadingURI=Downloading '{1}' to '{0}'.
+    DownloadingFailedRetry=Download of '{0}' failed on attempt {1} with this error: {2}
     CacheReflectsCurrentState=Cache reflects current state. No need for downloading file.
     CacheIsEmptyOrNotMatchCurrentState=Cache is empty or it doesn't reflect current state. File will be downloaded.
     MatchSourceFalse=MatchSource is false. No need for downloading file.


### PR DESCRIPTION
#### Pull Request (PR) description

Add a retry mechanism to resource xRemoteFile when the download fails.

#### This Pull Request (PR) fixes the following issues

- Fixes #629 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in
      CHANGELOG.md. Entry should say what was changed, and how that affects
      users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as
      appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See
      [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines and Best Practices](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/630)
<!-- Reviewable:end -->
